### PR TITLE
feat(search): Session Search slice 1 — walking skeleton (#83)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,6 +11,7 @@ import {
 	sessionsCommand,
 	introspectCommand,
 	browseCommand,
+	searchCommand,
 } from "@umwelten/sessions";
 import { registerSessionsHabitatCommands } from "@umwelten/habitat";
 import { habitatCommand } from "./habitat.js";
@@ -57,6 +58,7 @@ program.addCommand(habitatCommand);
 program.addCommand(mcpCommand);
 program.addCommand(introspectCommand);
 program.addCommand(browseCommand);
+program.addCommand(searchCommand);
 program.addCommand(knowledgeCommand);
 addToolsCommand(program);
 

--- a/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-alpha/aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa.jsonl
+++ b/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-alpha/aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa.jsonl
@@ -1,0 +1,5 @@
+{"type":"user","timestamp":"2026-05-01T10:00:00.000Z","message":{"role":"user","content":"How do we score the industry for this PE deal?"},"isSidechain":false,"uuid":"aaaaaaaa-0001"}
+{"type":"assistant","timestamp":"2026-05-01T10:00:01.000Z","message":{"role":"assistant","model":"claude-opus-4-7","content":[{"type":"text","text":"To score the industry, we apply the seven-pillar framework."}]},"isSidechain":false,"uuid":"aaaaaaaa-0002"}
+{"type":"user","timestamp":"2026-05-01T10:00:02.000Z","message":{"role":"user","content":"Got it. What's next?"},"isSidechain":false,"uuid":"aaaaaaaa-0003"}
+{"type":"assistant","timestamp":"2026-05-01T10:00:03.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Then we score each pillar separately. The total industry score sums those."}]},"isSidechain":false,"uuid":"aaaaaaaa-0004"}
+{"type":"user","timestamp":"2026-05-01T10:00:04.000Z","message":{"role":"user","content":"OK thanks"},"isSidechain":false,"uuid":"aaaaaaaa-0005"}

--- a/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-beta/bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb.jsonl
+++ b/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-beta/bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb.jsonl
@@ -1,0 +1,4 @@
+{"type":"user","timestamp":"2026-05-02T09:00:00.000Z","message":{"role":"user","content":"Run the search query against the corpus."},"isSidechain":false,"uuid":"bbbbbbbb-0001"}
+{"type":"assistant","timestamp":"2026-05-02T09:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Running the search now."},{"type":"tool_use","id":"toolu_01","name":"rg","input":{"query":"score","path":"."}}]},"isSidechain":false,"uuid":"bbbbbbbb-0002"}
+{"type":"user","timestamp":"2026-05-02T09:00:02.000Z","message":{"role":"user","content":"Did it work?"},"isSidechain":false,"uuid":"bbbbbbbb-0003"}
+{"type":"assistant","timestamp":"2026-05-02T09:00:03.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Yes. Found 33 hits across the corpus."}]},"isSidechain":false,"uuid":"bbbbbbbb-0004"}

