### PR TITLE
feat(search): Session Search slice 7 — q bounces back to search (#89)

### DIFF
--- a/packages/ui/src/tui/introspect/DashboardApp.test.tsx
+++ b/packages/ui/src/tui/introspect/DashboardApp.test.tsx
@@ -813,3 +813,57 @@ describe("DashboardApp — preSelectSessionId", () => {
 		);
 	});
 });
+
+// ── 8. Return to caller (slice 7, #89) ────────────────────────────────────
+
+describe("DashboardApp — returnToCaller", () => {
+	it("q emits a 'return' intent when returnToCaller is set", async () => {
+		const onExit = vi.fn();
+		const entries = [makeEntry("a")];
+		const { stdin } = renderDashboard({
+			entries,
+			onExit,
+			returnToCaller: true,
+		});
+		stdin.write("q");
+		await new Promise((r) => setTimeout(r, 50));
+		expect(onExit).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: "return" }),
+		);
+	});
+
+	it("q still emits 'none' (exit) when returnToCaller is not set", async () => {
+		const onExit = vi.fn();
+		const entries = [makeEntry("a")];
+		const { stdin } = renderDashboard({ entries, onExit });
+		stdin.write("q");
+		await new Promise((r) => setTimeout(r, 50));
+		expect(onExit).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: "none" }),
+		);
+	});
+
+	it("Ctrl+C stays a hard exit ('none') even when returnToCaller is set", async () => {
+		const onExit = vi.fn();
+		const entries = [makeEntry("a")];
+		const { stdin } = renderDashboard({
+			entries,
+			onExit,
+			returnToCaller: true,
+		});
+		stdin.write("\x03"); // Ctrl+C
+		await new Promise((r) => setTimeout(r, 50));
+		expect(onExit).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: "none" }),
+		);
+	});
+
+	it("shows a 'back to search' key hint when returnToCaller is set", () => {
+		const entries = [makeEntry("a")];
+		const { lastFrame } = renderDashboard({
+			entries,
+			returnToCaller: true,
+		});
+		expect(lastFrame() ?? "").toMatch(/q back/i);
+	});
+});

