### PR TITLE
fix(search): projectPath survives dashes — prefer JSONL cwd (#109)

### DIFF
--- a/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-The-Focus-AI-dashed-project/cccccccc-cccc-4ccc-cccc-cccccccccccc.jsonl
+++ b/packages/core/src/interaction/search/__fixtures__/projects/-tmp-search-fixture-The-Focus-AI-dashed-project/cccccccc-cccc-4ccc-cccc-cccccccccccc.jsonl
@@ -1,0 +1,5 @@
+{"type":"user","timestamp":"2026-06-01T09:00:00.000Z","cwd":"/tmp/search-fixture/The-Focus-AI/dashed-project","message":{"role":"user","content":"Can you find the dashed-path-token in this repo?"},"isSidechain":false,"uuid":"cccccccc-0001"}
+{"type":"assistant","timestamp":"2026-06-01T09:00:01.000Z","cwd":"/tmp/search-fixture/The-Focus-AI/dashed-project","message":{"role":"assistant","content":[{"type":"text","text":"Searching for dashed-path-token now."}]},"isSidechain":false,"uuid":"cccccccc-0002"}
+{"type":"user","timestamp":"2026-06-01T09:00:02.000Z","cwd":"/tmp/search-fixture/The-Focus-AI/dashed-project","message":{"role":"user","content":"Great, thanks."},"isSidechain":false,"uuid":"cccccccc-0003"}
+{"type":"assistant","timestamp":"2026-06-01T09:00:03.000Z","cwd":"/tmp/search-fixture/The-Focus-AI/dashed-project","message":{"role":"assistant","content":[{"type":"text","text":"Done. Anything else?"}]},"isSidechain":false,"uuid":"cccccccc-0004"}
+{"type":"user","timestamp":"2026-06-01T09:00:04.000Z","cwd":"/tmp/search-fixture/The-Focus-AI/dashed-project","message":{"role":"user","content":"No, that is all."},"isSidechain":false,"uuid":"cccccccc-0005"}

--- a/packages/core/src/interaction/search/hit-parser.test.ts
+++ b/packages/core/src/interaction/search/hit-parser.test.ts
@@ -167,6 +167,54 @@ describe("parseHit", () => {
 		);
 		expect(hit).toBeNull();
 	});