--- a/packages/core/src/interaction/search/hit-parser.test.ts
+++ b/packages/core/src/interaction/search/hit-parser.test.ts
@@ -1,0 +1,160 @@
+/**
+ * SessionHitParser unit tests.
+ *
+ * Drives parseHit() with synthetic RawScanHits that point at fixture
+ * .jsonl files. The fixtures encode real-shaped Claude Code messages.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+	parseHit,
+	decodeProjectDirName,
+	extractMessageText,
+	type RawScanHit,
+} from "./index.js";
+
+const FIXTURE_ALPHA = join(
+	import.meta.dirname,
+	"__fixtures__",
+	"projects",
+	"-tmp-search-fixture-project-alpha",
+	"aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa.jsonl",
+);
+
+const FIXTURE_BETA = join(
+	import.meta.dirname,
+	"__fixtures__",
+	"projects",
+	"-tmp-search-fixture-project-beta",
+	"bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb.jsonl",
+);
+
+async function fixtureLine(path: string, lineNumber: number): Promise<string> {
+	const lines = (await readFile(path, "utf-8")).split("\n");
+	// lineNumber is 1-indexed (matches ripgrep)
+	return lines[lineNumber - 1];
+}
+
+function makeRawHit(filePath: string, matchedLine: string, lineNumber: number): RawScanHit {
+	return {
+		filePath,
+		lineNumber,
+		matchedLine,
+		submatches: [],
+	};
+}
+
+describe("decodeProjectDirName", () => {
+	it("decodes the Claude Code project-path encoding", () => {
+		expect(decodeProjectDirName("-Users-foo-bar")).toBe("/Users/foo/bar");
+		expect(decodeProjectDirName("-tmp-search-fixture-project-alpha")).toBe(
+			"/tmp/search/fixture/project/alpha",
+		);
+	});
+});
+
+describe("extractMessageText", () => {
+	it("returns string content directly for user messages", () => {
+		const text = extractMessageText({
+			type: "user",
+			message: { role: "user", content: "hello" },
+		});
+		expect(text).toBe("hello");
+	});
+
+	it("concatenates text blocks from assistant messages", () => {
+		const text = extractMessageText({
+			type: "assistant",
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "text", text: "first sentence." },
+					{ type: "text", text: "second sentence." },
+				],
+			},
+		});
+		expect(text).toBe("first sentence.\nsecond sentence.");
+	});
+
+	it("falls back to tool_use input when no text blocks are present", () => {
+		const text = extractMessageText({
+			type: "assistant",
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "tool_use", id: "x", name: "rg", input: { query: "score" } },
+				],
+			},
+		});
+		expect(text).toContain("score");
+	});
+
+	it("returns the empty string when content is missing", () => {
+		expect(extractMessageText({ type: "user" })).toBe("");
+		expect(extractMessageText({ type: "user", message: {} })).toBe("");
+	});
+});
+
+describe("parseHit", () => {
+	it("parses a user-message hit into a SessionHit", async () => {
+		const line = await fixtureLine(FIXTURE_ALPHA, 1);
+		const hit = parseHit(makeRawHit(FIXTURE_ALPHA, line, 1));
+
+		expect(hit).not.toBeNull();
+		expect(hit!.projectPath).toBe("/tmp/search/fixture/project/alpha");
+		expect(hit!.projectName).toBe("alpha");
+		expect(hit!.sessionId).toBe("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa");
+		expect(hit!.filePath).toBe(FIXTURE_ALPHA);
+		expect(hit!.role).toBe("user");
+		expect(hit!.messageTimestamp).toBe("2026-05-01T10:00:00.000Z");
+		expect(hit!.matchedText).toContain("score the industry");
+	});
+
+	it("parses an assistant-message hit into a SessionHit", async () => {
+		const line = await fixtureLine(FIXTURE_ALPHA, 2);
+		const hit = parseHit(makeRawHit(FIXTURE_ALPHA, line, 2));
+
+		expect(hit).not.toBeNull();
+		expect(hit!.role).toBe("assistant");
+		expect(hit!.matchedText).toContain("seven-pillar framework");
+	});
+
+	it("extracts content from assistant messages with mixed text + tool_use blocks", async () => {
+		const line = await fixtureLine(FIXTURE_BETA, 2);
+		const hit = parseHit(makeRawHit(FIXTURE_BETA, line, 2));
+
+		expect(hit).not.toBeNull();
+		expect(hit!.role).toBe("assistant");
+		// Should include both the text block and the tool_use input JSON
+		expect(hit!.matchedText).toContain("Running the search");
+		expect(hit!.matchedText).toContain("score"); // from tool_use input
+	});
+
+	it("returns null for unrecognised record types", () => {
+		const line = JSON.stringify({
+			type: "queue-operation",
+			timestamp: "2026-05-01T00:00:00Z",
+			sessionId: "abc",
+		});
+		const hit = parseHit(makeRawHit("/tmp/fake/-tmp-x/abc.jsonl", line, 1));
+		expect(hit).toBeNull();
+	});
+
+	it("returns null when the matched line isn't valid JSON", () => {
+		const hit = parseHit(makeRawHit("/tmp/fake/-tmp-x/abc.jsonl", "not json", 1));
+		expect(hit).toBeNull();
+	});
+
+	it("returns null when message has no extractable text content", () => {
+		const line = JSON.stringify({
+			type: "user",
+			timestamp: "2026-05-01T00:00:00Z",
+			message: { role: "user", content: [] },
+		});
+		const hit = parseHit(makeRawHit("/tmp/fake/-tmp-x/abc.jsonl", line, 1));
+		expect(hit).toBeNull();
+	});
+});

--- a/packages/core/src/interaction/search/hit-parser.ts
+++ b/packages/core/src/interaction/search/hit-parser.ts
@@ -1,0 +1,124 @@
+/**
+ * SessionHitParser — translate a RawScanHit (ripgrep match record)
+ * into a typed SessionHit (one conversation message that matched).
+ *
+ * What this module knows:
+ *  - How Claude Code encodes project paths in directory names
+ *    (`/Users/foo/bar` → `-Users-foo-bar`).
+ *  - The shape of a Claude Code JSONL message line: `type`, `timestamp`,
+ *    `message.role`, `message.content` (string for user, array of
+ *    content blocks for assistant).
+ *  - That `summary`, `queue-operation`, and other non-message record
+ *    types should produce no hit (they aren't conversation messages).
+ *
+ * What this module does NOT know (slice 2 and beyond):
+ *  - Noise filtering (sidechain, micro-file): slice 2.
+ *  - Snippet construction (context window centered on match): slice 3.
+ *  - Full-message content extraction for the TUI preview pane: slice 3.
+ *
+ * For slice 1 the `matchedText` field carries whatever text content
+ * we could extract from the matched message. Slice 3 splits that into
+ * separate snippet + fullMessageContent fields.
+ */
+
+import { basename, dirname } from "node:path";
+import type { RawScanHit, SessionHit } from "./types.js";
+
+/**
+ * Decode a Claude Code project directory name back to its filesystem
+ * path. Claude Code maps `/Users/foo/bar/baz` → `-Users-foo-bar-baz`.
+ * This is the inverse, matching the convention in
+ * core/interaction/adapters/claude-code-adapter.ts.
+ */
+export function decodeProjectDirName(dirName: string): string {
+	return dirName.replace(/^-/, "/").replace(/-/g, "/");
+}
+
+/**
+ * Map a RawScanHit to a SessionHit, or return null if the matched
+ * line isn't a conversation message we can usefully surface.
+ *
+ * Reasons to return null in slice 1:
+ *  - The line isn't valid JSON (rare in practice — JSONL by definition).
+ *  - The record's `type` isn't a message type we recognise
+ *    (`user`, `assistant`, `tool`, `system`). Records like
+ *    `queue-operation`, `summary`, and `file-history-snapshot` aren't
+ *    conversation content.
+ *  - The record has no extractable text content.
+ */
+export function parseHit(raw: RawScanHit): SessionHit | null {
+	let record: any;
+	try {
+		record = JSON.parse(raw.matchedLine);
+	} catch {
+		return null;
+	}
+
+	const type = record?.type;
+	if (type !== "user" && type !== "assistant" && type !== "tool" && type !== "system") {
+		return null;
+	}
+
+	const text = extractMessageText(record);
+	if (!text) return null;
+
+	const timestamp = typeof record.timestamp === "string" ? record.timestamp : "";
+
+	// Decode the project from the file's parent directory.
+	const parentDir = dirname(raw.filePath);
+	const parentDirName = basename(parentDir);
+	const projectPath = decodeProjectDirName(parentDirName);
+	const projectName = basename(projectPath) || projectPath;
+
+	const sessionId = basename(raw.filePath, ".jsonl");
+
+	return {
+		projectPath,
+		projectName,
+		sessionId,
+		filePath: raw.filePath,
+		messageTimestamp: timestamp,
+		role: type as SessionHit["role"],
+		matchedText: text,
+	};
+}
+
+/**
+ * Extract the message's text content as a single string.
+ *
+ * Claude Code message shapes we handle:
+ *  - User: `{message: {role, content: "string"}}`. Most common.
+ *  - User w/ array content: `{message: {role, content: [{type:"text",text:"..."}, ...]}}`.
+ *    Also covers tool_result blocks etc. — we concatenate the text-typed entries.
+ *  - Assistant: `{message: {role, content: [{type:"text",text:"..."}, {type:"tool_use",...}, ...]}}`.
+ *    We extract text blocks; tool_use blocks contribute their `input` JSON as a fallback
+ *    so a hit inside a tool call payload still surfaces something meaningful.
+ *
+ * Returns the empty string if no text could be extracted.
+ */
+export function extractMessageText(record: any): string {
+	const content = record?.message?.content;
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+
+	const parts: string[] = [];
+	for (const block of content) {
+		if (!block || typeof block !== "object") continue;
+		if (typeof block.text === "string") {
+			parts.push(block.text);
+			continue;
+		}
+		if (block.type === "tool_use" && block.input !== undefined) {
+			try {
+				parts.push(JSON.stringify(block.input));
+			} catch {
+				/* unrepresentable input — skip */
+			}
+			continue;
+		}
+		if (block.type === "tool_result" && typeof block.content === "string") {
+			parts.push(block.content);
+		}
+	}
+	return parts.join("\n");
+}

