### PR TITLE
feat(search): Session Search slice 7 — q in dashboard bounces back to search (#89)

### DIFF
--- a/packages/ui/src/tui/introspect/DashboardApp.test.tsx
+++ b/packages/ui/src/tui/introspect/DashboardApp.test.tsx
@@ -813,3 +813,58 @@ describe("DashboardApp — preSelectSessionId", () => {
 		);
 	});
 });
+
+// ── 10. Return to caller (slice 7, #89) ──────────────────────────────────
+
+describe("DashboardApp — return to caller (slice 7, #89)", () => {
+	it("emits a return intent on q when returnToCaller is set", async () => {
+		const onExit = vi.fn();
+		const entries = [makeEntry("a")];
+		const { stdin } = renderDashboard({
+			entries,
+			onExit,
+			returnToCaller: true,
+		});
+		stdin.write("q");
+		await new Promise((r) => setTimeout(r, 50));
+		expect(onExit).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: "return" }),
+		);
+	});
+
+	it("still emits the exit intent on q when returnToCaller is explicitly false", async () => {
+		const onExit = vi.fn();
+		const entries = [makeEntry("a")];
+		const { stdin } = renderDashboard({
+			entries,
+			onExit,
+			returnToCaller: false,
+		});
+		stdin.write("q");
+		await new Promise((r) => setTimeout(r, 50));
+		expect(onExit).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: "none" }),
+		);
+	});
+
+	it("hard-exits (none intent) on Ctrl+C even when returnToCaller is set", async () => {
+		const onExit = vi.fn();
+		const entries = [makeEntry("a")];
+		const { stdin } = renderDashboard({
+			entries,
+			onExit,
+			returnToCaller: true,
+		});
+		stdin.write("\x03");
+		await new Promise((r) => setTimeout(r, 50));
+		expect(onExit).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: "none" }),
+		);
+	});
+
+	it("labels q as back-to-search in the footer when returnToCaller is set", () => {
+		const entries = [makeEntry("a")];
+		const { lastFrame } = renderDashboard({ entries, returnToCaller: true });
+		expect(lastFrame() ?? "").toMatch(/q back to search/i);
+	});
+});

