### PR TITLE
test(dashboard): un-skip DashboardApp tests (+ small SearchOptions lint fix)

### DIFF
--- a/packages/core/src/interaction/search/types.ts
+++ b/packages/core/src/interaction/search/types.ts
@@ -85,7 +85,7 @@ export interface ScanOptions {
 }
 
 /** Options controlling a search call (passed to SessionSearcher). */
-export interface SearchOptions extends ScanOptions {}
+export type SearchOptions = ScanOptions;
 
 /**
  * Error class for "ripgrep not on PATH". Thrown by RipgrepScanner.scan

--- a/packages/ui/src/tui/introspect/DashboardApp.test.tsx
+++ b/packages/ui/src/tui/introspect/DashboardApp.test.tsx
@@ -4,14 +4,6 @@
  * Uses ink-testing-library to render the component and assert on the rendered
  * frame string. Tests follow TDD vertical slices: each describe block exercises
  * one slice of behaviour through the public component interface.
- *
- * TODO(release): every describe in this file is currently `.skip`ped because
- * ink-testing-library@4 + ink@6 + react@19 + react-reconciler@0.29 collide on
- * `ReactCurrentOwner` (removed in React 19). Failure shape:
- *   TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')
- *     at react-reconciler/cjs/react-reconciler.development.js:491
- * The fix is upstream (Ink shipping a React-19-compatible reconciler) and is
- * not blocking on us. Un-skip once Ink ships the reconciler bump.
  */
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -166,7 +158,7 @@ function renderDashboard(
 
 // ── 1. Dashboard table rendering ─────────────────────────────────────────
 
-describe.skip("DashboardApp — table rendering", () => {
+describe("DashboardApp — table rendering", () => {
 	it("renders an empty-state message when no entries match the filter", () => {
 		const { lastFrame } = renderDashboard({ entries: [] });
 		expect(lastFrame()).toMatch(/no explorations/i);
@@ -241,7 +233,7 @@ describe.skip("DashboardApp — table rendering", () => {
 
 // ── 2. Status column ─────────────────────────────────────────────────────
 
-describe.skip("DashboardApp — status column", () => {
+describe("DashboardApp — status column", () => {
 	it("shows 'new' for entries without a digest", () => {
 		const entries = [makeEntry("a")];
 		const { lastFrame } = renderDashboard({ entries });
@@ -386,7 +378,7 @@ describe.skip("DashboardApp — status column", () => {
 
 // ── 3. Live status updates on progress events ────────────────────────────
 
-describe.skip("DashboardApp — live status updates", () => {
+describe("DashboardApp — live status updates", () => {
 	it("flips a row to 'digesting' when a progress event fires for that exploration", async () => {
 		const entries = [
 			makeEntry("a", { title: "Alpha" }),
@@ -519,7 +511,7 @@ describe.skip("DashboardApp — live status updates", () => {
 
 // ── 4. Confirmation overlay ──────────────────────────────────────────────
 
-describe.skip("DashboardApp — confirmation overlay", () => {
+describe("DashboardApp — confirmation overlay", () => {
 	it("shows an overlay at startup when there are undigested entries", () => {
 		const entries = [
 			makeEntry("a", { title: "Undigested A" }),
@@ -600,7 +592,7 @@ describe.skip("DashboardApp — confirmation overlay", () => {
 
 // ── 5. Keyboard navigation ───────────────────────────────────────────────
 
-describe.skip("DashboardApp — keyboard navigation", () => {
+describe("DashboardApp — keyboard navigation", () => {
 	it("quits and calls onExit when q is pressed", async () => {
 		const onExit = vi.fn();
 		const entries = [makeEntry("a")];
@@ -702,7 +694,7 @@ describe.skip("DashboardApp — keyboard navigation", () => {
 
 // ── 6. Confirmation overlay interactions ─────────────────────────────────
 
-describe.skip("DashboardApp — confirmation overlay interactions", () => {
+describe("DashboardApp — confirmation overlay interactions", () => {
 	it("calls onLaunchExtraction when the user confirms 'y' on the startup overlay", async () => {
 		const onLaunchExtraction = vi.fn();
 		const entries = [makeEntry("a", { title: "Undigested" })];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,15 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		include: ["packages/*/src/**/*.test.ts", "packages/*/src/**/*.test.tsx"],
-		exclude: [
-			"packages/*/src/**/*.integration.test.ts",
-			// TODO(release): ink-testing-library@4 + react-reconciler@0.29 +
-			// react@19 collide on `ReactCurrentOwner` at import time. Failure:
-			//   TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')
-			//     at react-reconciler/cjs/react-reconciler.development.js:491
-			// Un-skip once Ink ships a React-19-compatible reconciler.
-			"packages/ui/src/tui/introspect/DashboardApp.test.tsx",
-		],
+		exclude: ["packages/*/src/**/*.integration.test.ts"],
 		environment: "node",
 		globals: true,
 		coverage: {


### PR DESCRIPTION
## Summary

Two small follow-ups now that ink 7 (PR #76) has landed:

1. **fix(lint)**: \`packages/core/src/interaction/search/types.ts\` had
   \`interface SearchOptions extends ScanOptions {}\` which trips
   \`@typescript-eslint/no-empty-object-type\` (rule enabled in the
   new lint config). Replace with a type alias. Without this, lint
   on \`main\` is currently red — landed via PR #92 before CI was
   active (PR #94).

2. **test(dashboard)**: ink 7 ships a React-19-compatible
   react-reconciler, resolving the \`ReactCurrentOwner\` collision
   that forced \`packages/ui/src/tui/introspect/DashboardApp.test.tsx\`
   to be excluded from vitest and every \`describe\` to be
   \`.skip\`ped. Drop the exclude, un-skip all six describes, trim
   the stale TODO. **Recovers 30 dashboard tests**; full suite
   1173 → 1227 passing.

## Test plan

- [x] \`pnpm test:run\` — 1227/1227 (was 1173)
- [x] \`pnpm lint\` — exits 0 (was failing on the SearchOptions empty interface)
- [ ] CI on this PR turns green (assuming PR #94 has merged first; if not, this is the first run for the workflow)