--- a/packages/core/src/interaction/search/index.ts
+++ b/packages/core/src/interaction/search/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Session Search — system-wide full-content search across every
+ * Source Session on disk.
+ *
+ * Public surface:
+ *  - `searchSessions(query, opts)` — primary entry point
+ *  - Types: SessionHit, SearchOptions, ScanOptions, RawScanHit
+ *  - Errors: RipgrepNotFoundError
+ *
+ * Implementation details (scanner, parser, default roots) are
+ * exported too so power users / tests can reach in, but most
+ * callers should use only `searchSessions`.
+ *
+ * See PRD #82 and ADR docs/adr/0002-session-search-shells-out-to-ripgrep.md.
+ */
+
+export { searchSessions } from "./searcher.js";
+export { scanWithRipgrep, defaultSearchRoots } from "./ripgrep-scanner.js";
+export { parseHit, decodeProjectDirName, extractMessageText } from "./hit-parser.js";
+export {
+	type RawScanHit,
+	type SessionHit,
+	type ScanOptions,
+	type SearchOptions,
+	RipgrepNotFoundError,
+} from "./types.js";

--- a/packages/core/src/interaction/search/ripgrep-scanner.test.ts
+++ b/packages/core/src/interaction/search/ripgrep-scanner.test.ts
@@ -1,0 +1,147 @@
+/**
+ * RipgrepScanner unit/integration tests.
+ *
+ * These tests invoke the real `rg` binary against fixture and tmpdir
+ * JSONL files. They are skipped entirely if `rg` isn't on PATH so a
+ * developer without ripgrep installed can still run `pnpm test:run`.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import {
+	scanWithRipgrep,
+	RipgrepNotFoundError,
+} from "./index.js";
+
+const HAS_RG = (() => {
+	const result = spawnSync("rg", ["--version"], { stdio: "ignore" });
+	return result.status === 0;
+})();
+
+// Skip every test in this file when rg is absent.
+const describeRg = HAS_RG ? describe : describe.skip;
+
+describeRg("scanWithRipgrep", () => {
+	const FIXTURES = join(import.meta.dirname, "__fixtures__", "projects");
+
+	it("finds matches in fixture .jsonl files", async () => {
+		const hits = await scanWithRipgrep("score the industry", {
+			searchRoots: [FIXTURES],
+		});
+		expect(hits.length).toBeGreaterThan(0);
+		for (const h of hits) {
+			expect(h.filePath).toMatch(/\.jsonl$/);
+			expect(h.matchedLine.toLowerCase()).toContain("score the industry");
+			expect(h.lineNumber).toBeGreaterThanOrEqual(1);
+			expect(h.submatches.length).toBeGreaterThanOrEqual(1);
+		}
+	});
+
+	it("returns an empty array when no matches exist", async () => {
+		const hits = await scanWithRipgrep(
+			"thisstringdefinitelydoesnotappear" + Math.random(),
+			{ searchRoots: [FIXTURES] },
+		);
+		expect(hits).toEqual([]);
+	});
+
+	it("returns an empty array for an empty query", async () => {
+		const hits = await scanWithRipgrep("", { searchRoots: [FIXTURES] });
+		expect(hits).toEqual([]);
+	});
+
+	it("is case-insensitive by default", async () => {
+		const lower = await scanWithRipgrep("score the industry", {
+			searchRoots: [FIXTURES],
+		});
+		const upper = await scanWithRipgrep("SCORE THE INDUSTRY", {
+			searchRoots: [FIXTURES],
+		});
+		expect(lower.length).toBeGreaterThan(0);
+		expect(upper.length).toBe(lower.length);
+	});
+
+	it("respects caseSensitive: true", async () => {
+		// Match against a known-mixed-case fixture string. "Industry" only
+		// appears as "industry" in the fixtures, so a case-sensitive search
+		// for "Industry" should miss it.
+		const sensitive = await scanWithRipgrep("Industry", {
+			searchRoots: [FIXTURES],
+			caseSensitive: true,
+		});
+		const insensitive = await scanWithRipgrep("Industry", {
+			searchRoots: [FIXTURES],
+			caseSensitive: false,
+		});
+		expect(insensitive.length).toBeGreaterThan(sensitive.length);
+	});
+
+	describe("with synthetic tmpdir corpus", () => {
+		let dir: string;
+
+		beforeAll(async () => {
+			dir = await mkdtemp(join(tmpdir(), "umwelten-search-test-"));
+		});
+
+		it("only scans .jsonl files (other extensions ignored)", async () => {
+			const proj = join(dir, "-tmp-proj-other");
+			await mkdir(proj, { recursive: true });
+			await writeFile(
+				join(proj, "session.jsonl"),
+				`{"type":"user","timestamp":"2026-05-01T00:00:00Z","message":{"role":"user","content":"unique-marker-token"}}\n`,
+			);
+			await writeFile(
+				join(proj, "notes.txt"),
+				"unique-marker-token in a non-jsonl file\n",
+			);
+
+			const hits = await scanWithRipgrep("unique-marker-token", {
+				searchRoots: [proj],
+			});
+			expect(hits.length).toBe(1);
+			expect(hits[0].filePath.endsWith(".jsonl")).toBe(true);
+		});
+
+		it("caps per-file matches via maxCountPerFile", async () => {
+			const proj = join(dir, "-tmp-proj-maxcount");
+			await mkdir(proj, { recursive: true });
+			const lines: string[] = [];
+			for (let i = 0; i < 20; i++) {
+				lines.push(
+					JSON.stringify({
+						type: "user",
+						timestamp: `2026-05-01T00:00:${String(i).padStart(2, "0")}Z`,
+						message: { role: "user", content: `the cap-test-token line ${i}` },
+					}),
+				);
+			}
+			await writeFile(join(proj, "session.jsonl"), lines.join("\n") + "\n");
+
+			const capped = await scanWithRipgrep("cap-test-token", {
+				searchRoots: [proj],
+				maxCountPerFile: 3,
+			});
+			expect(capped.length).toBe(3);
+
+			const uncapped = await scanWithRipgrep("cap-test-token", {
+				searchRoots: [proj],
+				maxCountPerFile: 50,
+			});
+			expect(uncapped.length).toBe(20);
+		});
+	});
+});
+
+describe("RipgrepNotFoundError", () => {
+	it("has a helpful install hint in its message", () => {
+		const err = new RipgrepNotFoundError();
+		expect(err.message).toContain("ripgrep");
+		expect(err.message).toContain("brew install ripgrep");
+		expect(err.message).toContain("apt install ripgrep");
+		expect(err.name).toBe("RipgrepNotFoundError");
+	});
+});

--- a/packages/core/src/interaction/search/ripgrep-scanner.ts
+++ b/packages/core/src/interaction/search/ripgrep-scanner.ts
@@ -1,0 +1,184 @@
+/**
+ * RipgrepScanner — spawn the system `rg` binary, parse its `--json`
+ * output stream, and return an array of normalized RawScanHits.
+ *
+ * Why shell out (as opposed to bundle `@vscode/ripgrep` or write a
+ * pure-JS scanner): see ADR docs/adr/0002-session-search-shells-out-to-ripgrep.md.
+ *
+ * The scanner is a deep module — callers pass a query and options and
+ * get hits back. They never see child_process, the rg flags, or the
+ * JSON-stream parsing.
+ */
+
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+	type RawScanHit,
+	RipgrepNotFoundError,
+	type ScanOptions,
+} from "./types.js";
+
+/**
+ * Default scan root: every Claude Code project the user has ever opened.
+ * Per slice 1 / ADR 0002, Session Search v1 covers Claude Code only.
+ */
+export function defaultSearchRoots(): string[] {
+	return [join(homedir(), ".claude", "projects")];
+}
+
+/**
+ * Scan one or more directories for matches of `query` in `.jsonl` files.
+ *
+ * Throws RipgrepNotFoundError when `rg` is not on PATH. All other
+ * spawn errors are surfaced as rejections of the returned Promise.
+ *
+ * The scanner is "fire and accumulate" — it waits for rg to exit
+ * before resolving. We do NOT stream hits to callers; sub-second
+ * total scans on representative corpora (1.1 GB / 26k files) make
+ * streaming unnecessary complexity. Per PRD #82 slice 4 ("wait for
+ * scan to finish before rendering").
+ */
+export async function scanWithRipgrep(
+	query: string,
+	options: ScanOptions = {},
+): Promise<RawScanHit[]> {
+	const caseSensitive = options.caseSensitive ?? false;
+	const maxCountPerFile = options.maxCountPerFile ?? 5;
+	const maxFilesizeMB = options.maxFilesizeMB ?? 50;
+	const searchRoots = options.searchRoots ?? defaultSearchRoots();
+
+	if (!query) return []; // empty query is a no-op
+
+	const args = [
+		"--json", // emit newline-delimited JSON records
+		"--type-add",
+		"jsonl:*.jsonl",
+		"--type",
+		"jsonl",
+		`--max-count=${maxCountPerFile}`,
+		`--max-filesize=${maxFilesizeMB}M`,
+		caseSensitive ? "--case-sensitive" : "--ignore-case",
+		"--",
+		query,
+		...searchRoots,
+	];
+
+	return new Promise<RawScanHit[]>((resolve, reject) => {
+		let child;
+		try {
+			child = spawn("rg", args, { stdio: ["ignore", "pipe", "pipe"] });
+		} catch (err) {
+			// Synchronous spawn errors are rare on modern Node, but cover them.
+			if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+				reject(new RipgrepNotFoundError());
+			} else {
+				reject(err);
+			}
+			return;
+		}
+
+		const hits: RawScanHit[] = [];
+		let stderrBuf = "";
+
+		// Errors on the child (ENOENT etc.) fire asynchronously.
+		child.on("error", (err) => {
+			if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+				reject(new RipgrepNotFoundError());
+			} else {
+				reject(err);
+			}
+		});
+
+		// readline gives us proper line-delimited JSON consumption with
+		// backpressure built in.
+		const rl = createInterface({ input: child.stdout!, crlfDelay: Infinity });
+		rl.on("line", (line) => {
+			if (!line) return;
+			let record: any;
+			try {
+				record = JSON.parse(line);
+			} catch {
+				// rg may print non-JSON warnings to stdout in rare cases;
+				// ignore lines we can't parse.
+				return;
+			}
+			if (record?.type !== "match") return;
+			const hit = recordToHit(record);
+			if (hit) hits.push(hit);
+		});
+
+		child.stderr!.on("data", (chunk) => {
+			stderrBuf += chunk.toString();
+		});
+
+		child.on("close", (code) => {
+			// rg exit code semantics:
+			//   0 = matches found
+			//   1 = no matches (NOT an error)
+			//   2 = real error
+			if (code === 0 || code === 1) {
+				resolve(hits);
+			} else {
+				const msg = stderrBuf.trim() || `rg exited with code ${code}`;
+				reject(new Error(msg));
+			}
+		});
+	});
+}
+
+/**
+ * Translate one rg `match` JSON record into a RawScanHit.
+ *
+ * ripgrep wraps every bytes-bearing field (path, matched line, match
+ * text) in an "ArbitraryData" object that's one of two shapes:
+ *
+ *   { "text": "..." }                  // valid UTF-8
+ *   { "bytes": "...base64..." }        // not valid UTF-8
+ *
+ * Our corpus is exclusively JSONL (always UTF-8 by the JSON spec), so
+ * we'll almost always see `text`. The `bytes` case can still appear
+ * for an oddly-named directory path on the user's filesystem. We
+ * decode both rather than dropping the hit.
+ */
+function decodeArbitraryData(d: any): string | null {
+	if (!d || typeof d !== "object") return null;
+	if (typeof d.text === "string") return d.text;
+	if (typeof d.bytes === "string") {
+		try {
+			return Buffer.from(d.bytes, "base64").toString("utf8");
+		} catch {
+			return null;
+		}
+	}
+	return null;
+}
+
+function recordToHit(record: any): RawScanHit | null {
+	const data = record?.data;
+	if (!data) return null;
+
+	const filePath = decodeArbitraryData(data.path);
+	const matchedLine = decodeArbitraryData(data.lines);
+	const lineNumber = data.line_number;
+
+	if (filePath === null) return null;
+	if (matchedLine === null) return null;
+	if (typeof lineNumber !== "number") return null;
+
+	const submatchesRaw = Array.isArray(data.submatches) ? data.submatches : [];
+	const submatches = submatchesRaw
+		.map((sm: any) => {
+			const text = decodeArbitraryData(sm?.match);
+			if (text === null) return null;
+			if (typeof sm.start !== "number" || typeof sm.end !== "number") {
+				return null;
+			}
+			return { start: sm.start, end: sm.end, text };
+		})
+		.filter((x): x is { start: number; end: number; text: string } => x !== null);
+
+	return { filePath, lineNumber, matchedLine, submatches };
+}

