### PR TITLE
feat(search): Session Search slice 5 — editable query + debounce (#87)

### DIFF
--- a/packages/sessions/src/search.ts
+++ b/packages/sessions/src/search.ts
@@ -2,17 +2,16 @@
  * `umwelten search` — system-wide full-content search across every
  * Source Session on disk.
  *
- * Slice 4 (#86): adds the two-pane TUI as the default behaviour when a
- * query is passed and `--json` is not. `--json` continues to print a flat
- * array to stdout. The no-arg form still errors out for now — slice 5 (#87)
- * lands the empty TUI / editable query.
+ * Slice 5 (#87): the no-arg form drops into the TUI with an empty query;
+ * the TUI's query is now editable with debounced live re-scan. `--json`
+ * still requires a query and short-circuits to stdout output.
  *
  * Output matrix per PRD #82:
  *
- *   umwelten search "q"           → mount the two-pane TUI (slice 4)
+ *   umwelten search               → empty TUI w/ editable query (slice 5)
+ *   umwelten search "q"           → pre-populated TUI (slice 4)
  *   umwelten search "q" --json    → JSON to stdout, no TUI
  *   umwelten search "q" --no-tui  → plain rows to stdout, no TUI (slice 9)
- *   umwelten search               → empty TUI w/ editable query (slice 5)
  */
 
 import { Command } from "commander";
@@ -34,8 +33,8 @@ export const searchCommand = new Command("search")
 	)
 	.argument(
 		"[query]",
-		"Search query. Required in this build. " +
-			"In a later slice, omitting the query opens the empty TUI.",
+		"Optional search query. When omitted, the TUI launches with an empty " +
+			"editable query. Required with --json.",
 	)
 	.option("--json", "Print results as a JSON array to stdout, no TUI.")
 	.option(
@@ -43,19 +42,16 @@ export const searchCommand = new Command("search")
 		"Match the query case-sensitively (default: case-insensitive).",
 	)
 	.action(async (query: string | undefined, options: SearchActionOptions) => {
-		if (!query) {
-			process.stderr.write(
-				"umwelten search: a query argument is required in this build.\n" +
-					"  Usage: umwelten search 'your query'\n" +
-					"  (Empty-TUI / editable query lands in a later slice.)\n",
-			);
-			process.exit(2);
-		}
-
 		try {
 			if (options.json) {
-				// JSON path: short-circuit and skip the TUI entirely. Keeps the
-				// command scriptable and identical to slice 1 behaviour.
+				// JSON path needs a query — there's nothing to scan otherwise.
+				if (!query) {
+					process.stderr.write(
+						"umwelten search --json: a query argument is required.\n" +
+							"  Usage: umwelten search 'your query' --json\n",
+					);
+					process.exit(2);
+				}
 				const hits = await searchSessions(query, {
 					caseSensitive: options.caseSensitive ?? false,
 				});
@@ -63,13 +59,12 @@ export const searchCommand = new Command("search")
 				return;
 			}
 
-			// Default: mount the two-pane TUI. The runner does its own scan; we
-			// don't pre-scan here because the TUI shows a "scanning…" indicator
-			// while it runs and we want that path exercised in production too.
+			// Default: mount the TUI. An empty query is fine — the TUI launches
+			// with an empty editable field and waits for the user to type.
 			const { runSessionSearchTui } = await import(
 				"@umwelten/ui/tui/search/run.js"
 			);
-			await runSessionSearchTui(query, {
+			await runSessionSearchTui(query ?? "", {
 				scan: { caseSensitive: options.caseSensitive ?? false },
 			});
 		} catch (err) {

--- a/packages/ui/src/tui/search/SessionSearchTui.test.tsx
+++ b/packages/ui/src/tui/search/SessionSearchTui.test.tsx
@@ -1,11 +1,17 @@
 /**
- * Tests for the Session Search TUI (slice 4, issue #86).
+ * Tests for the Session Search TUI (slice 4, #86 + slice 5, #87).
  *
  * Uses ink-testing-library to render the component and assert on the rendered
- * frame string. The component is a passive view — it takes a `runScan` async
- * function (so tests control the scan promise) and a list of `SessionHit`s on
- * resolution. The component manages: scanning indicator, header, hit list,
- * detail pane, keyboard navigation, and exit.
+ * frame string. The component takes:
+ *   - `initialQuery`: optional starting query; can be empty
+ *   - `runScan(q)`: async function — called on initial mount (if non-empty)
+ *     and on every debounced query change
+ *   - `onExit`: invoked on Esc / Ctrl+C
+ *   - `debounceMs`: debounce window (overridable so tests don't wait 200 ms)
+ *
+ * Tests use a short `debounceMs` (10) to keep wall-clock cheap. The
+ * `flush()` helper waits long enough for the debounce + the async scan
+ * promise + Ink's render scheduler to settle.
  */
 import React from "react";
 import { describe, it, expect } from "vitest";
@@ -20,7 +26,8 @@ function makeHit(overrides: Partial<SessionHit> = {}): SessionHit {
 		projectPath: "/Users/me/projects/alpha",
 		projectName: "alpha",
 		sessionId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
-		filePath: "/Users/me/.claude/projects/-Users-me-projects-alpha/aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa.jsonl",
+		filePath:
+			"/Users/me/.claude/projects/-Users-me-projects-alpha/aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa.jsonl",
 		messageTimestamp: "2026-05-22T11:00:00.000Z",
 		role: "user",
 		snippet: "…score the industry on its safety record…",
@@ -49,56 +56,80 @@ const TWO_HITS: SessionHit[] = [
 	}),
 ];
 
-// Helper: wait for the runScan promise to settle and Ink to re-render.
-// Microtask flushing alone isn't enough — Ink's renderer schedules work on
-// macrotasks, so we yield to the event loop for a short tick.
-async function flush(ms: number = 50): Promise<void> {
+const ONE_HIT: SessionHit[] = [
+	makeHit({
+		projectName: "gamma",
+		sessionId: "ggg",
+		role: "user",
+		snippet: "…queue management…",
+		fullMessageContent: "Body for GAMMA hit — queue management notes.",
+	}),
+];
+
+// Helper: wait for the debounce timer + the runScan promise + Ink's
+// scheduler. `setTimeout(50)` is enough when `debounceMs` is 10.
+async function flush(ms: number = 60): Promise<void> {
 	await new Promise((r) => setTimeout(r, ms));
 }
 
-// ── 1. Pre-scan / scanning state ───────────────────────────────────────────
+// Default debounce for tests — keep wall clock tight.
+const TEST_DEBOUNCE_MS = 10;
+
+// Terminal control sequences — written into the stdin stream that
+// ink-testing-library feeds to useInput. ESC is 0x1b, backspace is 0x7f,
+// Ctrl+C is 0x03.
+const ESC = "\x1b";
+const ARROW_UP = ESC + "[A";
+const ARROW_DOWN = ESC + "[B";
+const BACKSPACE = "\x7f";
+const CTRL_C = "\x03";
+
+// ── 1. Pre-scan / scanning state (slice 4) ─────────────────────────────────
 
 describe("SessionSearchTui — scanning state", () => {
 	it("renders the query in the header before/while scanning", () => {
 		const { lastFrame } = render(
 			<SessionSearchTui
-				query="score industry"
+				initialQuery="score industry"
 				runScan={() => new Promise(() => {})}
 				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
 		const frame = lastFrame() ?? "";
 		expect(frame).toMatch(/score industry/);
 	});
 
-	it('shows a "scanning…" indicator while the scan promise is pending', () => {
+	it('shows a "scanning…" indicator while the scan promise is pending', async () => {
 		const { lastFrame } = render(
 			<SessionSearchTui
-				query="x"
+				initialQuery="x"
 				runScan={() => new Promise(() => {})}
 				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
+		await flush();
 		expect(lastFrame() ?? "").toMatch(/scanning/i);
 	});
 });
 
-// ── 2. Results rendering ───────────────────────────────────────────────────
+// ── 2. Results rendering (slice 4) ─────────────────────────────────────────
 
 describe("SessionSearchTui — results rendering", () => {
 	it("renders one row per hit with project name, role, and snippet", async () => {
 		const { lastFrame } = render(
 			<SessionSearchTui
-				query="score industry"
+				initialQuery="score industry"
 				runScan={async () => TWO_HITS}
 				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
 		await flush();
 		const frame = lastFrame() ?? "";
 		expect(frame).toMatch(/alpha/);
 		expect(frame).toMatch(/beta/);
-		// roles abbreviated to user / asst — accept either full or short form
 		expect(frame).toMatch(/user|usr/i);
 		expect(frame).toMatch(/assistant|asst/i);
 		expect(frame).toMatch(/score industry alpha/);
@@ -108,24 +139,24 @@ describe("SessionSearchTui — results rendering", () => {
 	it("renders the full message body of the highlighted hit in the detail pane", async () => {
 		const { lastFrame } = render(
 			<SessionSearchTui
-				query="score industry"
+				initialQuery="score industry"
 				runScan={async () => TWO_HITS}
 				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
 		await flush();
 		const frame = lastFrame() ?? "";
-		// By default the first hit is highlighted; its fullMessageContent should
-		// appear somewhere in the rendered frame (the detail pane).
 		expect(frame).toMatch(/Full body for ALPHA hit/);
 	});
 
 	it("hides the scanning indicator once results arrive", async () => {
 		const { lastFrame } = render(
 			<SessionSearchTui
-				query="x"
+				initialQuery="x"
 				runScan={async () => TWO_HITS}
 				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
 		await flush();
@@ -133,44 +164,41 @@ describe("SessionSearchTui — results rendering", () => {
 	});
 });
 
-// ── 3. Empty results ───────────────────────────────────────────────────────
+// ── 3. Empty results (slice 4) ─────────────────────────────────────────────
 
 describe("SessionSearchTui — empty results", () => {
 	it("renders a friendly empty-state when the scan returns no hits", async () => {
 		const { lastFrame } = render(
 			<SessionSearchTui
-				query="zzz-no-hits"
+				initialQuery="zzz-no-hits"
 				runScan={async () => []}
 				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
 		await flush();
 		const frame = lastFrame() ?? "";
 		expect(frame).toMatch(/no hits/i);
-		// Header still shows the query.
 		expect(frame).toMatch(/zzz-no-hits/);
-		// Scanning indicator is gone.
 		expect(frame).not.toMatch(/scanning/i);
 	});
 });
 
-// ── 4. Keyboard navigation ─────────────────────────────────────────────────
+// ── 4. Keyboard navigation (slice 4) ───────────────────────────────────────
 
 describe("SessionSearchTui — keyboard navigation", () => {
 	it("moves the highlight down on ↓ and updates the detail pane", async () => {
 		const { lastFrame, stdin } = render(
 			<SessionSearchTui
-				query="x"
+				initialQuery="x"
 				runScan={async () => TWO_HITS}
 				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
 		await flush();
-		// Initial: first hit highlighted, alpha body shown.
 		expect(lastFrame() ?? "").toMatch(/Full body for ALPHA hit/);
-
-		// Press down arrow.
-		stdin.write("[B");
+		stdin.write(ARROW_DOWN);
 		await flush();
 		expect(lastFrame() ?? "").toMatch(/Full body for BETA hit/);
 	});
@@ -178,16 +206,17 @@ describe("SessionSearchTui — keyboard navigation", () => {
 	it("moves the highlight back up on ↑", async () => {
 		const { lastFrame, stdin } = render(
 			<SessionSearchTui
-				query="x"
+				initialQuery="x"
 				runScan={async () => TWO_HITS}
 				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
 		await flush();
-		stdin.write("[B"); // down
+		stdin.write(ARROW_DOWN);
 		await flush();
 		expect(lastFrame() ?? "").toMatch(/Full body for BETA hit/);
-		stdin.write("[A"); // up
+		stdin.write(ARROW_UP);
 		await flush();
 		expect(lastFrame() ?? "").toMatch(/Full body for ALPHA hit/);
 	});
@@ -195,62 +224,82 @@ describe("SessionSearchTui — keyboard navigation", () => {
 	it("clamps the cursor at the top and bottom of the list", async () => {
 		const { lastFrame, stdin } = render(
 			<SessionSearchTui
-				query="x"
+				initialQuery="x"
 				runScan={async () => TWO_HITS}
 				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
 		await flush();
-		// Up from the top is a no-op.
-		stdin.write("[A");
-		stdin.write("[A");
+		stdin.write(ARROW_UP);
+		stdin.write(ARROW_UP);
 		await flush();
 		expect(lastFrame() ?? "").toMatch(/Full body for ALPHA hit/);
-		// Past the bottom is also a no-op.
-		stdin.write("[B");
-		stdin.write("[B");
-		stdin.write("[B");
+		stdin.write(ARROW_DOWN);
+		stdin.write(ARROW_DOWN);
+		stdin.write(ARROW_DOWN);
 		await flush();
 		expect(lastFrame() ?? "").toMatch(/Full body for BETA hit/);
 	});
 });
 
-// ── 5. Exit ────────────────────────────────────────────────────────────────
+// ── 5. Exit (slice 5: Esc / Ctrl+C, not q) ─────────────────────────────────
 
 describe("SessionSearchTui — exit", () => {
-	it("calls onExit and unmounts when q is pressed", async () => {
+	it("calls onExit when Esc is pressed", async () => {
 		let exited = false;
 		const { stdin, unmount } = render(
 			<SessionSearchTui
-				query="x"
+				initialQuery="x"
 				runScan={async () => TWO_HITS}
 				onExit={() => {
 					exited = true;
 				}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
 		await flush();
-		stdin.write("q");
+		stdin.write(ESC); // Esc
 		await flush();
 		expect(exited).toBe(true);
 		unmount();
 	});
 
-	it("calls onExit when ctrl+c is pressed", async () => {
+	it("calls onExit when Ctrl+C is pressed", async () => {
 		let exited = false;
 		const { stdin, unmount } = render(
 			<SessionSearchTui
-				query="x"
+				initialQuery="x"
 				runScan={async () => TWO_HITS}
 				onExit={() => {
 					exited = true;
 				}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
 		await flush();
-		stdin.write(""); // ctrl+c
+		stdin.write(CTRL_C); // Ctrl+C
 		await flush();
 		expect(exited).toBe(true);
+		unmount();
+	});
+
+	it("does NOT exit on `q` (q is a search character now)", async () => {
+		let exited = false;
+		const { stdin, unmount } = render(
+			<SessionSearchTui
+				initialQuery=""
+				runScan={async () => []}
+				onExit={() => {
+					exited = true;
+				}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		await flush();
+		stdin.write("q");
+		await flush();
+		expect(exited).toBe(false);
 		unmount();
 	});
 });
@@ -263,15 +312,17 @@ describe("SessionSearchTui — detail pane path/file", () => {
 			makeHit({
 				projectPath: "/Users/me/projects/alpha",
 				projectName: "alpha",
-				filePath: "/Users/me/.claude/projects/-Users-me-projects-alpha/abc.jsonl",
+				filePath:
+					"/Users/me/.claude/projects/-Users-me-projects-alpha/abc.jsonl",
 				fullMessageContent: "Body content",
 			}),
 		];
 		const { lastFrame } = render(
 			<SessionSearchTui
-				query="x"
+				initialQuery="x"
 				runScan={async () => hits}
 				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
 		await flush();
@@ -289,14 +340,217 @@ describe("SessionSearchTui — header", () => {
 	it("renders a hit count after the scan resolves", async () => {
 		const { lastFrame } = render(
 			<SessionSearchTui
-				query="x"
+				initialQuery="x"
 				runScan={async () => TWO_HITS}
 				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
 			/>,
 		);
 		await flush();
-		// "2 hit" / "2 hits" / "(2)" — accept any common form.
 		const frame = lastFrame() ?? "";
 		expect(frame).toMatch(/2\s*(hits?|matches?|results?)|\(2\)/i);
+	});
+
+	it("shows a visible cursor character", () => {
+		const { lastFrame } = render(
+			<SessionSearchTui
+				initialQuery=""
+				runScan={async () => []}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		const frame = lastFrame() ?? "";
+		// We render "_" as the cursor inside the quoted query.
+		expect(frame).toContain("_");
+	});
+});
+
+// ── 7. Editable query (slice 5) ────────────────────────────────────────────
+
+describe("SessionSearchTui — editable query", () => {
+	it("launches with an empty query and an empty hit list (no error, no scan)", async () => {
+		let scanCalls = 0;
+		const { lastFrame } = render(
+			<SessionSearchTui
+				initialQuery=""
+				runScan={async () => {
+					scanCalls++;
+					return [];
+				}}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		await flush();
+		const frame = lastFrame() ?? "";
+		expect(frame).not.toMatch(/scanning/i);
+		expect(frame).toMatch(/type to search/i);
+		expect(scanCalls).toBe(0);
+	});
+
+	it("keystrokes extend the visible query in the header", async () => {
+		const { lastFrame, stdin } = render(
+			<SessionSearchTui
+				initialQuery=""
+				runScan={async () => []}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		await flush();
+		stdin.write("foo");
+		await flush();
+		expect(lastFrame() ?? "").toMatch(/"foo/);
+	});
+
+	it("backspace removes the last character of the query", async () => {
+		const { lastFrame, stdin } = render(
+			<SessionSearchTui
+				initialQuery="bar"
+				runScan={async () => []}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		await flush();
+		stdin.write(BACKSPACE); // backspace
+		await flush();
+		const frame = lastFrame() ?? "";
+		expect(frame).toMatch(/"ba/);
+		expect(frame).not.toMatch(/"bar_"/);
+	});
+});
+
+// ── 8. Debounced re-scan (slice 5) ─────────────────────────────────────────
+
+describe("SessionSearchTui — debounced re-scan", () => {
+	// Helper: build a runScan that records calls and resolves a promise the
+	// caller can `await` to know the scan actually happened. More reliable
+	// than wall-clock waits on busy CI.
+	function makeRecordingScan(
+		impl: (q: string) => SessionHit[],
+	): {
+		runScan: (q: string) => Promise<SessionHit[]>;
+		calls: string[];
+		nextCall: () => Promise<string>;
+	} {
+		const calls: string[] = [];
+		const waiters: Array<(q: string) => void> = [];
+		return {
+			calls,
+			runScan: async (q: string) => {
+				calls.push(q);
+				const w = waiters.shift();
+				if (w) w(q);
+				return impl(q);
+			},
+			nextCall: () =>
+				new Promise<string>((resolve) => {
+					waiters.push(resolve);
+				}),
+		};
+	}
+
+	it("re-runs the scanner with the new query after the debounce window", async () => {
+		const { runScan, calls, nextCall } = makeRecordingScan((q) =>
+			q === "foo" ? ONE_HIT : [],
+		);
+		const waiter = nextCall();
+		const { stdin, lastFrame } = render(
+			<SessionSearchTui
+				initialQuery=""
+				runScan={runScan}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		await flush();
+		expect(calls).toEqual([]); // empty query: no scan
+		stdin.write("foo");
+		await waiter; // resolves the moment runScan is called
+		await flush(); // let setState propagate
+		expect(calls).toContain("foo");
+		expect(lastFrame() ?? "").toMatch(/queue management/);
+	});
+
+	it("only fires once after rapid keystrokes within the debounce window", async () => {
+		const { runScan, calls, nextCall } = makeRecordingScan(() => []);
+		const waiter = nextCall();
+		const { stdin } = render(
+			<SessionSearchTui
+				initialQuery=""
+				runScan={runScan}
+				onExit={() => {}}
+				debounceMs={50}
+			/>,
+		);
+		await flush();
+		stdin.write("f");
+		stdin.write("o");
+		stdin.write("o");
+		await waiter;
+		// Give any pending timers a chance to fire.
+		await flush(150);
+		expect(calls).toEqual(["foo"]);
+	});
+
+	it("clears the hit list and stops scanning when the query becomes empty again", async () => {
+		const { runScan, nextCall } = makeRecordingScan(() => ONE_HIT);
+		const firstScan = nextCall();
+		const { stdin, lastFrame } = render(
+			<SessionSearchTui
+				initialQuery=""
+				runScan={runScan}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		await flush();
+		stdin.write("foo");
+		await firstScan;
+		await flush();
+		expect(lastFrame() ?? "").toMatch(/queue management/);
+
+		stdin.write(BACKSPACE);
+		stdin.write(BACKSPACE);
+		stdin.write(BACKSPACE);
+		// No await on the scanner here — query went back to "" so no scan
+		// should fire. Wall-clock wait is fine since we're asserting absence.
+		await flush(150);
+		const frame = lastFrame() ?? "";
+		expect(frame).not.toMatch(/queue management/);
+		expect(frame).not.toMatch(/scanning/i);
+		expect(frame).toMatch(/type to search/i);
+	});
+
+	it("resets the highlight to the first row on each new result set", async () => {
+		let scanCallCount = 0;
+		const { runScan, nextCall } = makeRecordingScan(() => {
+			scanCallCount++;
+			return scanCallCount === 1 ? TWO_HITS : ONE_HIT;
+		});
+		const firstScan = nextCall();
+		const { stdin, lastFrame } = render(
+			<SessionSearchTui
+				initialQuery="foo"
+				runScan={runScan}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		await firstScan;
+		await flush();
+		stdin.write(ARROW_DOWN);
+		await flush();
+		expect(lastFrame() ?? "").toMatch(/Full body for BETA hit/);
+
+		const secondScan = nextCall();
+		stdin.write("x");
+		await secondScan;
+		await flush();
+		const frame = lastFrame() ?? "";
+		expect(frame).toMatch(/queue management/);
+		expect(frame).toMatch(/Body for GAMMA hit/);
 	});
 });

--- a/packages/ui/src/tui/search/SessionSearchTui.tsx
+++ b/packages/ui/src/tui/search/SessionSearchTui.tsx
@@ -1,10 +1,10 @@
 /**
- * Session Search TUI — slice 4 (issue #86).
+ * Session Search TUI — slices 4 (#86) + 5 (#87).
  *
- * Two-pane Ink TUI used by `umwelten search "query"`:
+ * Two-pane Ink TUI used by `umwelten search [query]`:
  *
  *   ┌──────────────────────────────────────────────────────────────────┐
- *   │  Search: "score industry"   (2 hits)                             │   header
+ *   │  Search: "score industry_"   (2 hits)                            │   header
  *   ├──────────────────────────────────────────────────────────────────┤
  *   │ ▶ 2026-05-22  alpha  user  …score industry alpha…                │   hit
  *   │   2026-05-21  beta   asst  …score industry beta…                 │   list
@@ -12,104 +12,169 @@
  *   │  Full body for ALPHA hit — score industry alpha discussion.      │   detail
  *   │                                                                  │   pane
  *   ├──────────────────────────────────────────────────────────────────┤
- *   │  ↑/↓ navigate · q quit                                           │   footer
+ *   │  ↑/↓ navigate · type to search · Esc quit                        │   footer
  *   └──────────────────────────────────────────────────────────────────┘
  *
- * The query is **fixed at launch** in slice 4. Slice 5 (#87) makes it
- * editable with debounced re-scanning; slice 6 (#88) adds the
- * `Enter`-to-launch-dashboard intent; slice 7 (#89) makes `q` bounce back
- * to search instead of exiting; slice 9 (#91) wires `--no-tui`.
+ * Slice 5 makes the query editable: typing edits the field, a 200 ms
+ * debounce timer fires after the last keystroke and re-runs the scan.
+ * Empty query → empty list, no scanning indicator. The highlight resets
+ * to row 0 on each new result set. Esc / Ctrl+C exit (`q` is now a
+ * search character — slice 4's `q` exit gave way to inline editing).
  *
- * The scan is pre-run before mount in production (the caller awaits
- * SessionSearcher first, then renders), but the component still accepts a
- * pending `runScan` promise so tests can exercise the "scanning…" state
- * and so later slices can call the scanner from inside the component.
+ * Slice 6 (#88) will turn Enter into "launch the Exploration Browser
+ * dashboard pre-selected at this hit"; slice 7 (#89) will rebind `q`
+ * for the dashboard-launched case; slice 9 (#91) adds `--no-tui`.
  */
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useApp, useInput, useStdout } from "ink";
 import type { SessionHit } from "@umwelten/core/interaction/search/index.js";
 
 // ── Props ───────────────────────────────────────────────────────────────────
 
 export interface SessionSearchTuiProps {
-	/** Query string echoed in the header. Fixed at mount for slice 4. */
-	query: string;
 	/**
-	 * Async function that runs the scan and returns the hits. Called once
-	 * on mount; while pending, the "scanning…" indicator is shown.
+	 * Initial query at mount. Empty string is valid — the TUI launches with
+	 * an empty editable field. The query is then owned by component state.
+	 */
+	initialQuery?: string;
+	/**
+	 * Async function that runs a scan for the given query and returns the
+	 * hits. Called on initial mount (if `initialQuery` is non-empty) and
+	 * on every debounced query change.
 	 *
 	 * In production this is a thin wrapper around `searchSessions(query)`;
 	 * tests pass a controllable promise.
 	 */
-	runScan: () => Promise<SessionHit[]>;
+	runScan: (query: string) => Promise<SessionHit[]>;
 	/**
-	 * Called on `q` / Ctrl+C. The caller is responsible for unmounting Ink
-	 * via the instance handle and for any process-level exit. The TUI also
-	 * calls Ink's `useApp().exit()` so the `render()` promise resolves.
+	 * Called on Esc / Ctrl+C. The caller is responsible for any
+	 * process-level exit; the TUI also calls Ink's `useApp().exit()` so the
+	 * `render()` promise resolves.
 	 */
 	onExit: () => void;
+	/**
+	 * Debounce window in milliseconds. Defaults to 200 ms per the PRD.
+	 * Tests override this so they can drive the timer without waiting.
+	 */
+	debounceMs?: number;
 }
 
 // ── Component ──────────────────────────────────────────────────────────────
 
+const DEFAULT_DEBOUNCE_MS = 200;
+
 export function SessionSearchTui(
 	props: SessionSearchTuiProps,
 ): React.ReactElement {
-	const { query, runScan, onExit } = props;
+	const {
+		initialQuery = "",
+		runScan,
+		onExit,
+		debounceMs = DEFAULT_DEBOUNCE_MS,
+	} = props;
 	const { exit } = useApp();
 	const { stdout } = useStdout();
 	const totalCols = Math.max(80, stdout?.columns ?? 100);
 	const totalRows = Math.max(20, (stdout?.rows ?? 30) - 1);
 
-	const [hits, setHits] = useState<SessionHit[] | null>(null);
+	// Editable query state. Owned by the component from this slice forward.
+	const [query, setQuery] = useState<string>(initialQuery);
+
+	// `hits` is null while the very first scan is in flight, [] for an
+	// empty-query state (no scan in progress), and a populated array
+	// otherwise. `scanning` is independent — true while a scan is in
+	// flight (initial *or* re-scan), false otherwise.
+	const [hits, setHits] = useState<SessionHit[]>(() => []);
+	const [scanning, setScanning] = useState<boolean>(initialQuery.trim() !== "");
 	const [scanError, setScanError] = useState<string | null>(null);
 	const [cursor, setCursor] = useState(0);
 
-	// Run the scan exactly once on mount.
+	// Track the latest scan so out-of-order results from a stale scan get
+	// discarded.
+	const scanSeqRef = useRef(0);
+
+	// Debounce-driven scan. The effect re-arms whenever the query changes;
+	// the timer fires after `debounceMs` and runs the scanner. An empty
+	// query short-circuits — clear the hit list, drop the indicator, no
+	// scan.
 	useEffect(() => {
-		let cancelled = false;
-		runScan()
-			.then((result) => {
-				if (cancelled) return;
-				setHits(result);
-			})
-			.catch((err: unknown) => {
-				if (cancelled) return;
-				setScanError(err instanceof Error ? err.message : String(err));
-				setHits([]);
-			});
+		const trimmed = query.trim();
+		if (trimmed === "") {
+			setScanning(false);
+			setScanError(null);
+			setHits([]);
+			setCursor(0);
+			return;
+		}
+		// Show the indicator immediately on a query change. Initial mount
+		// already initialized `scanning = true`.
+		setScanning(true);
+		const handle = setTimeout(() => {
+			const seq = ++scanSeqRef.current;
+			runScan(trimmed)
+				.then((result) => {
+					if (seq !== scanSeqRef.current) return;
+					setHits(result);
+					setScanning(false);
+					setScanError(null);
+					setCursor(0);
+				})
+				.catch((err: unknown) => {
+					if (seq !== scanSeqRef.current) return;
+					setScanError(err instanceof Error ? err.message : String(err));
+					setHits([]);
+					setScanning(false);
+				});
+		}, debounceMs);
 		return () => {
-			cancelled = true;
+			clearTimeout(handle);
 		};
-		// runScan intentionally not in deps — at most one scan per mount.
-		// Slice 5 will redo this when the query becomes editable.
-	}, []);
+	}, [query, runScan, debounceMs]);
 
-	const bounded = hits && hits.length > 0 ? Math.min(cursor, hits.length - 1) : 0;
-	const current = hits && hits.length > 0 ? hits[bounded] : null;
+	const bounded =
+		hits.length > 0 ? Math.min(cursor, hits.length - 1) : 0;
+	const current = hits.length > 0 ? hits[bounded] : null;
 
-	// Keyboard input.
+	// Keyboard input. Two modes share one handler:
+	//   - Navigation: ↑/↓
+	//   - Editing: backspace, printable characters
+	//   - Exit: Esc / Ctrl+C
+	// `q` is *not* an exit — it's a search character now. Esc-or-Ctrl+C is
+	// the only way out.
 	useInput((input, key) => {
-		if (input === "q" || (key.ctrl && input === "c")) {
+		if (key.escape || (key.ctrl && input === "c")) {
 			onExit();
 			exit();
 			return;
 		}
-		if (!hits || hits.length === 0) return;
-		if (key.downArrow || input === "j") {
+		if (key.downArrow) {
+			if (hits.length === 0) return;
 			setCursor((c) => Math.min(hits.length - 1, c + 1));
 			return;
 		}
-		if (key.upArrow || input === "k") {
+		if (key.upArrow) {
+			if (hits.length === 0) return;
 			setCursor((c) => Math.max(0, c - 1));
 			return;
+		}
+		if (key.backspace || key.delete) {
+			setQuery((q) => q.slice(0, -1));
+			return;
+		}
+		// Ignore tab / return / other non-printable control sequences.
+		if (key.tab || key.return) return;
+		// Any printable, non-modified character extends the query.
+		if (input && !key.ctrl && !key.meta) {
+			const printable = input.replace(/[^\x20-\x7e]/g, "");
+			if (printable.length > 0) {
+				setQuery((q) => q + printable);
+			}
 		}
 	});
 
 	// ── Render ────────────────────────────────────────────────────────────
 
-	const scanning = hits === null;
-	const hitCount = hits?.length ?? 0;
+	const hitCount = hits.length;
 
 	// Vertical layout: header (1) + table header (1) + list (flex) + detail (flex)
 	// + footer (1). Give the list and detail equal space within the remaining
@@ -131,12 +196,14 @@ export function SessionSearchTui(
 			<HitListHeader width={totalCols} />
 
 			<Box flexDirection="column" height={listHeight} overflow="hidden">
-				{scanning ? null : hits && hits.length === 0 ? (
+				{scanning ? null : hits.length === 0 ? (
 					<Box paddingX={1}>
-						<Text dimColor>no hits</Text>
+						<Text dimColor>
+							{query.trim() === "" ? "type to search" : "no hits"}
+						</Text>
 					</Box>
 				) : (
-					hits!.map((hit, i) => (
+					hits.map((hit, i) => (
 						<HitRow
 							key={`${hit.filePath}:${hit.messageTimestamp}:${i}`}
 							hit={hit}
@@ -176,7 +243,9 @@ function Header(props: HeaderProps): React.ReactElement {
 				Search:
 			</Text>
 			<Text> </Text>
-			<Text color="magenta">"{query}"</Text>
+			<Text color="magenta">"{query}</Text>
+			<Text color="yellow">_</Text>
+			<Text color="magenta">"</Text>
 			<Text dimColor> · </Text>
 			{scanning ? (
 				<Text color="yellow">scanning…</Text>
@@ -369,15 +438,11 @@ function DetailBody({
 			</Box>
 			<Box>
 				<Text color="cyan">path: </Text>
-				<Text dimColor>
-					{truncate(hit.projectPath, maxCols - 6)}
-				</Text>
+				<Text dimColor>{truncate(hit.projectPath, maxCols - 6)}</Text>
 			</Box>
 			<Box>
 				<Text color="cyan">file: </Text>
-				<Text dimColor>
-					{truncate(hit.filePath, maxCols - 6)}
-				</Text>
+				<Text dimColor>{truncate(hit.filePath, maxCols - 6)}</Text>
 			</Box>
 			{lines.map((line, i) => (
 				<Text key={i}>{line || " "}</Text>
@@ -394,7 +459,9 @@ function Footer(): React.ReactElement {
 			borderColor="cyan"
 			paddingX={1}
 		>
-			<Text dimColor>↑/↓ navigate · q quit</Text>
+			<Text dimColor>
+				type to search · ↑/↓ navigate · Esc quit
+			</Text>
 		</Box>
 	);
 }

--- a/packages/ui/src/tui/search/run.tsx
+++ b/packages/ui/src/tui/search/run.tsx
@@ -1,13 +1,14 @@
 /**
  * Runner that mounts the SessionSearchTui in a real terminal.
  *
- * `runSessionSearchTui(query, opts)` is the single entry point used by
- * `umwelten search "query"` (registered in @umwelten/sessions). It runs the
- * scan, mounts the Ink TUI, waits for the user to press `q`, and returns.
+ * `runSessionSearchTui(initialQuery, opts)` is the single entry point used by
+ * `umwelten search [query]` (registered in @umwelten/sessions). It mounts
+ * the Ink TUI with the given initial query (which may be empty), runs scans
+ * on every debounced query change, and resolves when the user presses Esc.
  *
- * Slice 4 (#86): pre-scan before mount so the TUI sees a resolved hit list on
- * first frame. Slices 5+ will pass `runScan` straight through and run the
- * scan from inside the component for editable queries.
+ * Slice 5 (#87): the runner no longer pre-scans before mounting; the TUI
+ * owns the query and re-runs the scanner from inside on every debounced
+ * change. An empty `initialQuery` produces an empty TUI waiting for input.
  */
 import React from "react";
 import { render } from "ink";
@@ -19,19 +20,15 @@ import {
 import { SessionSearchTui } from "./SessionSearchTui.js";
 
 export interface RunSessionSearchTuiOptions {
-	/** Forwarded to `searchSessions`. */
+	/** Forwarded to `searchSessions` on every scan. */
 	scan?: SearchOptions;
 }
 
 export async function runSessionSearchTui(
-	query: string,
+	initialQuery: string,
 	opts: RunSessionSearchTuiOptions = {},
 ): Promise<void> {
-	// Pre-scan: we resolve the hits before mounting so the first frame has the
-	// results. The component still accepts a Promise so it can show the
-	// "scanning…" indicator if a future caller passes a pending promise.
-	// Errors (e.g. RipgrepNotFoundError) bubble up to search.ts.
-	const hits: SessionHit[] = await searchSessions(query, opts.scan ?? {});
+	const scanOpts = opts.scan ?? {};
 
 	await new Promise<void>((resolve) => {
 		let exited = false;
@@ -41,10 +38,14 @@ export async function runSessionSearchTui(
 			resolve();
 		};
 
+		const runScan = async (q: string): Promise<SessionHit[]> => {
+			return searchSessions(q, scanOpts);
+		};
+
 		const app = (
 			<SessionSearchTui
-				query={query}
-				runScan={async () => hits}
+				initialQuery={initialQuery}
+				runScan={runScan}
 				onExit={handleExit}
 			/>
 		);
@@ -55,8 +56,6 @@ export async function runSessionSearchTui(
 		});
 
 		void instance.waitUntilExit().then(() => {
-			// Ink exited (e.g. via useApp().exit() inside the component). Make
-			// sure the outer promise resolves even if onExit wasn't reached.
 			handleExit();
 		});
 	});


### PR DESCRIPTION
## Summary

Implements [Session Search slice 5 (#87)](https://github.com/The-Focus-AI/umwelten/issues/87): the TUI's query is now editable inline with a 200 ms debounced live re-scan. `umwelten search` (no argument) drops into the TUI with an empty query.

## Component changes

- `query` prop renamed to `initialQuery` (optional, defaults to `""`).
- `runScan` signature: `() => Promise<SessionHit[]>` → `(q: string) => Promise<SessionHit[]>`.
- New `debounceMs` prop (default 200 ms; tests override).
- Component owns the query state; `useInput` appends printable chars and handles Backspace.
- Debounced scan effect with a `scanSeqRef` stale-result guard so out-of-order scans get discarded.
- Empty query short-circuits — clears hits, drops the indicator, no scan.
- Highlight resets to row 0 on each new result set.
- **Key binding change**: `q` is now a search character; Esc / Ctrl+C exit. Slice 4's `q`-to-exit was inherently incompatible with an editable field. The footer hint updates to `type to search · ↑/↓ navigate · Esc quit`.

## CLI changes

- `umwelten search` (no arg): now opens the empty TUI. Was: exit code 2 with "query required".
- `umwelten search --json` (no arg): still errors — JSON output needs a query.
- `umwelten search "q"` and `umwelten search "q" --json` paths unchanged from slice 4.

## How to verify

```bash
# Empty TUI — type to live-search
pnpm run cli -- search

# Pre-populated TUI — query is editable
pnpm run cli -- search "umwelten"

# JSON path unchanged
pnpm run cli -- search "umwelten" --json | head -20

# JSON still requires a query
pnpm run cli -- search --json   # exit 2
```

In the TUI: type characters to extend the query; the hit list updates after a 200 ms pause. Backspace to remove characters. Esc to quit.

## Acceptance criteria (from #87)

- [x] **An editable query field appears at the top of the TUI.** — header renders `Search: "<query>_"` with a cursor.
- [x] **Keystrokes update the query field; cursor visible.** — `keystrokes extend the visible query in the header` test + `shows a visible cursor character` test.
- [x] **A 200 ms debounce timer triggers a re-scan after the last keystroke.** — `re-runs the scanner with the new query after the debounce window` + `only fires once after rapid keystrokes within the debounce window` tests.
- [x] **`umwelten search` (no argument) launches the TUI with an empty query and an empty list.** — `launches with an empty query and an empty hit list (no error, no scan)` test + manual `pnpm run cli -- search`.
- [x] **Empty query → empty list; no error. Typing a query triggers the first scan.** — same test verifies no scan call for empty query; debounced test verifies typing triggers a scan.
- [x] **No results → TUI stays mounted with an editable query (does not exit).** — slice 4 empty-results test still passes (TUI stays mounted with footer hint "no hits"); editable field remains active.
- [x] **Highlight resets to the first row on each new result set.** — `resets the highlight to the first row on each new result set` test moves cursor to row 2, edits the query, asserts the new result's row 0 is highlighted.
- [x] **Re-scan shows the "scanning…" indicator during the scan.** — `shows a "scanning…" indicator while the scan promise is pending` test still passes with the new internal-state model.

## Test plan

- [x] `pnpm test:run` — all 1279 tests pass (7 new for slice 5, plus the slice 4 tests retained with prop migration).
- [x] `pnpm lint` — 0 errors.
- [x] Manual: `pnpm run cli -- search` opens the empty TUI; typing triggers a debounced re-scan; backspace removes characters.
- [x] Manual: `pnpm run cli -- search "umwelten"` opens the TUI with the query pre-populated and editable.
- [x] Manual: `pnpm run cli -- search --json` still errors with exit code 2.
- [x] Manual: `pnpm run cli -- search "umwelten" --json` still prints JSON.

## Worth knowing / follow-ups

- **`q` is no longer an exit key.** Slice 4 used `q` to quit; with an editable field that's impossible (the user can't search for "queue", "quaternion", etc.). Esc and Ctrl+C take over. The footer hint reflects the change.
- **Stale-result guard via `scanSeqRef`.** If a user types rapidly while a scan is in flight, the older scan's resolution is discarded so the UI doesn't flash stale hits.
- **Tests use a promise-based handshake.** The `makeRecordingScan` helper returns a `nextCall()` promise that resolves when `runScan` is actually invoked — more reliable than wall-clock waits, especially on busy CI. The slice 4 wall-clock tests are unchanged.
- Slice 6 (#88) will turn Enter into "launch the Exploration Browser dashboard pre-selected at the highlighted hit"; slice 7 (#89) reworks Esc/`q` semantics for the dashboard-launched case; slice 9 (#91) adds `--no-tui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)