+
+	// #109 — the directory-name encoding is lossy for paths containing
+	// dashes (`The-Focus-AI` decodes to `The/Focus/AI`). The record's
+	// `cwd` field is the authoritative project path when present.
+	describe("cwd-based project path (#109)", () => {
+		const DASHED_DIR_FILE =
+			"/tmp/fake/-Users-wschenk-The-Focus-AI-umwelten/abc.jsonl";
+
+		it("prefers the record's cwd field over the decoded directory name", () => {
+			const line = JSON.stringify({
+				type: "user",
+				timestamp: "2026-05-01T00:00:00Z",
+				cwd: "/Users/wschenk/The-Focus-AI/umwelten",
+				message: { role: "user", content: "hello dashed world" },
+			});
+			const hit = parseHit(makeRawHit(DASHED_DIR_FILE, line, 1), "dashed");
+			expect(hit).not.toBeNull();
+			expect(hit!.projectPath).toBe("/Users/wschenk/The-Focus-AI/umwelten");
+			expect(hit!.projectName).toBe("umwelten");
+		});
+
+		it("falls back to the decoded directory name when cwd is absent", () => {
+			const line = JSON.stringify({
+				type: "user",
+				timestamp: "2026-05-01T00:00:00Z",
+				message: { role: "user", content: "hello dashed world" },
+			});
+			const hit = parseHit(makeRawHit(DASHED_DIR_FILE, line, 1), "dashed");
+			expect(hit).not.toBeNull();
+			// Lossy, but the documented best-effort fallback.
+			expect(hit!.projectPath).toBe("/Users/wschenk/The/Focus/AI/umwelten");
+			expect(hit!.projectName).toBe("umwelten");
+		});
+
+		it("falls back when cwd is empty or not a string", () => {
+			for (const cwd of ["", 42, null, { not: "a string" }]) {
+				const line = JSON.stringify({
+					type: "user",
+					timestamp: "2026-05-01T00:00:00Z",
+					cwd,
+					message: { role: "user", content: "hello dashed world" },
+				});
+				const hit = parseHit(makeRawHit(DASHED_DIR_FILE, line, 1), "dashed");
+				expect(hit).not.toBeNull();
+				expect(hit!.projectPath).toBe("/Users/wschenk/The/Focus/AI/umwelten");
+			}
+		});
+	});
 });
 
 describe("buildSnippet", () => {

--- a/packages/core/src/interaction/search/hit-parser.ts
+++ b/packages/core/src/interaction/search/hit-parser.ts
@@ -33,6 +33,12 @@ const ELLIPSIS = "…";
  * path. Claude Code maps `/Users/foo/bar/baz` → `-Users-foo-bar-baz`.
  * This is the inverse, matching the convention in
  * core/interaction/adapters/claude-code-adapter.ts.
+ *
+ * WARNING (#109): the encoding is lossy — original `-` characters and
+ * `/` separators both encode to `-`, so `The-Focus-AI` decodes to
+ * `The/Focus/AI`. This is a best-effort FALLBACK only; parseHit prefers
+ * the authoritative `cwd` field carried on every Claude Code JSONL
+ * message record.
  */
 export function decodeProjectDirName(dirName: string): string {
 	return dirName.replace(/^-/, "/").replace(/-/g, "/");
@@ -75,10 +81,16 @@ export function parseHit(raw: RawScanHit, query: string): SessionHit | null {
 
 	const timestamp = typeof record.timestamp === "string" ? record.timestamp : "";
 
-	// Decode the project from the file's parent directory.
+	// Prefer the record's `cwd` field — every Claude Code message line
+	// carries the session's working directory verbatim. The directory-name
+	// decode below is lossy (#109): the encoder maps both `/` and
+	// pre-existing `-` to `-`, so `The-Focus-AI` decodes to `The/Focus/AI`.
+	// Only fall back to decoding when the record has no usable cwd.
+	const cwd =
+		typeof record.cwd === "string" && record.cwd.length > 0 ? record.cwd : null;
 	const parentDir = dirname(raw.filePath);
 	const parentDirName = basename(parentDir);
-	const projectPath = decodeProjectDirName(parentDirName);
+	const projectPath = cwd ?? decodeProjectDirName(parentDirName);
 	const projectName = basename(projectPath) || projectPath;
 
 	const sessionId = basename(raw.filePath, ".jsonl");

--- a/packages/core/src/interaction/search/searcher.test.ts
+++ b/packages/core/src/interaction/search/searcher.test.ts
@@ -54,6 +54,28 @@ describeRg("searchSessions (integration)", () => {
 		expect(h.snippet).toContain("seven-pillar");
 	});
 
+	// #109 — projectPath must survive dashes in real directory names.
+	// The fixture directory is `-tmp-search-fixture-The-Focus-AI-dashed-project`
+	// and every record carries the authoritative
+	// `cwd: "/tmp/search-fixture/The-Focus-AI/dashed-project"`. The lossy
+	// directory-name decode would mangle this to
+	// `/tmp/search/fixture/The/Focus/AI/dashed/project`.
+	describe("dashed project paths (#109)", () => {
+		it("returns projectPath matching the JSONL cwd, not the lossy decode", async () => {
+			const hits = await searchSessions("dashed-path-token", {
+				searchRoots: [FIXTURES],
+			});
+			expect(hits.length).toBeGreaterThan(0);
+			for (const h of hits) {
+				expect(h.projectPath).toBe(
+					"/tmp/search-fixture/The-Focus-AI/dashed-project",
+				);
+				expect(h.projectName).toBe("dashed-project");
+				expect(h.sessionId).toBe("cccccccc-cccc-4ccc-cccc-cccccccccccc");
+			}
+		});
+	});
+
 	it("returns an empty array for an empty query", async () => {
 		const hits = await searchSessions("", { searchRoots: [FIXTURES] });
 		expect(hits).toEqual([]);


### PR DESCRIPTION
Closes #109.

## What was built

`decodeProjectDirName` is inherently lossy: the Claude Code directory encoding maps both `/` separators and literal `-` characters to `-`, so any project path containing dashes was mangled in every search output mode (TUI, `--json`, API consumers):

```
/Users/wschenk/The-Focus-AI/umwelten  →  /Users/wschenk/The/Focus/AI/umwelten
```

`parseHit` (`packages/core/src/interaction/search/hit-parser.ts`) now reads the authoritative `cwd` field carried on every Claude Code JSONL message record and uses it as `projectPath` (and its basename as `projectName`). The lossy decode remains only as a documented fallback for records with no usable `cwd`. Zero extra disk I/O — the `cwd` comes from the already-parsed matched line.

Tests were written first (red), then the fix (green):
- 3 new unit tests in `hit-parser.test.ts` (cwd preferred; fallback when absent; fallback when empty/non-string)
- 1 new integration test in `searcher.test.ts` against a new fixture project `-tmp-search-fixture-The-Focus-AI-dashed-project` whose records carry `cwd: /tmp/search-fixture/The-Focus-AI/dashed-project`

## Success criteria from #109 — how to validate each

**1. `searchSessions` returns `projectPath` matching the actual JSONL `cwd` value**

```bash
pnpm test:run -- packages/core/src/interaction/search/searcher.test.ts
```

Look for `dashed project paths (#109) > returns projectPath matching the JSONL cwd, not the lossy decode` passing. To validate against real sessions (this repo's own path contains dashes), run a search over your live corpus and inspect `projectPath` on any hit from this repo — it must read `/Users/wschenk/The-Focus-AI/umwelten`, not `/Users/wschenk/The/Focus/AI/umwelten`.

**2. `projectName` becomes the correct basename**

```bash
pnpm test:run -- packages/core/src/interaction/search/hit-parser.test.ts
```

`cwd-based project path (#109) > prefers the record's cwd field over the decoded directory name` asserts `projectName === "umwelten"` for cwd `/Users/wschenk/The-Focus-AI/umwelten`.

**3. Integration test fixtures include dashed project paths**

```bash
ls packages/core/src/interaction/search/__fixtures__/projects/
```

New fixture dir: `-tmp-search-fixture-The-Focus-AI-dashed-project` (5-line session, all records carry a dashed `cwd`).

**4. Existing fixtures remain passing**

```bash
pnpm test:run
```

Full suite: 93 files / 1283 tests pass. The pre-existing fixtures (alpha, beta, noisy, batchrun) have no `cwd` field, so they exercise the fallback path and their expectations are unchanged.

## Worth knowing / further work

- **Same lossy decode exists in the discovery layer**: `claude-code-adapter.ts:76` uses the identical `replace(/^-/, '/').replace(/-/g, '/')` pattern, so dashboard discovery still mangles dashed paths. Out of scope per #109 (which scopes to hit-parser), but it should get the same cwd-based treatment — likely by peeking the first record of each session file. Worth a follow-up issue.
- A matched record that lacks `cwd` (rare; e.g. some system records) falls back to the lossy decode rather than peeking a sibling record. The per-file `peekFile` pass in `searcher.ts` already parses each file's first line once, so threading a `firstCwd` through `PeekedFile` is a cheap upgrade if this ever matters in practice.
- `pnpm lint` could not be run locally in this session (tool-permission availability); the PR CI workflow runs lint + unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