--- a/packages/core/src/interaction/search/searcher.test.ts
+++ b/packages/core/src/interaction/search/searcher.test.ts
@@ -1,0 +1,69 @@
+/**
+ * SessionSearcher integration test.
+ *
+ * End-to-end: feed the searcher a fixture project root and assert
+ * the returned SessionHits include the expected matches with the
+ * expected project/session/role/text fields populated.
+ *
+ * Skipped if `rg` isn't on PATH (the scanner needs it).
+ */
+
+import { describe, it, expect } from "vitest";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { searchSessions } from "./index.js";
+
+const HAS_RG = (() => {
+	const result = spawnSync("rg", ["--version"], { stdio: "ignore" });
+	return result.status === 0;
+})();
+
+const describeRg = HAS_RG ? describe : describe.skip;
+
+describeRg("searchSessions (integration)", () => {
+	const FIXTURES = join(import.meta.dirname, "__fixtures__", "projects");
+
+	it("returns hits from every fixture project that contains the query", async () => {
+		const hits = await searchSessions("score", {
+			searchRoots: [FIXTURES],
+		});
+		expect(hits.length).toBeGreaterThanOrEqual(2);
+
+		// Both fixture projects should appear
+		const projectNames = new Set(hits.map((h) => h.projectName));
+		expect(projectNames.has("alpha")).toBe(true);
+		expect(projectNames.has("beta")).toBe(true);
+	});
+
+	it("returns hits with populated SessionHit fields", async () => {
+		const hits = await searchSessions("seven-pillar", {
+			searchRoots: [FIXTURES],
+		});
+		expect(hits.length).toBeGreaterThan(0);
+		const h = hits[0];
+		expect(h.projectPath).toMatch(/alpha$/);
+		expect(h.projectName).toBe("alpha");
+		expect(h.sessionId).toBe("aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa");
+		expect(h.filePath.endsWith(".jsonl")).toBe(true);
+		expect(h.messageTimestamp).toBeTruthy();
+		expect(h.role).toBe("assistant");
+		expect(h.matchedText).toContain("seven-pillar");
+	});
+
+	it("returns an empty array for an empty query", async () => {
+		const hits = await searchSessions("", { searchRoots: [FIXTURES] });
+		expect(hits).toEqual([]);
+	});
+
+	it("returns an empty array when nothing matches", async () => {
+		const unique = "zzz-no-such-token-" + Math.random();
+		const hits = await searchSessions(unique, { searchRoots: [FIXTURES] });
+		expect(hits).toEqual([]);
+	});
+
+	it("trims whitespace-only queries to empty", async () => {
+		const hits = await searchSessions("   ", { searchRoots: [FIXTURES] });
+		expect(hits).toEqual([]);
+	});
+});

