### PR TITLE
test(search): Session Search slice 8 — pin batch-run contract (#90)

### DIFF
--- a/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-batchrun/run-001.jsonl
+++ b/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-batchrun/run-001.jsonl
@@ -1,0 +1,5 @@
+{"type":"user","timestamp":"2026-05-10T09:00:00.000Z","message":{"role":"user","content":"Score the industry for trinity-hunt-pilot-batchrun candidate A"},"isSidechain":false,"uuid":"run-001-0001"}
+{"type":"assistant","timestamp":"2026-05-10T09:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Acknowledged candidate A — beginning analysis."}]},"isSidechain":false,"uuid":"run-001-0002"}
+{"type":"user","timestamp":"2026-05-10T09:00:02.000Z","message":{"role":"user","content":"Continue with pillar one."},"isSidechain":false,"uuid":"run-001-0003"}
+{"type":"assistant","timestamp":"2026-05-10T09:00:03.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Pillar one for candidate A complete."}]},"isSidechain":false,"uuid":"run-001-0004"}
+{"type":"user","timestamp":"2026-05-10T09:00:04.000Z","message":{"role":"user","content":"Done, thanks."},"isSidechain":false,"uuid":"run-001-0005"}

--- a/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-batchrun/run-002.jsonl
+++ b/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-batchrun/run-002.jsonl
@@ -1,0 +1,5 @@
+{"type":"user","timestamp":"2026-05-10T10:00:00.000Z","message":{"role":"user","content":"Score the industry for trinity-hunt-pilot-batchrun candidate B"},"isSidechain":false,"uuid":"run-002-0001"}
+{"type":"assistant","timestamp":"2026-05-10T10:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Acknowledged candidate B — different framing."}]},"isSidechain":false,"uuid":"run-002-0002"}
+{"type":"user","timestamp":"2026-05-10T10:00:02.000Z","message":{"role":"user","content":"Use the alternative pillar set."},"isSidechain":false,"uuid":"run-002-0003"}
+{"type":"assistant","timestamp":"2026-05-10T10:00:03.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Alternative pillar set applied to candidate B."}]},"isSidechain":false,"uuid":"run-002-0004"}
+{"type":"user","timestamp":"2026-05-10T10:00:04.000Z","message":{"role":"user","content":"Done."},"isSidechain":false,"uuid":"run-002-0005"}

--- a/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-batchrun/run-003.jsonl
+++ b/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-batchrun/run-003.jsonl
@@ -1,0 +1,5 @@
+{"type":"user","timestamp":"2026-05-10T11:00:00.000Z","message":{"role":"user","content":"Score the industry for trinity-hunt-pilot-batchrun candidate C"},"isSidechain":false,"uuid":"run-003-0001"}
+{"type":"assistant","timestamp":"2026-05-10T11:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Acknowledged candidate C — focusing on growth signals."}]},"isSidechain":false,"uuid":"run-003-0002"}
+{"type":"user","timestamp":"2026-05-10T11:00:02.000Z","message":{"role":"user","content":"Focus on margins."},"isSidechain":false,"uuid":"run-003-0003"}
+{"type":"assistant","timestamp":"2026-05-10T11:00:03.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Margin analysis for candidate C complete."}]},"isSidechain":false,"uuid":"run-003-0004"}
+{"type":"user","timestamp":"2026-05-10T11:00:04.000Z","message":{"role":"user","content":"Wrap it up."},"isSidechain":false,"uuid":"run-003-0005"}

--- a/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-batchrun/run-004.jsonl
+++ b/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-batchrun/run-004.jsonl
@@ -1,0 +1,5 @@
+{"type":"user","timestamp":"2026-05-10T12:00:00.000Z","message":{"role":"user","content":"Score the industry for trinity-hunt-pilot-batchrun candidate D"},"isSidechain":false,"uuid":"run-004-0001"}
+{"type":"assistant","timestamp":"2026-05-10T12:00:01.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Acknowledged candidate D — looking at market share."}]},"isSidechain":false,"uuid":"run-004-0002"}
+{"type":"user","timestamp":"2026-05-10T12:00:02.000Z","message":{"role":"user","content":"Cover the regulatory angle."},"isSidechain":false,"uuid":"run-004-0003"}
+{"type":"assistant","timestamp":"2026-05-10T12:00:03.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Regulatory angle covered for candidate D."}]},"isSidechain":false,"uuid":"run-004-0004"}
+{"type":"user","timestamp":"2026-05-10T12:00:04.000Z","message":{"role":"user","content":"That's enough."},"isSidechain":false,"uuid":"run-004-0005"}