--- a/packages/ui/src/tui/introspect/DashboardApp.tsx
+++ b/packages/ui/src/tui/introspect/DashboardApp.tsx
@@ -79,6 +79,14 @@ export interface DashboardAppProps {
 	 * If the id doesn't match any entry, the cursor falls back to 0.
 	 */
 	preSelectSessionId?: string;
+	/**
+	 * When true, `q` emits a `return` intent instead of `none` so the caller
+	 * that launched the dashboard (the Session Search TUI, slice 7 #89) can
+	 * take control back instead of the process exiting. Ctrl+C still emits
+	 * `none` — it is always a hard exit. Defaults to false (direct launches
+	 * via `umwelten browse` keep exiting on `q`).
+	 */
+	returnToCaller?: boolean;
 }
 
 const DEFAULT_FILTER: FilterState = {
@@ -168,6 +176,7 @@ export function DashboardApp(props: DashboardAppProps): React.ReactElement {
 		subscribeToTitleUpdates,
 		initialTitles,
 		preSelectSessionId,
+		returnToCaller = false,
 	} = props;
 
 	const { exit } = useApp();
@@ -337,7 +346,12 @@ export function DashboardApp(props: DashboardAppProps): React.ReactElement {
 
 	useInput(
 		(input, key) => {
-			if (input === "q" || (key.ctrl && input === "c")) {
+			if (input === "q") {
+				onExit(returnToCaller ? { kind: "return" } : { kind: "none" });
+				exit();
+				return;
+			}
+			if (key.ctrl && input === "c") {
 				onExit({ kind: "none" });
 				exit();
 				return;
@@ -440,7 +454,7 @@ export function DashboardApp(props: DashboardAppProps): React.ReactElement {
 				keysHint={
 					searchMode
 						? "Type to filter · Enter/Esc commit"
-						: "↑/↓ select · Enter detail · D digest · v transcript · b beats · R reflect · P promote · / search · q quit"
+						: `↑/↓ select · Enter detail · D digest · v transcript · b beats · R reflect · P promote · / search · ${returnToCaller ? "q back to search" : "q quit"}`
 				}
 			/>
 		</Box>

--- a/packages/ui/src/tui/introspect/browse.tsx
+++ b/packages/ui/src/tui/introspect/browse.tsx
@@ -28,7 +28,23 @@ export interface RunBrowseTuiOptions {
 	 * after detail/transcript/digest views start with the cursor at the top.
 	 */
 	preSelectSessionId?: string;
+	/**
+	 * When true, `q` in the dashboard resolves the browse loop with
+	 * `"return"` instead of exiting, so the caller (the Session Search TUI,
+	 * slice 7 #89) can re-mount itself. Ctrl+C always resolves `"exit"`.
+	 * Defaults to false — direct launches (`umwelten browse`) exit on `q`.
+	 */
+	returnToCaller?: boolean;
 }
+
+/**
+ * How the browse loop ended:
+ * - `"exit"`   — the user quit (q on a direct launch, or Ctrl+C anywhere);
+ *                the caller should let the process end.
+ * - `"return"` — the user pressed `q` in a dashboard mounted with
+ *                `returnToCaller`; the caller should take control back.
+ */
+export type BrowseTuiOutcome = "exit" | "return";
 
 // ── Exploration-oriented browser (v2) — command-center dashboard ────────
 
@@ -154,6 +170,8 @@ async function showDashboardTui(args: {
 	onLaunchExtraction: () => void;
 	/** Pre-select the matching row on mount (Session Search → open hit). */
 	preSelectSessionId?: string;
+	/** Forwarded to DashboardApp: `q` emits a return intent (slice 7, #89). */
+	returnToCaller?: boolean;
 }): Promise<DashboardIntent> {
 	let intent: DashboardIntent = { kind: "none" };
 
@@ -192,6 +210,7 @@ async function showDashboardTui(args: {
 			subscribeToTitleUpdates={args.bus.subscribeToTitles}
 			initialTitles={args.bus.liveTitles}
 			preSelectSessionId={args.preSelectSessionId}
+			returnToCaller={args.returnToCaller}
 		/>
 	);
 
@@ -346,7 +365,7 @@ async function runExtractionPass(args: {
  */
 export async function runExploreBrowseTui(
 	opts: RunBrowseTuiOptions,
-): Promise<void> {
+): Promise<BrowseTuiOutcome> {
 	const {
 		projectPath: rawProject,
 		targetPath: rawTarget,
@@ -354,6 +373,7 @@ export async function runExploreBrowseTui(
 		model,
 		force = false,
 		preSelectSessionId,
+		returnToCaller = false,
 	} = opts;
 	const projectPath = resolve(rawProject);
 	const targetPath = resolve(rawTarget);
@@ -383,7 +403,9 @@ export async function runExploreBrowseTui(
 			console.log(chalk.yellow("No explorations found for this project."));
 			console.log(chalk.dim(`Project: ${projectPath}`));
 			if (sessionsDir) console.log(chalk.dim(`Sessions dir: ${sessionsDir}`));
-			return;
+			// When launched from search, hand control back instead of killing
+			// the process — the user can pick a different hit.
+			return returnToCaller ? "return" : "exit";
 		}
 
 		const modelLabel = `${model.provider}:${model.name}`;
@@ -397,6 +419,7 @@ export async function runExploreBrowseTui(
 			startupConfirm: !askedAtLeastOnce,
 			bus,
 			preSelectSessionId: pendingPreSelect,
+			returnToCaller,
 			onLaunchExtraction: () => {
 				askedAtLeastOnce = true;
 				if (extractionLaunched) {
@@ -427,7 +450,8 @@ export async function runExploreBrowseTui(
 		// cursor back to the same row.
 		pendingPreSelect = undefined;
 
-		if (intent.kind === "none") return;
+		if (intent.kind === "none") return "exit";
+		if (intent.kind === "return") return "return";
 
 		const entry = intent.entry;
 

--- a/packages/ui/src/tui/introspect/dashboard/types.ts
+++ b/packages/ui/src/tui/introspect/dashboard/types.ts
@@ -28,9 +28,14 @@ export type DashboardStatus =
 /**
  * Intent returned from the dashboard when the user picks an action.
  * The CLI loop acts on this after the TUI exits.
+ *
+ * `none` ends the browse loop entirely. `return` hands control back to the
+ * caller that launched the dashboard (the Session Search TUI, slice 7 #89) —
+ * it is only emitted when the dashboard was mounted with `returnToCaller`.
  */
 export type DashboardIntent =
 	| { kind: "none" }
+	| { kind: "return" }
 	| { kind: "detail"; entry: ExplorationBrowserEntry }
 	| { kind: "transcript"; entry: ExplorationBrowserEntry }
 	| { kind: "digest"; entry: ExplorationBrowserEntry }

--- a/packages/ui/src/tui/search/SessionSearchTui.test.tsx
+++ b/packages/ui/src/tui/search/SessionSearchTui.test.tsx
@@ -641,6 +641,8 @@ describe("SessionSearchTui — open hit on Enter", () => {
 		expect(onSelectHit).toHaveBeenCalledTimes(1);
 		expect(onSelectHit).toHaveBeenCalledWith(
 			expect.objectContaining({ sessionId: "aaa", projectName: "alpha" }),
+			// Slice 7 (#89): a state snapshot rides along for restore-on-return.
+			expect.anything(),
 		);
 	});
 
@@ -662,6 +664,8 @@ describe("SessionSearchTui — open hit on Enter", () => {
 		await flush();
 		expect(onSelectHit).toHaveBeenCalledWith(
 			expect.objectContaining({ sessionId: "bbb", projectName: "beta" }),
+			// Slice 7 (#89): a state snapshot rides along for restore-on-return.
+			expect.anything(),
 		);
 	});
 
@@ -704,3 +708,111 @@ describe("SessionSearchTui — open hit on Enter", () => {
 		expect(onExit).not.toHaveBeenCalled();
 	});
 });
+
+// ── 8. Return-to-search state restore (slice 7, #89) ───────────────────────
+
+describe("SessionSearchTui — restore state (slice 7, #89)", () => {
+	it("renders initialHits immediately without re-running the scan", async () => {
+		let scanCalls = 0;
+		const { lastFrame } = render(
+			<SessionSearchTui
+				initialQuery="score industry"
+				initialHits={TWO_HITS}
+				runScan={async () => {
+					scanCalls++;
+					return [];
+				}}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		await flush(150);
+		const frame = lastFrame() ?? "";
+		expect(frame).toMatch(/score industry alpha/);
+		expect(frame).not.toMatch(/scanning/i);
+		expect(scanCalls).toBe(0);
+	});
+
+	it("highlights the row given by initialCursor", async () => {
+		const { lastFrame } = render(
+			<SessionSearchTui
+				initialQuery="x"
+				initialHits={TWO_HITS}
+				initialCursor={1}
+				runScan={async () => TWO_HITS}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		await flush();
+		expect(lastFrame() ?? "").toMatch(/Full body for BETA hit/);
+	});
+
+	it("editing the query after a restore still triggers a fresh scan", async () => {
+		// Await the actual scan call rather than fixed wall-clock waits —
+		// Ink's async input processing makes fixed waits flaky under load
+		// (same pattern as the debounced re-scan tests above).
+		const calls: string[] = [];
+		let resolveScanCalled: () => void = () => {};
+		const scanCalled = new Promise<void>((r) => {
+			resolveScanCalled = r;
+		});
+		const { stdin, lastFrame } = render(
+			<SessionSearchTui
+				initialQuery="x"
+				initialHits={TWO_HITS}
+				runScan={async (q) => {
+					calls.push(q);
+					resolveScanCalled();
+					return ONE_HIT;
+				}}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		await flush();
+		expect(calls).toEqual([]); // the restore itself did not re-scan
+		stdin.write("y");
+		await scanCalled; // resolves the moment the re-scan fires
+		await flush();
+		expect(calls).toEqual(["xy"]);
+		expect(lastFrame() ?? "").toMatch(/queue management/);
+	});
+
+	it("passes a snapshot (query, hits, cursorIndex) to onSelectHit", async () => {
+		const onSelectHit = vi.fn();
+		const { stdin, lastFrame } = render(
+			<SessionSearchTui
+				initialQuery="x"
+				runScan={async () => TWO_HITS}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+				onSelectHit={onSelectHit}
+			/>,
+		);
+		// Poll for each state transition instead of fixed waits — input
+		// processing latency varies under parallel test load.
+		await waitFor(() => (lastFrame() ?? "").includes("Full body for ALPHA hit"));
+		stdin.write(ARROW_DOWN);
+		await waitFor(() => (lastFrame() ?? "").includes("Full body for BETA hit"));
+		stdin.write("\r");
+		await waitFor(() => onSelectHit.mock.calls.length > 0);
+		expect(onSelectHit).toHaveBeenCalledWith(
+			expect.objectContaining({ sessionId: "bbb" }),
+			expect.objectContaining({ query: "x", cursorIndex: 1, hits: TWO_HITS }),
+		);
+	});
+});
+
+// Poll until `cond` is truthy (20 ms interval, 5 s timeout). Throws on
+// timeout so failures point at the stalled transition instead of a
+// downstream assertion.
+async function waitFor(cond: () => boolean, timeoutMs = 5000): Promise<void> {
+	const start = Date.now();
+	while (!cond()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error("waitFor: condition not met within timeout");
+		}
+		await new Promise((r) => setTimeout(r, 20));
+	}
+}

--- a/packages/ui/src/tui/search/SessionSearchTui.tsx
+++ b/packages/ui/src/tui/search/SessionSearchTui.tsx
@@ -32,6 +32,19 @@ import type { SessionHit } from "@umwelten/core/interaction/search/index.js";
 
 // ── Props ───────────────────────────────────────────────────────────────────
 
+/**
+ * Snapshot of the search TUI's interactive state at the moment a hit is
+ * opened (slice 7, #89). The runner holds onto it so that when the launched
+ * dashboard bounces back with `q`, search re-mounts exactly where the user
+ * left it — same query, same hit list, same highlighted row — without
+ * re-running the scan.
+ */
+export interface SearchTuiSnapshot {
+	query: string;
+	hits: SessionHit[];
+	cursorIndex: number;
+}
+
 export interface SessionSearchTuiProps {
 	/**
 	 * Initial query at mount. Empty string is valid — the TUI launches with
@@ -63,8 +76,21 @@ export interface SessionSearchTuiProps {
 	 * The TUI also calls Ink's `useApp().exit()` to unmount cleanly so the
 	 * caller can launch the Exploration Browser dashboard for the hit's
 	 * project. If omitted, Enter is a no-op.
+	 *
+	 * The second argument (slice 7, #89) is a snapshot of the TUI state at
+	 * selection time, so the caller can re-mount search with the same query,
+	 * hit list, and highlight when the dashboard returns.
 	 */
-	onSelectHit?: (hit: SessionHit) => void;
+	onSelectHit?: (hit: SessionHit, snapshot: SearchTuiSnapshot) => void;
+	/**
+	 * Seed the hit list at mount and skip the initial scan for
+	 * `initialQuery` (slice 7, #89). Used when re-mounting search after a
+	 * dashboard round trip so the user lands on the same results without
+	 * waiting for a re-scan. Subsequent query edits re-scan as usual.
+	 */
+	initialHits?: SessionHit[];
+	/** Highlight this row index at mount (clamped to the hit list). */
+	initialCursor?: number;
 }
 
 // ── Component ──────────────────────────────────────────────────────────────
@@ -80,6 +106,8 @@ export function SessionSearchTui(
 		onExit,
 		debounceMs = DEFAULT_DEBOUNCE_MS,
 		onSelectHit,
+		initialHits,
+		initialCursor,
 	} = props;
 	const { exit } = useApp();
 	const { stdout } = useStdout();
@@ -93,15 +121,25 @@ export function SessionSearchTui(
 	// empty-query state (no scan in progress), and a populated array
 	// otherwise. `scanning` is independent — true while a scan is in
 	// flight (initial *or* re-scan), false otherwise.
-	const [hits, setHits] = useState<SessionHit[]>(() => []);
-	const [scanning, setScanning] = useState<boolean>(initialQuery.trim() !== "");
+	const [hits, setHits] = useState<SessionHit[]>(() => initialHits ?? []);
+	const [scanning, setScanning] = useState<boolean>(
+		initialQuery.trim() !== "" && initialHits === undefined,
+	);
 	const [scanError, setScanError] = useState<string | null>(null);
-	const [cursor, setCursor] = useState(0);
+	const [cursor, setCursor] = useState(initialCursor ?? 0);
 	const [scrollOffset, setScrollOffset] = useState(0);
 
 	// Track the latest scan so out-of-order results from a stale scan get
 	// discarded.
 	const scanSeqRef = useRef(0);
+
+	// When the caller seeds hits (re-mount after a dashboard round trip,
+	// slice 7 #89), the first run of the debounce effect must not re-scan —
+	// the seeded hits ARE the results for `initialQuery`. Consumed once;
+	// later query edits re-scan as usual.
+	const skipInitialScanRef = useRef(
+		initialHits !== undefined && initialQuery.trim() !== "",
+	);
 
 	// Debounce-driven scan. The effect re-arms whenever the query changes;
 	// the timer fires after `debounceMs` and runs the scanner. An empty
@@ -114,6 +152,10 @@ export function SessionSearchTui(
 			setScanError(null);
 			setHits([]);
 			setCursor(0);
+			return;
+		}
+		if (skipInitialScanRef.current) {
+			skipInitialScanRef.current = false;
 			return;
 		}
 		// Show the indicator immediately on a query change. Initial mount
@@ -164,7 +206,7 @@ export function SessionSearchTui(
 			// project. We exit() to unmount Ink so the dashboard can take
 			// over the terminal.
 			if (!current || !onSelectHit) return;
-			onSelectHit(current);
+			onSelectHit(current, { query, hits, cursorIndex: bounded });
 			exit();
 			return;
 		}

--- a/packages/ui/src/tui/search/run.test.ts
+++ b/packages/ui/src/tui/search/run.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the search ↔ dashboard round-trip loop (slice 7, #89).
+ *
+ * `runSearchDashboardLoop` is the orchestration seam inside run.tsx: it
+ * mounts the search TUI, launches the dashboard for a selected hit, and —
+ * when the dashboard resolves with "return" — re-mounts search with the
+ * snapshot captured at selection time (same query, same hit list, same
+ * highlight). The deps are injected so these tests never touch Ink.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { SessionHit } from "@umwelten/core/interaction/search/index.js";
+import {
+	runSearchDashboardLoop,
+	type SearchSelection,
+} from "./run.js";
+import type { SearchTuiSnapshot } from "./SessionSearchTui.js";
+
+function makeHit(overrides: Partial<SessionHit> = {}): SessionHit {
+	return {
+		projectPath: "/Users/me/projects/alpha",
+		projectName: "alpha",
+		sessionId: "aaa",
+		filePath:
+			"/Users/me/.claude/projects/-Users-me-projects-alpha/aaa.jsonl",
+		messageTimestamp: "2026-05-22T11:00:00.000Z",
+		role: "user",
+		snippet: "…score industry alpha…",
+		fullMessageContent: "Full body for ALPHA hit.",
+		...overrides,
+	};
+}
+
+function makeSelection(
+	hit: SessionHit,
+	snapshot: Partial<SearchTuiSnapshot> = {},
+): SearchSelection {
+	return {
+		hit,
+		snapshot: {
+			query: "score industry",
+			hits: [hit],
+			cursorIndex: 0,
+			...snapshot,
+		},
+	};
+}
+
+describe("runSearchDashboardLoop (slice 7, #89)", () => {
+	it("exits cleanly when the user quits the search TUI without selecting", async () => {
+		const mountSearch = vi.fn().mockResolvedValue(null);
+		const launchDashboard = vi.fn();
+		await runSearchDashboardLoop("foo", { mountSearch, launchDashboard });
+		expect(mountSearch).toHaveBeenCalledTimes(1);
+		expect(mountSearch).toHaveBeenCalledWith({
+			query: "foo",
+			restore: undefined,
+		});
+		expect(launchDashboard).not.toHaveBeenCalled();
+	});
+
+	it("re-mounts search with the preserved snapshot when the dashboard returns", async () => {
+		const hit = makeHit();
+		const selection = makeSelection(hit, {
+			query: "score industry",
+			cursorIndex: 2,
+		});
+		const mountSearch = vi
+			.fn()
+			.mockResolvedValueOnce(selection)
+			.mockResolvedValueOnce(null);
+		const launchDashboard = vi.fn().mockResolvedValue("return");
+
+		await runSearchDashboardLoop("score industry", {
+			mountSearch,
+			launchDashboard,
+		});
+
+		expect(launchDashboard).toHaveBeenCalledTimes(1);
+		expect(launchDashboard).toHaveBeenCalledWith(hit);
+		expect(mountSearch).toHaveBeenCalledTimes(2);
+		// Second mount restores the state captured at selection time.
+		expect(mountSearch).toHaveBeenNthCalledWith(2, {
+			query: "score industry",
+			restore: selection.snapshot,
+		});
+	});
+
+	it("ends the loop without re-mounting search when the dashboard hard-exits", async () => {
+		const mountSearch = vi
+			.fn()
+			.mockResolvedValue(makeSelection(makeHit()));
+		const launchDashboard = vi.fn().mockResolvedValue("exit");
+
+		await runSearchDashboardLoop("foo", { mountSearch, launchDashboard });
+
+		expect(mountSearch).toHaveBeenCalledTimes(1);
+		expect(launchDashboard).toHaveBeenCalledTimes(1);
+	});
+
+	it("supports repeated open → return → open round trips", async () => {
+		const hitA = makeHit({ sessionId: "aaa" });
+		const hitB = makeHit({ sessionId: "bbb", projectName: "beta" });
+		const selA = makeSelection(hitA, { query: "q1", cursorIndex: 0 });
+		const selB = makeSelection(hitB, { query: "q2", cursorIndex: 1 });
+		const mountSearch = vi
+			.fn()
+			.mockResolvedValueOnce(selA)
+			.mockResolvedValueOnce(selB)
+			.mockResolvedValueOnce(null);
+		const launchDashboard = vi.fn().mockResolvedValue("return");
+
+		await runSearchDashboardLoop("q1", { mountSearch, launchDashboard });
+
+		expect(launchDashboard).toHaveBeenCalledTimes(2);
+		expect(launchDashboard).toHaveBeenNthCalledWith(1, hitA);
+		expect(launchDashboard).toHaveBeenNthCalledWith(2, hitB);
+		expect(mountSearch).toHaveBeenCalledTimes(3);
+		// Each re-mount restores the most recent selection's snapshot.
+		expect(mountSearch).toHaveBeenNthCalledWith(2, {
+			query: "q1",
+			restore: selA.snapshot,
+		});
+		expect(mountSearch).toHaveBeenNthCalledWith(3, {
+			query: "q2",
+			restore: selB.snapshot,
+		});
+	});
+});

--- a/packages/ui/src/tui/search/run.tsx
+++ b/packages/ui/src/tui/search/run.tsx
@@ -12,10 +12,14 @@
  *
  * Slice 6 (#88): pressing Enter on a hit unmounts the search TUI and launches
  * the Exploration Browser dashboard scoped to the hit's project, with the
- * hit's session pre-selected as the highlighted row. `q` in the launched
- * dashboard exits the process (slice 7 will change that to bounce back to
- * search). When the dashboard returns, this runner returns — search is a
- * one-way trip in slice 6.
+ * hit's session pre-selected as the highlighted row.
+ *
+ * Slice 7 (#89): the search ↔ dashboard trip is a round trip. The dashboard
+ * is launched with `returnToCaller`, so `q` resolves it with `"return"`
+ * instead of exiting; the loop then re-mounts search with the snapshot
+ * captured at selection time (same query, same hit list, same highlight) and
+ * without re-running the scan. Ctrl+C in the dashboard — or quitting the
+ * search TUI itself with Esc — still ends the whole run.
  */
 import React from "react";
 import { render } from "ink";
@@ -25,7 +29,10 @@ import {
 	type SearchOptions,
 	type SessionHit,
 } from "@umwelten/core/interaction/search/index.js";
-import { SessionSearchTui } from "./SessionSearchTui.js";
+import {
+	SessionSearchTui,
+	type SearchTuiSnapshot,
+} from "./SessionSearchTui.js";
 
 export interface RunSessionSearchTuiOptions {
 	/** Forwarded to `searchSessions` on every scan. */
@@ -43,66 +50,123 @@ const DEFAULT_DASHBOARD_MODEL: ModelDetails = {
 	name: "gemini-3-flash-preview",
 };
 
+// ── Round-trip loop (slice 7, #89) ──────────────────────────────────────────
+
+/** A hit the user opened, plus the TUI state to restore on bounce-back. */
+export interface SearchSelection {
+	hit: SessionHit;
+	snapshot: SearchTuiSnapshot;
+}
+
+/**
+ * Injected seams for `runSearchDashboardLoop`. Production wires these to the
+ * Ink mounts; tests drive the loop without a terminal.
+ */
+export interface SearchLoopDeps {
+	/**
+	 * Mount the search TUI. Resolves with the user's selection, or null when
+	 * the user quit search (Esc / Ctrl+C) — null ends the loop.
+	 */
+	mountSearch: (mount: {
+		query: string;
+		restore?: SearchTuiSnapshot;
+	}) => Promise<SearchSelection | null>;
+	/**
+	 * Launch the Exploration Browser dashboard for a hit. Resolves "return"
+	 * when the user pressed `q` (bounce back to search) or "exit" when the
+	 * dashboard ended for good (Ctrl+C).
+	 */
+	launchDashboard: (hit: SessionHit) => Promise<"exit" | "return">;
+}
+
+/**
+ * The search ↔ dashboard round trip: search until the user opens a hit,
+ * show the dashboard, and on `q` re-mount search with the preserved
+ * snapshot. Repeats until the user quits search itself or hard-exits the
+ * dashboard.
+ */
+export async function runSearchDashboardLoop(
+	initialQuery: string,
+	deps: SearchLoopDeps,
+): Promise<void> {
+	let restore: SearchTuiSnapshot | undefined;
+	while (true) {
+		const selection = await deps.mountSearch({
+			query: restore?.query ?? initialQuery,
+			restore,
+		});
+		if (!selection) return;
+		restore = selection.snapshot;
+		const outcome = await deps.launchDashboard(selection.hit);
+		if (outcome === "exit") return;
+	}
+}
+
+// ── Production wiring ────────────────────────────────────────────────────────
+
 export async function runSessionSearchTui(
 	initialQuery: string,
 	opts: RunSessionSearchTuiOptions = {},
 ): Promise<void> {
 	const scanOpts = opts.scan ?? {};
+	const runScan = async (q: string): Promise<SessionHit[]> => {
+		return searchSessions(q, scanOpts);
+	};
 
-	let selectedHit: SessionHit | null = null;
+	await runSearchDashboardLoop(initialQuery, {
+		mountSearch: async ({ query, restore }) => {
+			let selection: SearchSelection | null = null;
 
-	await new Promise<void>((resolve) => {
-		let exited = false;
-		const handleExit = () => {
-			if (exited) return;
-			exited = true;
-			resolve();
-		};
+			await new Promise<void>((resolve) => {
+				let exited = false;
+				const handleExit = () => {
+					if (exited) return;
+					exited = true;
+					resolve();
+				};
 
-		const runScan = async (q: string): Promise<SessionHit[]> => {
-			return searchSessions(q, scanOpts);
-		};
+				const app = (
+					<SessionSearchTui
+						initialQuery={query}
+						initialHits={restore?.hits}
+						initialCursor={restore?.cursorIndex}
+						runScan={runScan}
+						onExit={handleExit}
+						onSelectHit={(hit, snapshot) => {
+							// Remember the hit and the TUI state; the dashboard
+							// launch happens after Ink fully unmounts so the
+							// alt-screen / raw mode is released before the next
+							// TUI takes over.
+							selection = { hit, snapshot };
+						}}
+					/>
+				);
 
-		const app = (
-			<SessionSearchTui
-				initialQuery={initialQuery}
-				runScan={runScan}
-				onExit={handleExit}
-				onSelectHit={(hit) => {
-					// Remember the hit; the dashboard launch happens after Ink
-					// fully unmounts so the alt-screen / raw mode is released
-					// before the next TUI takes over.
-					selectedHit = hit;
-				}}
-			/>
-		);
+				const instance = render(app, {
+					stdin: process.stdin,
+					stdout: process.stdout,
+				});
 
-		const instance = render(app, {
-			stdin: process.stdin,
-			stdout: process.stdout,
-		});
+				void instance.waitUntilExit().then(() => {
+					handleExit();
+				});
+			});
 
-		void instance.waitUntilExit().then(() => {
-			handleExit();
-		});
-	});
-
-	if (!selectedHit) return;
-
-	// Slice 6 (#88): the user picked a hit. Hand off to the Exploration
-	// Browser dashboard, scoped to the hit's project with the hit's session
-	// pre-selected. The dashboard runs its own event loop until the user
-	// quits with `q` (slice 7 will make `q` bounce back to search results).
-	const { initializeAdapters } = await import(
-		"@umwelten/core/interaction/adapters/index.js"
-	);
-	initializeAdapters();
-	const { runExploreBrowseTui } = await import("../introspect/browse.js");
-	const hit: SessionHit = selectedHit;
-	await runExploreBrowseTui({
-		projectPath: hit.projectPath,
-		targetPath: hit.projectPath,
-		model: opts.model ?? DEFAULT_DASHBOARD_MODEL,
-		preSelectSessionId: hit.sessionId,
+			return selection;
+		},
+		launchDashboard: async (hit) => {
+			const { initializeAdapters } = await import(
+				"@umwelten/core/interaction/adapters/index.js"
+			);
+			initializeAdapters();
+			const { runExploreBrowseTui } = await import("../introspect/browse.js");
+			return runExploreBrowseTui({
+				projectPath: hit.projectPath,
+				targetPath: hit.projectPath,
+				model: opts.model ?? DEFAULT_DASHBOARD_MODEL,
+				preSelectSessionId: hit.sessionId,
+				returnToCaller: true,
+			});
+		},
 	});
 }


### PR DESCRIPTION
Closes #89. Parent PRD: #82.

## What this builds

Slice 7 of Session Search: the search ↔ dashboard trip becomes a **round trip**. When you open a hit from `umwelten search` and land in the Exploration Browser dashboard, pressing `q` now bounces you back to your search results — same query, same hit list, same highlighted row, no re-scan — instead of killing the process. You can hop between hits indefinitely. Dashboards launched directly (`umwelten browse`) are unchanged: `q` still exits.

### How it works

- **`DashboardIntent` gains a `return` variant** (`packages/ui/src/tui/introspect/dashboard/types.ts`). Matches the existing intent union — no parallel system.
- **`DashboardApp` takes a `returnToCaller` prop**. When set, `q` emits `{ kind: "return" }`; Ctrl+C always stays a hard exit (`{ kind: "none" }`). The footer hint switches from `q quit` to `q back to search`.
- **`runExploreBrowseTui` now resolves with a `BrowseTuiOutcome`** (`"exit" | "return"`). Its existing caller in `@umwelten/sessions` ignores the return value, so the direct browse path is untouched. When launched from search against a project with no explorations, it resolves `"return"` instead of dying, so a bad hit doesn't kill your search.
- **`SessionSearchTui` accepts `initialHits` / `initialCursor`** to re-mount restored state without re-running the scan (later query edits re-scan normally), and `onSelectHit` now also passes a `SearchTuiSnapshot` (`query`, `hits`, `cursorIndex`) captured at selection time.
- **`run.tsx` hosts `runSearchDashboardLoop`**, the round-trip orchestration with injectable `mountSearch` / `launchDashboard` seams — unit-tested without a terminal.

## Tests

11 new unit tests (all green; full suite 1304 passing, lint 0 errors):

- `DashboardApp.test.tsx`: `q` → `return` intent with `returnToCaller`; `q` → `none` without; Ctrl+C → `none` always; footer label swap.
- `SessionSearchTui.test.tsx`: restore renders seeded hits with zero scan calls; `initialCursor` highlight; post-restore query edits re-scan; snapshot contents on select. (Two slice-6 assertions updated for the new second argument to `onSelectHit`.)
- `run.test.ts` (new): quit-search ends the loop; `return` re-mounts with the preserved snapshot; `exit` ends without re-mount; repeated round trips preserve the latest snapshot.

## Acceptance criteria from #89, with validation steps

**1. A "return to caller" intent variant exists on the dashboard intent type.**
```bash
grep -n 'kind: "return"' packages/ui/src/tui/introspect/dashboard/types.ts
```

**2. When invoked from the search TUI, `q` in the dashboard returns control to search rather than exiting.**
```bash
pnpm vitest run packages/ui/src/tui/introspect/DashboardApp.test.tsx -t "return to caller"
```
Manual: `dotenvx run -- pnpm run cli search "umwelten"` → Enter on a hit → wait for the dashboard → press `q` → you're back at the search results, not the shell.

**3. Search TUI re-mounts on return with same query, hit list, and highlighted row.**
```bash
pnpm vitest run packages/ui/src/tui/search/ -t "restore"
pnpm vitest run packages/ui/src/tui/search/run.test.ts
```
Manual: in the flow above, before pressing Enter note the query and arrow down a few rows; after `q` from the dashboard, the same row is highlighted and the header shows the same query and hit count instantly (no "scanning…" flash).

**4. Dashboards launched directly still exit on `q`.**
```bash
pnpm vitest run packages/ui/src/tui/introspect/DashboardApp.test.tsx -t "explicitly false"
```
Manual: `dotenvx run -- pnpm run cli browse` → `q` → process exits as before; footer still reads `q quit`.

**5. Repeated open → `q` → open → `q` round trips without re-running the scan.**
```bash
pnpm vitest run packages/ui/src/tui/search/run.test.ts -t "repeated"
```
Manual: bounce between two different hits a few times; each return is instant.

**6. Closing the search TUI itself exits the process cleanly.**
```bash
pnpm vitest run packages/ui/src/tui/search/run.test.ts -t "exits cleanly"
```
Manual: from search results press **Esc** → clean shell prompt. Note: since slice 5 (#87), `q` is a search character in the search TUI — **Esc / Ctrl+C** are its exit keys (the issue text predates that change; the criterion's intent — round trip is search ↔ dashboard, not search ↔ nothing — holds).

## Worth knowing / follow-on

- **Esc-vs-q nuance** above: the acceptance criterion says "closing the search TUI with `q`", but `q` became a typed character in slice 5. Implemented per the slice-5 reality.
- **Ctrl+C in the dashboard is a hard exit by design**, even when launched from search — `q` is the bounce-back, Ctrl+C means "get me out".
- **Empty-exploration projects return to search** rather than exiting — a defensive touch beyond the letter of the issue (a hit whose project fails projection no longer kills the session).
- **TUI tests and wall-clock waits**: under parallel vitest load, Ink's async input processing can exceed fixed `setTimeout` flushes. New tests await the actual scan call or poll frames instead. Some pre-existing slice 4–6 tests still use fixed waits and could theoretically flake under heavy load.
- **Unblocks #91 (slice 9)**: docs/CLI finalization can now describe the full search → open → return flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