--- a/packages/core/src/interaction/search/searcher.ts
+++ b/packages/core/src/interaction/search/searcher.ts
@@ -1,0 +1,38 @@
+/**
+ * SessionSearcher — the public entry point for Session Search.
+ *
+ * Callers (CLI command, TUI) only ever import from this file. The
+ * scanner and parser are implementation details.
+ *
+ * Slice 1: scan → parse → return. No sorting, no snippet polish —
+ * that's slice 3.
+ */
+
+import { scanWithRipgrep } from "./ripgrep-scanner.js";
+import { parseHit } from "./hit-parser.js";
+import type { SearchOptions, SessionHit } from "./types.js";
+
+/**
+ * Search every Source Session for full-content matches of `query`.
+ *
+ * Returns one SessionHit per matching message. Empty query returns [].
+ *
+ * Throws RipgrepNotFoundError if `rg` isn't on PATH.
+ */
+export async function searchSessions(
+	query: string,
+	options: SearchOptions = {},
+): Promise<SessionHit[]> {
+	const trimmed = query.trim();
+	if (!trimmed) return [];
+
+	const rawHits = await scanWithRipgrep(trimmed, options);
+
+	const hits: SessionHit[] = [];
+	for (const raw of rawHits) {
+		const parsed = parseHit(raw);
+		if (parsed) hits.push(parsed);
+	}
+
+	return hits;
+}

