### PR TITLE
feat: implement CandidatePersistence module for project-local candidate storage

### DIFF
--- a/packages/core/src/interaction/knowledge/candidate-persistence.test.ts
+++ b/packages/core/src/interaction/knowledge/candidate-persistence.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { rm, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { CandidatePersistence } from "./candidate-persistence.js";
+
+let testDir: string;
+let store: CandidatePersistence;
+
+beforeEach(() => {
+	testDir = join(tmpdir(), `candidate-persistence-test-${randomUUID()}`);
+	store = new CandidatePersistence(testDir);
+});
+
+afterEach(async () => {
+	await rm(testDir, { recursive: true, force: true });
+});
+
+describe("CandidatePersistence", () => {
+	it("reads an empty array for a non-existent candidate kind", async () => {
+		const results = await store.read("project-facts");
+		expect(results).toEqual([]);
+	});
+
+	it("appends and reads back candidates of a single kind", async () => {
+		const fact1 = { text: "We use pnpm for all packages", confidence: 0.9 };
+		const fact2 = { text: "Company name is TheFocus.AI", confidence: 1.0 };
+
+		await store.append("project-facts", fact1);
+		await store.append("project-facts", fact2);
+
+		const results = await store.read("project-facts");
+		expect(results).toHaveLength(2);
+		expect(results[0]).toEqual(fact1);
+		expect(results[1]).toEqual(fact2);
+	});
+
+	it("creates the files under the correct project-local path", async () => {
+		const loop = { issue: 57, status: "in-progress" };
+		await store.append("open-loops", loop);
+
+		const filePath = join(testDir, ".umwelten/candidates/open-loops.jsonl");
+		const content = await readFile(filePath, "utf-8");
+		expect(content.trim()).toBe(JSON.stringify(loop));
+	});
+
+	it("reads all candidate kinds using readAll()", async () => {
+		const fact = { text: "Fact A" };
+		const loop = { text: "Loop B" };
+
+		await store.append("project-facts", fact);
+		await store.append("open-loops", loop);
+
+		const all = await store.readAll();
+		expect(all["project-facts"]).toEqual([fact]);
+		expect(all["open-loops"]).toEqual([loop]);
+		expect(all["skill-candidates"]).toEqual([]);
+		expect(all["preferences"]).toEqual([]);
+		expect(all["mistakes"]).toEqual([]);
+	});
+
+	it("handles malformed lines or whitespace-only lines gracefully by skipping them", async () => {
+		// Create a file with mixed content: a valid line, a blank line, an invalid line, another valid line
+		const dirPath = join(testDir, ".umwelten/candidates");
+		const { mkdir, writeFile } = await import("node:fs/promises");
+		await mkdir(dirPath, { recursive: true });
+
+		const rawContent = [
+			JSON.stringify({ index: 1 }),
+			"",
+			"this-is-not-json",
+			JSON.stringify({ index: 2 }),
+		].join("\n");
+
+		await writeFile(join(dirPath, "preferences.jsonl"), rawContent, "utf-8");
+
+		const results = await store.read("preferences");
+		expect(results).toHaveLength(2);
+		expect(results[0]).toEqual({ index: 1 });
+		expect(results[1]).toEqual({ index: 2 });
+	});
+});

--- a/packages/core/src/interaction/knowledge/candidate-persistence.ts
+++ b/packages/core/src/interaction/knowledge/candidate-persistence.ts
@@ -1,0 +1,87 @@
+import { readFile, mkdir, appendFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export type CandidateKind =
+	| "project-facts"
+	| "skill-candidates"
+	| "open-loops"
+	| "preferences"
+	| "mistakes";
+
+const CANDIDATES_DIR = ".umwelten/candidates";
+
+export class CandidatePersistence {
+	constructor(private readonly projectRoot: string) {}
+
+	private get storeDir(): string {
+		return join(this.projectRoot, CANDIDATES_DIR);
+	}
+
+	private filePath(kind: CandidateKind): string {
+		return join(this.storeDir, `${kind}.jsonl`);
+	}
+
+	private async ensureDir(): Promise<void> {
+		await mkdir(this.storeDir, { recursive: true });
+	}
+
+	/**
+	 * Append a candidate of a specific kind to its project-local JSONL file.
+	 */
+	async append(kind: CandidateKind, payload: Record<string, any>): Promise<void> {
+		await this.ensureDir();
+		const file = this.filePath(kind);
+		const line = JSON.stringify(payload) + "\n";
+		await appendFile(file, line, "utf-8");
+	}
+
+	/**
+	 * Read all candidates of a specific kind.
+	 * Returns empty array if file is missing (ENOENT) or empty.
+	 */
+	async read(kind: CandidateKind): Promise<Record<string, any>[]> {
+		const file = this.filePath(kind);
+		try {
+			const content = await readFile(file, "utf-8");
+			const lines = content.split("\n");
+			const results: Record<string, any>[] = [];
+			for (const line of lines) {
+				const trimmed = line.trim();
+				if (!trimmed) continue;
+				try {
+					results.push(JSON.parse(trimmed));
+				} catch {
+					// Gracefully skip malformed JSONL lines in production/tests
+				}
+			}
+			return results;
+		} catch (error: any) {
+			if (error?.code === "ENOENT") {
+				return [];
+			}
+			throw error;
+		}
+	}
+
+	/**
+	 * Read all candidate kinds and return them as a mapped object.
+	 */
+	async readAll(): Promise<Record<CandidateKind, Record<string, any>[]>> {
+		const kinds: CandidateKind[] = [
+			"project-facts",
+			"skill-candidates",
+			"open-loops",
+			"preferences",
+			"mistakes",
+		];
+		
+		const results = await Promise.all(kinds.map(kind => this.read(kind)));
+		
+		const map = {} as Record<CandidateKind, Record<string, any>[]>;
+		kinds.forEach((kind, index) => {
+			map[kind] = results[index];
+		});
+		
+		return map;
+	}
+}

--- a/packages/core/src/interaction/knowledge/index.ts
+++ b/packages/core/src/interaction/knowledge/index.ts
@@ -38,3 +38,8 @@ export type { UserModelEntryOptions } from "./user-model-writer.js";
 // Saved Exploration store — .umwelten/explorations/
 export { SavedExplorationStore } from "./saved-exploration-store.js";
 export type { SavedExplorationSummary } from "./saved-exploration-store.js";
+
+// Candidate persistence module — .umwelten/candidates/
+export { CandidatePersistence } from "./candidate-persistence.js";
+export type { CandidateKind } from "./candidate-persistence.js";
+


### PR DESCRIPTION
## Description

This PR implements the `CandidatePersistence` module (under Issue #57), which acts as a project-local, file-based persistence layer for extracted AI candidates (project facts, skill candidates, open loops, preferences, and mistakes). 

It writes to append-only JSONL files under `.umwelten/candidates/` and is parameterized by the target `projectRoot`.

## Success Criteria Checklist & Verification Steps

### 1. `append(kind, payload)` writes JSONL lines to `.umwelten/candidates/<kind>.jsonl`
* **Validation**: Run the following command in node/tsx to append a fact:
  ```bash
  npx tsx -e "
  import { CandidatePersistence } from './packages/core/src/interaction/knowledge/candidate-persistence.js';
  const cp = new CandidatePersistence('./temp-test-pr');
  cp.append('project-facts', { fact: 'Hello from PR Verification' }).then(() => {
    import('node:fs/promises').then(fs => {
      fs.readFile('./temp-test-pr/.umwelten/candidates/project-facts.jsonl', 'utf8').then(console.log);
    });
  });
  "
  ```
* **Expected Output**:
  ```json
  {"fact":"Hello from PR Verification"}
  ```

### 2. `read(kind)` returns all candidates of that kind, `[]` for missing/empty files
* **Validation**: Read back the written files and non-existent files:
  ```bash
  npx tsx -e "
  import { CandidatePersistence } from './packages/core/src/interaction/knowledge/candidate-persistence.js';
  const cp = new CandidatePersistence('./temp-test-pr');
  cp.read('project-facts').then(facts => {
    console.log('Facts:', facts);
    cp.read('open-loops').then(loops => console.log('Open Loops (missing file):', loops));
  });
  "
  ```
* **Expected Output**:
  ```
  Facts: [ { fact: 'Hello from PR Verification' } ]
  Open Loops (missing file): []
  ```

### 3. `readAll()` returns all five kinds as a map
* **Validation**:
  ```bash
  npx tsx -e "
  import { CandidatePersistence } from './packages/core/src/interaction/knowledge/candidate-persistence.js';
  const cp = new CandidatePersistence('./temp-test-pr');
  cp.readAll().then(all => console.log('All kinds:', Object.keys(all)));
  "
  ```
* **Expected Output**:
  ```
  All kinds: [ 'project-facts', 'skill-candidates', 'open-loops', 'preferences', 'mistakes' ]
  ```

### 4. Tests pass successfully (TDD verified)
* **Validation**: Run the vitest command:
  ```bash
  pnpm test:run packages/core/src/interaction/knowledge/candidate-persistence.test.ts
  ```
* **Expected Output**: All 5 tests pass successfully.

### Cleanup test directory:
```bash
rm -rf ./temp-test-pr
```

Closes #57