--- a/packages/ui/src/tui/introspect/DashboardApp.tsx
+++ b/packages/ui/src/tui/introspect/DashboardApp.tsx
@@ -79,6 +79,13 @@ export interface DashboardAppProps {
 	 * If the id doesn't match any entry, the cursor falls back to 0.
 	 */
 	preSelectSessionId?: string;
+	/**
+	 * When true, `q` emits `{ kind: "return" }` instead of `{ kind: "none" }`
+	 * so the caller that launched the dashboard (the search TUI, slice 7 #89)
+	 * can take the terminal back instead of the process exiting. Ctrl+C stays
+	 * a hard exit. Dashboards launched directly leave this unset — `q` quits.
+	 */
+	returnToCaller?: boolean;
 }
 
 const DEFAULT_FILTER: FilterState = {
@@ -168,6 +175,7 @@ export function DashboardApp(props: DashboardAppProps): React.ReactElement {
 		subscribeToTitleUpdates,
 		initialTitles,
 		preSelectSessionId,
+		returnToCaller = false,
 	} = props;
 
 	const { exit } = useApp();
@@ -338,7 +346,10 @@ export function DashboardApp(props: DashboardAppProps): React.ReactElement {
 	useInput(
 		(input, key) => {
 			if (input === "q" || (key.ctrl && input === "c")) {
-				onExit({ kind: "none" });
+				// `q` bounces back to the caller (search TUI) when one is
+				// waiting; Ctrl+C is always a hard exit (#89).
+				const isReturn = returnToCaller && input === "q" && !key.ctrl;
+				onExit(isReturn ? { kind: "return" } : { kind: "none" });
 				exit();
 				return;
 			}
@@ -440,7 +451,7 @@ export function DashboardApp(props: DashboardAppProps): React.ReactElement {
 				keysHint={
 					searchMode
 						? "Type to filter · Enter/Esc commit"
-						: "↑/↓ select · Enter detail · D digest · v transcript · b beats · R reflect · P promote · / search · q quit"
+						: `↑/↓ select · Enter detail · D digest · v transcript · b beats · R reflect · P promote · / search · ${returnToCaller ? "q back to search" : "q quit"}`
 				}
 			/>
 		</Box>

--- a/packages/ui/src/tui/introspect/browse.tsx
+++ b/packages/ui/src/tui/introspect/browse.tsx
@@ -28,7 +28,22 @@ export interface RunBrowseTuiOptions {
 	 * after detail/transcript/digest views start with the cursor at the top.
 	 */
 	preSelectSessionId?: string;
+	/**
+	 * When true, `q` in the dashboard resolves the browse loop with the
+	 * "return" outcome instead of "exit", so the caller (the search TUI,
+	 * slice 7 #89) can re-take the terminal. Direct launches (`umwelten
+	 * browse`) leave this unset — `q` exits as before.
+	 */
+	returnToCaller?: boolean;
 }
+
+/**
+ * How the browse loop ended:
+ * - `exit`   — the user quit (q on a direct launch, or Ctrl+C anywhere).
+ * - `return` — the user pressed `q` in a dashboard launched with
+ *   `returnToCaller`; the caller should resume (e.g. re-mount search).
+ */
+export type BrowseTuiOutcome = "exit" | "return";
 
 // ── Exploration-oriented browser (v2) — command-center dashboard ────────
 
@@ -154,6 +169,8 @@ async function showDashboardTui(args: {
 	onLaunchExtraction: () => void;
 	/** Pre-select the matching row on mount (Session Search → open hit). */
 	preSelectSessionId?: string;
+	/** `q` emits a "return" intent instead of exiting (slice 7, #89). */
+	returnToCaller?: boolean;
 }): Promise<DashboardIntent> {
 	let intent: DashboardIntent = { kind: "none" };
 
@@ -192,6 +209,7 @@ async function showDashboardTui(args: {
 			subscribeToTitleUpdates={args.bus.subscribeToTitles}
 			initialTitles={args.bus.liveTitles}
 			preSelectSessionId={args.preSelectSessionId}
+			returnToCaller={args.returnToCaller}
 		/>
 	);
 
@@ -346,7 +364,7 @@ async function runExtractionPass(args: {
  */
 export async function runExploreBrowseTui(
 	opts: RunBrowseTuiOptions,
-): Promise<void> {
+): Promise<BrowseTuiOutcome> {
 	const {
 		projectPath: rawProject,
 		targetPath: rawTarget,
@@ -354,6 +372,7 @@ export async function runExploreBrowseTui(
 		model,
 		force = false,
 		preSelectSessionId,
+		returnToCaller = false,
 	} = opts;
 	const projectPath = resolve(rawProject);
 	const targetPath = resolve(rawTarget);
@@ -383,7 +402,7 @@ export async function runExploreBrowseTui(
 			console.log(chalk.yellow("No explorations found for this project."));
 			console.log(chalk.dim(`Project: ${projectPath}`));
 			if (sessionsDir) console.log(chalk.dim(`Sessions dir: ${sessionsDir}`));
-			return;
+			return "exit";
 		}
 
 		const modelLabel = `${model.provider}:${model.name}`;
@@ -397,6 +416,7 @@ export async function runExploreBrowseTui(
 			startupConfirm: !askedAtLeastOnce,
 			bus,
 			preSelectSessionId: pendingPreSelect,
+			returnToCaller,
 			onLaunchExtraction: () => {
 				askedAtLeastOnce = true;
 				if (extractionLaunched) {
@@ -427,7 +447,8 @@ export async function runExploreBrowseTui(
 		// cursor back to the same row.
 		pendingPreSelect = undefined;
 
-		if (intent.kind === "none") return;
+		if (intent.kind === "none") return "exit";
+		if (intent.kind === "return") return "return";
 
 		const entry = intent.entry;
 

--- a/packages/ui/src/tui/introspect/dashboard/types.ts
+++ b/packages/ui/src/tui/introspect/dashboard/types.ts
@@ -28,9 +28,16 @@ export type DashboardStatus =
 /**
  * Intent returned from the dashboard when the user picks an action.
  * The CLI loop acts on this after the TUI exits.
+ *
+ * - `none`   — quit; the host should exit the browse loop entirely.
+ * - `return` — hand control back to the caller that launched the dashboard
+ *   (slice 7, #89: `q` in a dashboard launched from the search TUI bounces
+ *   back to the search results instead of exiting the process). Only emitted
+ *   when the host sets `returnToCaller` on DashboardApp.
  */
 export type DashboardIntent =
 	| { kind: "none" }
+	| { kind: "return" }
 	| { kind: "detail"; entry: ExplorationBrowserEntry }
 	| { kind: "transcript"; entry: ExplorationBrowserEntry }
 	| { kind: "digest"; entry: ExplorationBrowserEntry }

--- a/packages/ui/src/tui/search/SessionSearchTui.test.tsx
+++ b/packages/ui/src/tui/search/SessionSearchTui.test.tsx
@@ -641,6 +641,7 @@ describe("SessionSearchTui — open hit on Enter", () => {
 		expect(onSelectHit).toHaveBeenCalledTimes(1);
 		expect(onSelectHit).toHaveBeenCalledWith(
 			expect.objectContaining({ sessionId: "aaa", projectName: "alpha" }),
+			expect.anything(),
 		);
 	});
 
@@ -662,6 +663,7 @@ describe("SessionSearchTui — open hit on Enter", () => {
 		await flush();
 		expect(onSelectHit).toHaveBeenCalledWith(
 			expect.objectContaining({ sessionId: "bbb", projectName: "beta" }),
+			expect.anything(),
 		);
 	});
 
@@ -702,5 +704,107 @@ describe("SessionSearchTui — open hit on Enter", () => {
 		// invoked because Enter is "open hit", not "quit search".
 		expect(onSelectHit).toHaveBeenCalled();
 		expect(onExit).not.toHaveBeenCalled();
+	});
+});
+
+// ── 8. Snapshot + restored mounts (slice 7, #89) ───────────────────────────
+
+describe("SessionSearchTui — onSelectHit snapshot (slice 7)", () => {
+	it("passes a snapshot with the query, hit list, and cursor on Enter", async () => {
+		const onSelectHit = vi.fn();
+		const { stdin } = render(
+			<SessionSearchTui
+				initialQuery="x"
+				runScan={async () => TWO_HITS}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+				onSelectHit={onSelectHit}
+			/>,
+		);
+		await flush();
+		stdin.write(ARROW_DOWN);
+		await flush();
+		stdin.write("\r");
+		await flush();
+		expect(onSelectHit).toHaveBeenCalledWith(
+			expect.objectContaining({ sessionId: "bbb" }),
+			expect.objectContaining({
+				query: "x",
+				hits: TWO_HITS,
+				cursor: 1,
+			}),
+		);
+	});
+});
+
+describe("SessionSearchTui — restored mount (slice 7)", () => {
+	it("renders restored hits without re-running the scan", async () => {
+		let scanCalls = 0;
+		const { lastFrame } = render(
+			<SessionSearchTui
+				initialQuery="x"
+				initialHits={TWO_HITS}
+				initialCursor={0}
+				runScan={async () => {
+					scanCalls++;
+					return [];
+				}}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		// Wait well past the debounce window — no scan may fire.
+		await flush(150);
+		const frame = lastFrame() ?? "";
+		expect(scanCalls).toBe(0);
+		expect(frame).not.toMatch(/scanning/i);
+		expect(frame).toMatch(/score industry alpha/);
+		expect(frame).toMatch(/score industry beta/);
+		expect(frame).toMatch(/"x/); // restored query in the header
+	});
+
+	it("restores the highlighted row from initialCursor", async () => {
+		const { lastFrame } = render(
+			<SessionSearchTui
+				initialQuery="x"
+				initialHits={TWO_HITS}
+				initialCursor={1}
+				runScan={async () => []}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		await flush();
+		// Detail pane follows the highlight — row 1 is the BETA hit.
+		expect(lastFrame() ?? "").toMatch(/Full body for BETA hit/);
+	});
+
+	it("editing the query after a restored mount re-runs the scan normally", async () => {
+		// Await the actual scan call instead of wall-clock (same rationale as
+		// the makeRecordingScan helper above — timers drift on busy CI).
+		const calls: string[] = [];
+		let resolveNext: ((q: string) => void) | undefined;
+		const nextCall = new Promise<string>((r) => {
+			resolveNext = r;
+		});
+		const { stdin } = render(
+			<SessionSearchTui
+				initialQuery="x"
+				initialHits={TWO_HITS}
+				initialCursor={0}
+				runScan={async (q) => {
+					calls.push(q);
+					resolveNext?.(q);
+					return ONE_HIT;
+				}}
+				onExit={() => {}}
+				debounceMs={TEST_DEBOUNCE_MS}
+			/>,
+		);
+		await flush(150);
+		expect(calls).toEqual([]); // restored mount: no scan
+		stdin.write("y");
+		await nextCall;
+		expect(calls).toEqual(["xy"]); // edits scan as usual
 	});
 });

--- a/packages/ui/src/tui/search/SessionSearchTui.tsx
+++ b/packages/ui/src/tui/search/SessionSearchTui.tsx
@@ -23,14 +23,29 @@
  *
  * Slice 6 turns Enter into "launch the Exploration Browser dashboard
  * pre-selected at this hit" (via the `onSelectHit` prop and Ink's
- * `exit()`). Slice 7 (#89) will rebind exit for the dashboard-launched
- * case; slice 9 (#91) adds `--no-tui`.
+ * `exit()`). Slice 7 (#89) makes that a round trip: `onSelectHit` carries a
+ * state snapshot (query, hits, cursor), and `initialHits` / `initialCursor`
+ * let the runner re-mount this TUI exactly where the user left it — without
+ * re-running the scan. Slice 9 (#91) adds `--no-tui`.
  */
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useApp, useInput, useStdout } from "ink";
 import type { SessionHit } from "@umwelten/core/interaction/search/index.js";
 
 // ── Props ───────────────────────────────────────────────────────────────────
+
+/**
+ * Snapshot of the search TUI's interactive state, taken at the moment the
+ * user opens a hit (slice 7, #89). The runner holds onto it while the
+ * dashboard owns the terminal and feeds it back via `initialHits` /
+ * `initialCursor` so a re-mounted search TUI resumes exactly where the user
+ * left off — same query, same hit list, same highlighted row.
+ */
+export interface SearchTuiSnapshot {
+	query: string;
+	hits: SessionHit[];
+	cursor: number;
+}
 
 export interface SessionSearchTuiProps {
 	/**
@@ -63,8 +78,20 @@ export interface SessionSearchTuiProps {
 	 * The TUI also calls Ink's `useApp().exit()` to unmount cleanly so the
 	 * caller can launch the Exploration Browser dashboard for the hit's
 	 * project. If omitted, Enter is a no-op.
+	 *
+	 * Slice 7 (#89): also receives a snapshot of the current search state so
+	 * the caller can re-mount the TUI with it after the dashboard returns.
 	 */
-	onSelectHit?: (hit: SessionHit) => void;
+	onSelectHit?: (hit: SessionHit, snapshot: SearchTuiSnapshot) => void;
+	/**
+	 * Restored hit list for a re-mount after a dashboard round trip (slice 7,
+	 * #89). When set, the initial debounced scan is skipped — the list is
+	 * trusted as-is and no "scanning…" indicator shows. Subsequent query
+	 * edits re-scan as usual.
+	 */
+	initialHits?: SessionHit[];
+	/** Restored highlight index, paired with `initialHits`. */
+	initialCursor?: number;
 }
 
 // ── Component ──────────────────────────────────────────────────────────────
@@ -80,6 +107,8 @@ export function SessionSearchTui(
 		onExit,
 		debounceMs = DEFAULT_DEBOUNCE_MS,
 		onSelectHit,
+		initialHits,
+		initialCursor,
 	} = props;
 	const { exit } = useApp();
 	const { stdout } = useStdout();
@@ -93,15 +122,23 @@ export function SessionSearchTui(
 	// empty-query state (no scan in progress), and a populated array
 	// otherwise. `scanning` is independent — true while a scan is in
 	// flight (initial *or* re-scan), false otherwise.
-	const [hits, setHits] = useState<SessionHit[]>(() => []);
-	const [scanning, setScanning] = useState<boolean>(initialQuery.trim() !== "");
+	const [hits, setHits] = useState<SessionHit[]>(() => initialHits ?? []);
+	const [scanning, setScanning] = useState<boolean>(
+		initialQuery.trim() !== "" && initialHits === undefined,
+	);
 	const [scanError, setScanError] = useState<string | null>(null);
-	const [cursor, setCursor] = useState(0);
+	const [cursor, setCursor] = useState(initialCursor ?? 0);
 	const [scrollOffset, setScrollOffset] = useState(0);
 
 	// Track the latest scan so out-of-order results from a stale scan get
 	// discarded.
 	const scanSeqRef = useRef(0);
+
+	// Restored mounts (slice 7, #89) come with a trusted hit list — the first
+	// run of the debounce effect must not re-scan or the restored cursor
+	// would be wiped by the result handler. One-shot: query edits re-arm the
+	// effect and scan as usual.
+	const skipInitialScanRef = useRef(initialHits !== undefined);
 
 	// Debounce-driven scan. The effect re-arms whenever the query changes;
 	// the timer fires after `debounceMs` and runs the scanner. An empty
@@ -114,6 +151,10 @@ export function SessionSearchTui(
 			setScanError(null);
 			setHits([]);
 			setCursor(0);
+			return;
+		}
+		if (skipInitialScanRef.current) {
+			skipInitialScanRef.current = false;
 			return;
 		}
 		// Show the indicator immediately on a query change. Initial mount
@@ -162,9 +203,11 @@ export function SessionSearchTui(
 			// receives the hit via onSelectHit and is responsible for
 			// launching the Exploration Browser dashboard scoped to its
 			// project. We exit() to unmount Ink so the dashboard can take
-			// over the terminal.
+			// over the terminal. Slice 7 (#89): the snapshot lets the caller
+			// re-mount search with this exact state when the dashboard
+			// bounces back.
 			if (!current || !onSelectHit) return;
-			onSelectHit(current);
+			onSelectHit(current, { query, hits, cursor: bounded });
 			exit();
 			return;
 		}

--- a/packages/ui/src/tui/search/run.test.ts
+++ b/packages/ui/src/tui/search/run.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the search ↔ dashboard round-trip loop (slice 7, #89).
+ *
+ * `runSearchDashboardLoop` is the pure orchestrator behind
+ * `runSessionSearchTui`: mount search → user selects a hit → launch the
+ * dashboard → if the dashboard returns with "return" (q pressed while
+ * `returnToCaller` is set), re-mount search with the prior state preserved;
+ * any other outcome ends the loop. Deps are injected so the loop is testable
+ * without Ink.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { SessionHit } from "@umwelten/core/interaction/search/index.js";
+import {
+	runSearchDashboardLoop,
+	type SearchMountState,
+	type SearchSelection,
+} from "./run.js";
+
+function makeHit(overrides: Partial<SessionHit> = {}): SessionHit {
+	return {
+		projectPath: "/Users/me/projects/alpha",
+		projectName: "alpha",
+		sessionId: "aaa",
+		filePath: "/Users/me/.claude/projects/-Users-me-projects-alpha/aaa.jsonl",
+		messageTimestamp: "2026-05-22T11:00:00.000Z",
+		role: "user",
+		snippet: "…alpha…",
+		fullMessageContent: "Alpha body",
+		...overrides,
+	};
+}
+
+const HIT_A = makeHit({ sessionId: "aaa" });
+const HIT_B = makeHit({ sessionId: "bbb", projectName: "beta" });
+
+function selection(
+	hit: SessionHit,
+	snapshot: Partial<SearchSelection["snapshot"]> = {},
+): SearchSelection {
+	return {
+		hit,
+		snapshot: {
+			query: "alpha",
+			hits: [HIT_A, HIT_B],
+			cursor: 0,
+			...snapshot,
+		},
+	};
+}
+
+describe("runSearchDashboardLoop", () => {
+	it("exits without launching the dashboard when search resolves null (Esc)", async () => {
+		const mountSearch = vi.fn(async () => null);
+		const launchDashboard = vi.fn(async () => "exit" as const);
+
+		await runSearchDashboardLoop("alpha", { mountSearch, launchDashboard });
+
+		expect(mountSearch).toHaveBeenCalledTimes(1);
+		expect(mountSearch).toHaveBeenCalledWith({ query: "alpha" });
+		expect(launchDashboard).not.toHaveBeenCalled();
+	});
+
+	it("launches the dashboard for the selected hit and ends on 'exit'", async () => {
+		const mountSearch = vi.fn(async () => selection(HIT_A));
+		const launchDashboard = vi.fn(async () => "exit" as const);
+
+		await runSearchDashboardLoop("alpha", { mountSearch, launchDashboard });
+
+		expect(launchDashboard).toHaveBeenCalledTimes(1);
+		expect(launchDashboard).toHaveBeenCalledWith(HIT_A);
+		expect(mountSearch).toHaveBeenCalledTimes(1);
+	});
+
+	it("re-mounts search with the preserved snapshot when the dashboard returns", async () => {
+		const states: SearchMountState[] = [];
+		const mountSearch = vi.fn(async (state: SearchMountState) => {
+			states.push(state);
+			// First mount: select a hit; second mount: quit search.
+			return states.length === 1
+				? selection(HIT_B, { query: "alp", cursor: 1 })
+				: null;
+		});
+		const launchDashboard = vi.fn(async () => "return" as const);
+
+		await runSearchDashboardLoop("alp", { mountSearch, launchDashboard });
+
+		expect(mountSearch).toHaveBeenCalledTimes(2);
+		// First mount: fresh — just the initial query.
+		expect(states[0]).toEqual({ query: "alp" });
+		// Second mount: same query, same hit list, same highlighted row.
+		expect(states[1]).toEqual({
+			query: "alp",
+			hits: [HIT_A, HIT_B],
+			cursor: 1,
+		});
+	});
+
+	it("supports repeated round trips: open → return → open → return → quit", async () => {
+		let mounts = 0;
+		const mountSearch = vi.fn(async () => {
+			mounts++;
+			if (mounts === 1) return selection(HIT_A, { cursor: 0 });
+			if (mounts === 2) return selection(HIT_B, { cursor: 1 });
+			return null; // third mount: user quits search
+		});
+		const launchDashboard = vi.fn(async () => "return" as const);
+
+		await runSearchDashboardLoop("alpha", { mountSearch, launchDashboard });
+
+		expect(launchDashboard).toHaveBeenCalledTimes(2);
+		expect(launchDashboard).toHaveBeenNthCalledWith(1, HIT_A);
+		expect(launchDashboard).toHaveBeenNthCalledWith(2, HIT_B);
+		expect(mountSearch).toHaveBeenCalledTimes(3);
+	});
+
+	it("ends the loop when the dashboard outcome is 'exit' (Ctrl+C in dashboard)", async () => {
+		const mountSearch = vi.fn(async () => selection(HIT_A));
+		const launchDashboard = vi.fn(async () => "exit" as const);
+
+		await runSearchDashboardLoop("alpha", { mountSearch, launchDashboard });
+
+		expect(mountSearch).toHaveBeenCalledTimes(1);
+		expect(launchDashboard).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/ui/src/tui/search/run.tsx
+++ b/packages/ui/src/tui/search/run.tsx
@@ -12,10 +12,15 @@
  *
  * Slice 6 (#88): pressing Enter on a hit unmounts the search TUI and launches
  * the Exploration Browser dashboard scoped to the hit's project, with the
- * hit's session pre-selected as the highlighted row. `q` in the launched
- * dashboard exits the process (slice 7 will change that to bounce back to
- * search). When the dashboard returns, this runner returns — search is a
- * one-way trip in slice 6.
+ * hit's session pre-selected as the highlighted row.
+ *
+ * Slice 7 (#89): the handoff is now a round trip. The dashboard is launched
+ * with `returnToCaller`, so `q` resolves it with the "return" outcome and the
+ * search TUI re-mounts with its prior state preserved — same query, same hit
+ * list, same highlighted row, no re-scan. The user can open hit → q → open
+ * another hit → q → … indefinitely; Esc/Ctrl+C in search (or Ctrl+C in the
+ * dashboard) ends the loop. The loop itself (`runSearchDashboardLoop`) takes
+ * injected deps so it is unit-testable without Ink.
  */
 import React from "react";
 import { render } from "ink";
@@ -25,7 +30,11 @@ import {
 	type SearchOptions,
 	type SessionHit,
 } from "@umwelten/core/interaction/search/index.js";
-import { SessionSearchTui } from "./SessionSearchTui.js";
+import type { BrowseTuiOutcome } from "../introspect/browse.js";
+import {
+	SessionSearchTui,
+	type SearchTuiSnapshot,
+} from "./SessionSearchTui.js";
 
 export interface RunSessionSearchTuiOptions {
 	/** Forwarded to `searchSessions` on every scan. */
@@ -43,13 +52,73 @@ const DEFAULT_DASHBOARD_MODEL: ModelDetails = {
 	name: "gemini-3-flash-preview",
 };
 
-export async function runSessionSearchTui(
-	initialQuery: string,
-	opts: RunSessionSearchTuiOptions = {},
-): Promise<void> {
-	const scanOpts = opts.scan ?? {};
+// ── Loop orchestrator (unit-testable, no Ink) ───────────────────────────────
 
-	let selectedHit: SessionHit | null = null;
+/** State a search mount starts from — fresh (query only) or restored. */
+export interface SearchMountState {
+	query: string;
+	/** Restored hit list from a prior mount; skips the initial scan. */
+	hits?: SessionHit[];
+	/** Restored highlight index, paired with `hits`. */
+	cursor?: number;
+}
+
+/** What the user did in a search mount: picked a hit (+ state snapshot). */
+export interface SearchSelection {
+	hit: SessionHit;
+	snapshot: SearchTuiSnapshot;
+}
+
+export interface SearchLoopDeps {
+	/**
+	 * Mount the search TUI with the given state. Resolves with the selected
+	 * hit + snapshot when the user presses Enter, or null when the user quits
+	 * search (Esc / Ctrl+C).
+	 */
+	mountSearch: (state: SearchMountState) => Promise<SearchSelection | null>;
+	/**
+	 * Launch the Exploration Browser dashboard for the hit. Resolves with
+	 * "return" when the user pressed `q` (bounce back to search) or "exit"
+	 * for a hard quit (Ctrl+C).
+	 */
+	launchDashboard: (hit: SessionHit) => Promise<BrowseTuiOutcome>;
+}
+
+/**
+ * Search ↔ dashboard round-trip loop (slice 7, #89). Pure orchestration:
+ * mounts search, launches the dashboard on selection, and re-mounts search
+ * with the preserved snapshot for as long as the dashboard keeps resolving
+ * with "return".
+ */
+export async function runSearchDashboardLoop(
+	initialQuery: string,
+	deps: SearchLoopDeps,
+): Promise<void> {
+	let state: SearchMountState = { query: initialQuery };
+
+	while (true) {
+		const selection = await deps.mountSearch(state);
+		if (!selection) return; // Esc / Ctrl+C in search — exit cleanly.
+
+		const outcome = await deps.launchDashboard(selection.hit);
+		if (outcome !== "return") return; // hard quit from the dashboard.
+
+		// `q` bounced back: restore search exactly where the user left it.
+		state = {
+			query: selection.snapshot.query,
+			hits: selection.snapshot.hits,
+			cursor: selection.snapshot.cursor,
+		};
+	}
+}
+
+// ── Real-terminal wiring ────────────────────────────────────────────────────
+
+async function mountSearchTui(
+	state: SearchMountState,
+	runScan: (q: string) => Promise<SessionHit[]>,
+): Promise<SearchSelection | null> {
+	let selection: SearchSelection | null = null;
 
 	await new Promise<void>((resolve) => {
 		let exited = false;
@@ -59,20 +128,18 @@ export async function runSessionSearchTui(
 			resolve();
 		};
 
-		const runScan = async (q: string): Promise<SessionHit[]> => {
-			return searchSessions(q, scanOpts);
-		};
-
 		const app = (
 			<SessionSearchTui
-				initialQuery={initialQuery}
+				initialQuery={state.query}
+				initialHits={state.hits}
+				initialCursor={state.cursor}
 				runScan={runScan}
 				onExit={handleExit}
-				onSelectHit={(hit) => {
+				onSelectHit={(hit, snapshot) => {
 					// Remember the hit; the dashboard launch happens after Ink
 					// fully unmounts so the alt-screen / raw mode is released
 					// before the next TUI takes over.
-					selectedHit = hit;
+					selection = { hit, snapshot };
 				}}
 			/>
 		);
@@ -87,22 +154,33 @@ export async function runSessionSearchTui(
 		});
 	});
 
-	if (!selectedHit) return;
+	return selection;
+}
 
-	// Slice 6 (#88): the user picked a hit. Hand off to the Exploration
-	// Browser dashboard, scoped to the hit's project with the hit's session
-	// pre-selected. The dashboard runs its own event loop until the user
-	// quits with `q` (slice 7 will make `q` bounce back to search results).
-	const { initializeAdapters } = await import(
-		"@umwelten/core/interaction/adapters/index.js"
-	);
-	initializeAdapters();
-	const { runExploreBrowseTui } = await import("../introspect/browse.js");
-	const hit: SessionHit = selectedHit;
-	await runExploreBrowseTui({
-		projectPath: hit.projectPath,
-		targetPath: hit.projectPath,
-		model: opts.model ?? DEFAULT_DASHBOARD_MODEL,
-		preSelectSessionId: hit.sessionId,
+export async function runSessionSearchTui(
+	initialQuery: string,
+	opts: RunSessionSearchTuiOptions = {},
+): Promise<void> {
+	const scanOpts = opts.scan ?? {};
+	const runScan = async (q: string): Promise<SessionHit[]> => {
+		return searchSessions(q, scanOpts);
+	};
+
+	await runSearchDashboardLoop(initialQuery, {
+		mountSearch: (state) => mountSearchTui(state, runScan),
+		launchDashboard: async (hit) => {
+			const { initializeAdapters } = await import(
+				"@umwelten/core/interaction/adapters/index.js"
+			);
+			initializeAdapters();
+			const { runExploreBrowseTui } = await import("../introspect/browse.js");
+			return runExploreBrowseTui({
+				projectPath: hit.projectPath,
+				targetPath: hit.projectPath,
+				model: opts.model ?? DEFAULT_DASHBOARD_MODEL,
+				preSelectSessionId: hit.sessionId,
+				returnToCaller: true,
+			});
+		},
 	});
 }


### PR DESCRIPTION
## Summary

Session Search slice 7 (#82 / closes #89): dashboards launched from the search TUI now **return to search on `q`** instead of exiting the process. The search TUI re-mounts with its prior state — same query, same hit list, same highlighted row — without re-running the scan. Direct launches (`umwelten browse`) are untouched.

## What was built

- `{ kind: "return" }` variant on `DashboardIntent` (`packages/ui/src/tui/introspect/dashboard/types.ts`).
- `DashboardApp` gains a `returnToCaller` prop: `q` emits the `return` intent when set; Ctrl+C stays a hard exit; the status-bar hint flips to `q back to search`.
- `runExploreBrowseTui` accepts `returnToCaller` and now resolves with a `BrowseTuiOutcome` (`"exit" | "return"`).
- `SessionSearchTui.onSelectHit` now also receives a `SearchTuiSnapshot` (query, hits, cursor); new `initialHits` / `initialCursor` props restore a mount with the initial debounce scan suppressed (one-shot).
- `run.tsx` is now a round-trip loop, `runSearchDashboardLoop`, with injected deps so the orchestration is unit-tested without Ink (`run.test.ts`, new).

## Success criteria (from #89) and how to validate

Run the focused suites first (all validation commands assume the repo root):

```bash
npx vitest run packages/ui/src/tui/search packages/ui/src/tui/introspect
```

1. **A "return to caller" intent variant exists on the dashboard intent type.**
   - Automated: `DashboardApp.test.tsx` > `returnToCaller` > "q emits a 'return' intent when returnToCaller is set".
   - Inspect: `packages/ui/src/tui/introspect/dashboard/types.ts` — `DashboardIntent` includes `{ kind: "return" }`.

2. **When invoked from the search TUI, `q` in the dashboard returns control to the search TUI rather than exiting the process.**
   - Automated: `run.test.ts` > "re-mounts search with the preserved snapshot when the dashboard returns".
   - Manual:
     ```bash
     dotenvx run -- pnpm run cli search "some query"
     ```
     Press Enter on a hit -> dashboard opens -> press `q` -> you are back at the search results (process still running).

3. **Search TUI re-mounts on return with: same query, same hit list, same highlighted row.**
   - Automated: `run.test.ts` state assertions + `SessionSearchTui.test.tsx` > "renders restored hits without re-running the scan" and "restores the highlighted row from initialCursor".
   - Manual: in the search TUI, arrow down to a non-first row before pressing Enter. After `q` in the dashboard, the same row is highlighted, the query is unchanged, and the hit count is identical — with no "scanning…" flash.

4. **Dashboards launched directly (no caller) still exit on `q`.**
   - Automated: `DashboardApp.test.tsx` > "q still emits 'none' (exit) when returnToCaller is not set" (plus the pre-existing `q` exit test).
   - Manual:
     ```bash
     dotenvx run -- pnpm run cli browse
     ```
     Press `q` -> process exits as before.

5. **User can repeatedly: open hit -> `q` -> open another hit -> `q` -> … without re-running the scan.**
   - Automated: `run.test.ts` > "supports repeated round trips: open -> return -> open -> return -> quit"; the no-re-scan half is pinned by "renders restored hits without re-running the scan" (scan call count stays 0 on restored mounts).
   - Manual: repeat the Enter/`q` cycle several times in one `umwelten search` session; the hit list reappears instantly each time.

6. **Closing the search TUI itself exits the process cleanly.**
   - Automated: `run.test.ts` > "exits without launching the dashboard when search resolves null (Esc)".
   - Manual: press Esc (or Ctrl+C) in the search TUI -> clean exit, terminal restored. Note: since slice 5, `q` is a search *character* in the search TUI — Esc/Ctrl+C are the exits there; the criterion's `q` applies to the dashboard side.

## Verify everything

```bash
pnpm install
pnpm test:run          # full unit suite: 94 files, 1305 tests — all green on this branch
npx vitest run packages/ui/src/tui/search packages/ui/src/tui/introspect   # focused suites
dotenvx run -- pnpm run cli search "umwelten"   # live round-trip smoke test
```

## Worth knowing / further work

- `runExploreBrowseTui`'s return type changed `Promise<void>` -> `Promise<BrowseTuiOutcome>`. The two existing callers (`umwelten browse` / `introspect browse`, and the search runner) were checked; direct launches ignore the value, so no behavior change.
- Ctrl+C in the dashboard is deliberately a **hard exit** even when launched from search — only `q` bounces back.
- Each round trip launches a fresh `runExploreBrowseTui`, so `preSelectSessionId` pre-selects the newly opened hit every time; the extraction bus (and its cached phases) does **not** survive across round trips — same lifecycle as slice 6.
- The restored-mount scan suppression is one-shot: the first non-empty debounce pass is skipped; any query edit afterwards re-scans normally (tested).
- Manual TUI testing was not possible in this environment (no interactive terminal); the live smoke test above is the one human step worth doing before merge.
- Pre-existing, unrelated: `npx tsc -p packages/ui --noEmit` reports legacy errors in `packages/core` (AI SDK v2/v3 type mismatches) and one pre-existing `createdMs` fixture complaint in `DashboardApp.test.tsx` — both present on `main`, untouched here.
- This unblocks slice 9 (#91, `--no-tui` + CLI contract), whose walkthrough doc should cover this search -> hit -> return flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