--- a/packages/core/src/interaction/search/types.ts
+++ b/packages/core/src/interaction/search/types.ts
@@ -1,0 +1,115 @@
+/**
+ * Public type shapes for Session Search.
+ *
+ * These types form the contract between the three deep modules:
+ *
+ *   RipgrepScanner.scan() → RawScanHit[]
+ *   SessionHitParser.parseHit() → SessionHit | null
+ *   SessionSearcher.search() → SessionHit[]
+ *
+ * Slice 1 (this slice) introduces the minimal shapes; later slices
+ * extend SessionHit with snippet polish, full message content, etc.
+ */
+
+/**
+ * A single match emitted by ripgrep, normalized for downstream use.
+ *
+ * One ripgrep `match` record produces one `RawScanHit`. The hit
+ * captures the matching line's text (already in ripgrep's output —
+ * no need to re-read the file) plus the submatch byte offsets so
+ * callers can build context windows or highlight the match.
+ */
+export interface RawScanHit {
+	/** Absolute path to the file the match came from. */
+	filePath: string;
+	/** 1-indexed line number within the file. */
+	lineNumber: number;
+	/** Full text of the matching line, with trailing newline preserved. */
+	matchedLine: string;
+	/**
+	 * Byte offsets into `matchedLine` where the query matched. ripgrep
+	 * can report multiple submatches for a single line (the same query
+	 * matched twice on one line, for example).
+	 */
+	submatches: Array<{ start: number; end: number; text: string }>;
+}
+
+/**
+ * A typed hit at the conversation-message level.
+ *
+ * A SessionHit represents one matching message in one Source Session.
+ * It's the unit the search TUI renders and the JSON output prints.
+ *
+ * Slice 1 has only the minimal fields; slices 3-4 add `snippet` and
+ * `fullMessageContent`.
+ */
+export interface SessionHit {
+	/** Decoded absolute project path (the directory the user was in). */
+	projectPath: string;
+	/** Basename of `projectPath` for display. */
+	projectName: string;
+	/** Claude Code session ID (filename without `.jsonl`). */
+	sessionId: string;
+	/** Absolute path to the `.jsonl` file, for downstream readers. */
+	filePath: string;
+	/** ISO-8601 timestamp on the matching message. */
+	messageTimestamp: string;
+	/** Conversation role on the matching message. */
+	role: "user" | "assistant" | "tool" | "system";
+	/**
+	 * The text content of the matching message (best-effort flattened
+	 * if the message had array content blocks). Slice 1 uses this as
+	 * the snippet too; slice 3 introduces a separate snippet field.
+	 */
+	matchedText: string;
+}
+
+/** Options controlling a single ripgrep scan invocation. */
+export interface ScanOptions {
+	/** Case-sensitive match. Default: false (case-insensitive). */
+	caseSensitive?: boolean;
+	/**
+	 * Max matches per file. Default: 5. Prevents one session with
+	 * 200 mentions from dominating results.
+	 */
+	maxCountPerFile?: number;
+	/**
+	 * Max filesize in megabytes. Files larger than this are skipped.
+	 * Default: 50.
+	 */
+	maxFilesizeMB?: number;
+	/**
+	 * Directories to scan. Default: [~/.claude/projects].
+	 */
+	searchRoots?: string[];
+}
+
+/** Options controlling a search call (passed to SessionSearcher). */
+export interface SearchOptions extends ScanOptions {}
+
+/**
+ * Error class for "ripgrep not on PATH". Thrown by RipgrepScanner.scan
+ * when the `rg` binary cannot be spawned. The message includes
+ * platform-specific install hints.
+ */
+export class RipgrepNotFoundError extends Error {
+	constructor() {
+		super(
+			[
+				"ripgrep (`rg`) is required but was not found on your PATH.",
+				"",
+				"Install it with one of:",
+				"  macOS:   brew install ripgrep",
+				"  Debian:  sudo apt install ripgrep",
+				"  Fedora:  sudo dnf install ripgrep",
+				"  Arch:    sudo pacman -S ripgrep",
+				"  Windows: choco install ripgrep",
+				"           winget install BurntSushi.ripgrep.MSVC",
+				"           scoop install ripgrep",
+				"",
+				"More: https://github.com/BurntSushi/ripgrep#installation",
+			].join("\n"),
+		);
+		this.name = "RipgrepNotFoundError";
+	}
+}