--- a/packages/core/src/interaction/search/searcher.test.ts
+++ b/packages/core/src/interaction/search/searcher.test.ts
@@ -253,6 +253,58 @@ describeRg("searchSessions (integration)", () => {
 			expect(hits.length).toBe(12);
 		});
 	});
+
+	// Slice 8 (#90) — search must NOT collapse batch-run sessions the
+	// way the Claude Code adapter's discovery layer does. Search is
+	// "find every place I said X." Collapsing hides what the user is
+	// asking for.
+	//
+	// The fixture has 4 sessions whose first user message shares the
+	// long prefix `Score the industry for trinity-hunt-pilot-batchrun`
+	// — exactly the shape of the real-world trinity-hunt-pilot corpus
+	// that motivated the adapter's `collapseBatchRuns` behavior. The
+	// adapter would surface ONE row for these on the dashboard;
+	// `SessionSearcher.search()` MUST surface every individual hit.
+	describe("batch-run contract", () => {
+		const BATCHRUN = join(
+			import.meta.dirname,
+			"__fixtures__",
+			"projects",
+			"-tmp-search-fixture-project-batchrun",
+		);
+		const SHARED_PREFIX = "Score the industry for trinity-hunt-pilot-batchrun";
+
+		it("returns one hit per matching session, not a collapsed representative", async () => {
+			const hits = await searchSessions(SHARED_PREFIX, {
+				searchRoots: [BATCHRUN],
+			});
+
+			// 4 sessions, one matching message each → 4 hits. If search
+			// ever started applying the adapter's batch-collapse rule,
+			// this would drop to 1.
+			expect(hits.length).toBe(4);
+
+			// All 4 sessions must be represented — every sessionId
+			// distinct.
+			const sessionIds = new Set(hits.map((h) => h.sessionId));
+			expect(sessionIds.size).toBe(4);
+			expect(sessionIds.has("run-001")).toBe(true);
+			expect(sessionIds.has("run-002")).toBe(true);
+			expect(sessionIds.has("run-003")).toBe(true);
+			expect(sessionIds.has("run-004")).toBe(true);
+		});
+
+		it("returns hits with distinct timestamps for the same shared prefix", async () => {
+			const hits = await searchSessions(SHARED_PREFIX, {
+				searchRoots: [BATCHRUN],
+			});
+			const timestamps = new Set(hits.map((h) => h.messageTimestamp));
+			// Each fixture session opens at a distinct hour, so all 4
+			// timestamps should be distinct. A collapsing implementation
+			// would lose 3 of them.
+			expect(timestamps.size).toBe(4);
+		});
+	});
 });
 
 function makeMessage(

--- a/packages/core/src/interaction/search/searcher.ts
+++ b/packages/core/src/interaction/search/searcher.ts
@@ -30,6 +30,16 @@ import type { SearchOptions, SessionHit } from "./types.js";
  * Hits from noise files (sidechain / micro) are filtered out.
  *
  * Throws RipgrepNotFoundError if `rg` isn't on PATH.
+ *
+ * Deliberate divergence from the Claude Code adapter's discovery
+ * filter set: the adapter's `discoverSessions()` applies a
+ * batch-run-collapse rule that folds 2,610 trinity-hunt-pilot "Score
+ * the industry…" sessions into one representative dashboard row.
+ * Search does NOT apply that collapse — search returns every matching
+ * message in every matching Source Session individually. Rationale:
+ * search is "find every place I said X." A collapsed result hides
+ * exactly what the user is asking for. Pinned by the "batch-run
+ * contract" test in `searcher.test.ts`.
  */
 export async function searchSessions(
 	query: string,


### PR DESCRIPTION
Closes #90 (parent PRD #82).

## Summary

Documents and pins via test the contract that **Session Search does NOT collapse batch-run sessions** the way the Claude Code adapter's discovery layer does. The adapter folds the 2,610 trinity-hunt-pilot \"Score the industry…\" sessions into one representative dashboard row; search must surface every individual hit because search is \"find every place I said X\" — a collapsed result hides what the user is asking for.

What's in this slice:

- **Batch-run fixture** under `packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-batchrun/` — 4 sessions whose first user message shares the 50-char prefix `Score the industry for trinity-hunt-pilot-batchrun`, each followed by a distinct candidate letter and continuation lines (≥5 lines so the noise filter passes).
- **`batch-run contract` test block** in `searcher.test.ts` (2 assertions) — verifies the searcher returns 4 hits with 4 distinct `sessionId`s and 4 distinct `messageTimestamp`s. A collapsing implementation would drop to 1.
- **Inline documentation** on `searchSessions()` explaining the deliberate divergence and pointing at the test as the contract pin.

No Claude Code adapter changes; per PRD #82 Out of Scope (\"do not change the adapter's collapse behavior in this slice\").

## Verifying the acceptance criteria

Run from the repo root:

```bash
pnpm test:run packages/core/src/interaction/search/searcher.test.ts
```

Expected: 10 tests pass, including the 2 new `batch-run contract` tests.

### Fixture project dir with N≥3 sessions sharing a 40-char `firstPrompt` prefix

The fixture has **4 sessions** (`run-001.jsonl` through `run-004.jsonl`) sharing the 50-character prefix `Score the industry for trinity-hunt-pilot-batchrun`. Verify:

```bash
ls packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-batchrun/
# run-001.jsonl run-002.jsonl run-003.jsonl run-004.jsonl

rg -l 'Score the industry for trinity-hunt-pilot-batchrun' \
  packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-project-batchrun/
# All 4 files listed
```

### `SessionSearcher.search()` returns one hit per matching message per session

Covered by `batch-run contract > returns one hit per matching session, not a collapsed representative`. The fixture has exactly 1 matching first user message per session × 4 sessions = 4 expected hits. The test asserts `hits.length === 4` and that all 4 session IDs are distinct.

### Test asserts hit count matches expectations across the batch

`expect(hits.length).toBe(4)` + a `Set` of `sessionId`s asserting size 4 + `Set` of `messageTimestamp`s asserting size 4. If the searcher ever started applying the adapter's batch-collapse rule, all three assertions would fail simultaneously.

### Inline comment / README note explaining the deliberate divergence

The note lives on `searchSessions()` in `packages/core/src/interaction/search/searcher.ts:21-38`. To read it:

```bash
sed -n '21,38p' packages/core/src/interaction/search/searcher.ts
```

### No changes to the Claude Code adapter's `collapseBatchRuns` behavior

Verify the adapter file is unchanged on this branch:

```bash
git diff origin/main -- packages/core/src/interaction/adapters/claude-code-adapter.ts
# (empty)
```

The PR's diff scope is search module only:

```bash
git diff --stat origin/main
# packages/core/src/interaction/search/...  6 files changed, 82 insertions(+)
```

## Worth knowing / further work

- **No `collapseBatchRuns()` symbol exists in the codebase today.** The PRD describes the adapter's discovery layer as applying a batch-collapse rule, but a grep of the repo turns up no such function. The behavior may live elsewhere (a downstream filter), may be planned but not yet implemented, or the PRD may be describing intent rather than current code. This slice's contract — \"search must not collapse\" — holds either way: it's a permanent guardrail for any future implementer who might be tempted to share noise filters between discovery and search.
- **Shared prefix length is 50 chars**, not exactly 40 as the issue title suggests. \"40-char\" in the acceptance criterion appears to be illustrative of \"long enough to mimic the trinity-hunt-pilot batch-run shape,\" not an exact constraint. The 50-char prefix used here is well above the threshold any reasonable collapse heuristic would trigger on.
- **Fixture sessions each have exactly 5 lines** (the noise filter's `CLAUDE_CODE_MIN_SESSION_LINES`). One fewer line and the searcher would drop them all as micro-files; the test would fail in a confusing way. If the noise threshold ever changes, the fixtures must scale with it.
- **This contract sits orthogonally on top of slice 3 (#85, PR #97).** The two PRs touch different fields on `SessionHit` (slice 3 swaps `matchedText` → `snippet`/`fullMessageContent`; slice 8 reads `sessionId` + `messageTimestamp` which both stay stable). They are independently mergeable; whoever lands second gets a trivial conflict to resolve in the test file's `import` line and field reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)