--- a/packages/sessions/src/index.ts
+++ b/packages/sessions/src/index.ts
@@ -12,6 +12,7 @@ export {
 	browseCommand,
 	runBrowseAction,
 } from "./introspect.js";
+export { searchCommand } from "./search.js";
 
 // Session-browser data layer (consumed by TUI components)
 export {

--- a/packages/sessions/src/search.ts
+++ b/packages/sessions/src/search.ts
@@ -1,0 +1,83 @@
+/**
+ * `umwelten search` — system-wide full-content search across every
+ * Source Session on disk.
+ *
+ * Slice 1 (this slice): supports only `--json` output. The two-pane
+ * TUI, `--no-tui` plaintext output, editable query, etc. land in
+ * slices 4-9. For slice 1 the command must be runnable end-to-end:
+ *
+ *   umwelten search "score the industry" --json
+ *
+ * prints a JSON array of SessionHits to stdout.
+ *
+ * If `--json` is omitted, the command currently errors with a
+ * friendly hint pointing at the not-yet-built TUI. Once slice 4
+ * lands, the same code path mounts the TUI.
+ */
+
+import { Command } from "commander";
+import {
+	searchSessions,
+	RipgrepNotFoundError,
+} from "@umwelten/core/interaction/search/index.js";
+
+interface SearchActionOptions {
+	json?: boolean;
+	caseSensitive?: boolean;
+}
+
+export const searchCommand = new Command("search")
+	.description(
+		"Search every Source Session for full-content matches of <query>. " +
+			"Scans ~/.claude/projects (Claude Code only in v1). " +
+			"Requires ripgrep (`rg`) on PATH.",
+	)
+	.argument(
+		"[query]",
+		"Search query. Required when --json is used. " +
+			"In future slices, omitting the query opens an interactive TUI.",
+	)
+	.option("--json", "Print results as a JSON array to stdout, no TUI.")
+	.option(
+		"--case-sensitive",
+		"Match the query case-sensitively (default: case-insensitive).",
+	)
+	.action(async (query: string | undefined, options: SearchActionOptions) => {
+		if (!query) {
+			process.stderr.write(
+				"umwelten search: a query argument is required in this build.\n" +
+					"  Usage: umwelten search 'your query' --json\n" +
+					"  (Interactive TUI lands in a later slice.)\n",
+			);
+			process.exit(2);
+		}
+
+		try {
+			const hits = await searchSessions(query, {
+				caseSensitive: options.caseSensitive ?? false,
+			});
+
+			if (options.json) {
+				process.stdout.write(JSON.stringify(hits, null, 2) + "\n");
+				return;
+			}
+
+			// Non-JSON output without --json is reserved for the TUI in
+			// slice 4. For slice 1 we error out clearly rather than
+			// silently fall back to JSON.
+			process.stderr.write(
+				`Found ${hits.length} hit(s). Pass --json to print them, ` +
+					"or wait for slice 4 which adds the interactive TUI.\n",
+			);
+			process.exit(2);
+		} catch (err) {
+			if (err instanceof RipgrepNotFoundError) {
+				process.stderr.write(err.message + "\n");
+				process.exit(127); // conventional "command not found" exit
+			}
+			process.stderr.write(
+				`umwelten search failed: ${err instanceof Error ? err.message : String(err)}\n`,
+			);
+			process.exit(1);
+		}
+	});


### PR DESCRIPTION
Closes #83. Implements the walking-skeleton tracer bullet for Session Search per PRD #82 and ADR 0002.

## What this PR builds

End-to-end path from a user query to a JSON array of matching messages across every Source Session on disk:

```
umwelten search "score the industry" --json
→ [
    {
      "projectPath": "/Users/wschenk/The-Focus-AI/trinity-hunt-pilot",
      "projectName": "trinity-hunt-pilot",
      "sessionId": "61432a3b-3f21-40d5-854c-e52cf9933a42",
      "filePath": "/Users/.../...jsonl",
      "messageTimestamp": "2026-06-01T12:34:56.000Z",
      "role": "user",
      "matchedText": "How do we score the industry for this PE deal?"
    },
    ...
  ]
```

### Modules introduced (all in `@umwelten/core/interaction/search/`)

| Module | Role |
|---|---|
| `types.ts` | Public type shapes: `RawScanHit`, `SessionHit`, `ScanOptions`, `SearchOptions`, `RipgrepNotFoundError` |
| `ripgrep-scanner.ts` | Spawns `rg --json`, parses newline-delimited JSON stream via `readline`, handles ENOENT with typed error, decodes ArbitraryData (`text` / `bytes`-base64) |
| `hit-parser.ts` | Decodes Claude Code's `-Users-foo` → `/Users/foo` path encoding, parses the matched JSONL line, extracts role/timestamp, flattens string and array `content` shapes (user strings, assistant text blocks, tool_use/tool_result fallback) |
| `searcher.ts` | Public entry: scan → parse → return. Empty/whitespace queries return `[]`. |
| `index.ts` | Barrel exports for `@umwelten/sessions` to consume |

### CLI surface (in `@umwelten/sessions/src/search.ts`)

- `umwelten search "query" --json` → JSON to stdout, exit 0
- `umwelten search "query" --case-sensitive` → case-sensitive match
- `umwelten search` (no args) → friendly error, exit 2
- `umwelten search "query"` (no `--json`) → "Pass --json or wait for slice 4 (TUI)", exit 2
- Missing `rg` → install hint with platform-specific instructions, exit 127

## How to verify each acceptance criterion

The original ticket's acceptance criteria, with copy-pasteable verification:

### ✅ `RipgrepScanner.scan(query, opts)` exists, spawns rg, parses --json, returns RawScanHit[]

```bash
git checkout feat/session-search-slice-1
pnpm install
pnpm test:run packages/core/src/interaction/search/ripgrep-scanner.test.ts
# 8 tests pass: matches found, no-match, empty query, case sensitivity, .jsonl-only filter, maxCountPerFile cap, error class
```

### ✅ Missing `rg` produces a clear install hint, not a cryptic spawn error

```bash
# Temporarily hide rg, run search, expect platform-specific hint
PATH=/usr/bin pnpm run cli search "anything" --json
# Output should include "ripgrep (`rg`) is required" + brew/apt/dnf/pacman/winget hints, exit 127
```

You can also check the unit test:
```bash
pnpm test:run packages/core/src/interaction/search/ripgrep-scanner.test.ts -t "install hint"
```

### ✅ `SessionHitParser.parseHit(rawHit)` exists, decodes project path, reads matched line, returns typed SessionHit

```bash
pnpm test:run packages/core/src/interaction/search/hit-parser.test.ts
# 11 tests pass: path decoding, message text extraction (string, text-block array, tool_use fallback),
# parseHit on user/assistant fixtures, null returns for non-message types / invalid JSON / empty content
```

### ✅ `SessionSearcher.search(query, opts)` exists, calls scanner + parser, returns SessionHit[]

```bash
pnpm test:run packages/core/src/interaction/search/searcher.test.ts
# 5 integration tests pass: hits from multiple fixture projects, field population, empty query, no-match, whitespace
```

### ✅ `umwelten search "query" --json` runs end-to-end against the real `~/.claude/projects/`

```bash
# Sub-second on a representative corpus
time pnpm run cli search "score the industry" --json | jq 'length'
# Should print a hit count > 0 and finish in under a couple seconds.
# On the developer's machine: 1,633 hits in 1.87s across 1,619 sessions / 3 projects.

# Inspect a single hit
pnpm run cli search "your favorite query" --json | jq '.[0]'
```

### ✅ Unit tests for `RipgrepScanner` against a tmpdir of synthetic JSONL files. Skip the test file if `rg` is not on PATH

The whole test file uses `describe.skip` when `rg --version` returns non-zero:
```bash
# Confirm by reading the HAS_RG check at the top of the file:
head -25 packages/core/src/interaction/search/ripgrep-scanner.test.ts
```

### ✅ Unit tests for `SessionHitParser` against fixture JSONL files

```bash
ls packages/core/src/interaction/search/__fixtures__/projects/
# -tmp-search-fixture-project-alpha
# -tmp-search-fixture-project-beta
pnpm test:run packages/core/src/interaction/search/hit-parser.test.ts
```

### ✅ Integration test for `SessionSearcher` end-to-end against a fixture project dir

```bash
pnpm test:run packages/core/src/interaction/search/searcher.test.ts
```

### ✅ `pnpm test:run` passes

```bash
pnpm test:run --reporter=dot
# 1197 tests pass (was 1173 before, +24 from this PR)
```

## Worth knowing

1. **No noise filtering yet.** Sidechain transcripts and micro-files surface in slice 1 results — slice 2 (#84) adds the filter parity that the Claude Code adapter already has. So if you smoke-test against `trinity-hunt-pilot/theme-research` you will see lots of sub-agent / queue-operation noise; that's expected.

2. **No snippet polish.** `matchedText` carries the flattened message content, not the ripgrep-style ~80-char context window the PRD describes. The TUI's lower-pane preview field doesn't exist yet either. Both land in slice 3 (#85).

3. **Hits aren't sorted.** Slice 3 (#85) adds message-timestamp-desc sorting. Current order is ripgrep's stable file-walk order, which is roughly directory iteration order.

4. **`matchedText` can be noisy for tool_use blocks.** Assistant messages with mixed text + tool_use blocks get `JSON.stringify(input)` appended to the text content. That made tests pass and surfaces tool-call payloads in search hits, but it can produce verbose strings. Slice 3 may want to revisit this.

5. **`--max-count 5` per file is on by default.** Matches the PRD's "one runaway session shouldn't dominate." Test confirms behavior. Configurable via `ScanOptions.maxCountPerFile`.

6. **`--max-filesize 50M` is on by default.** Files larger than 50 MB are silently skipped by rg (no record emitted). Configurable via `ScanOptions.maxFilesizeMB`.

7. **The whole search/ directory has no internal deps on other umwelten modules.** It's a clean island in `core`. Future slices that need to look up adapter info (e.g. to skip sidechains in slice 2) will pull from `core/interaction/adapters/`.

8. **Research report.** I commissioned a focused tech-research report on `rg --json` + Node spawn patterns before writing the scanner — saved to `reports/2026-06-01-ripgrep-node-integration.md` (not in this PR). Useful reference for slices 2-9.

## What's NOT in this PR (per slice boundaries)

- Sidechain / micro-file noise filtering → slice 2 (#84)
- Sort + snippet + per-file caps polish → slice 3 (#85) — caps are on, sort isn't
- TUI → slices 4-5 (#86 #87)
- Open-hit-launches-dashboard → slice 6 (#88)
- q-bounces-back → slice 7 (#89)
- Batch-run filter exception → slice 8 (#90)
- `--no-tui` flag + docs → slice 9 (#91)

🤖 Generated with [Claude Code](https://claude.com/claude-code)