### PR TITLE
feat(search): Session Search slice 9 — --no-tui, CLI contract finalization, rg preflight, docs (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Every AI model lives in its own perceptual bubble — its *Umwelt*. Umwelten let
 git clone https://github.com/The-Focus-AI/umwelten.git
 cd umwelten && pnpm install && cp env.template .env
 # Add your GOOGLE_GENERATIVE_AI_API_KEY to .env
+# `umwelten search` requires ripgrep (rg) on PATH: brew install ripgrep
 ```
 
 ```bash

--- a/docs/walkthroughs/index.md
+++ b/docs/walkthroughs/index.md
@@ -43,6 +43,18 @@ Manual testing guide for the Bridge MCP system:
 
 ## Session Management
 
+### [Session Search Walkthrough](./session-search-walkthrough.md)
+
+Search every Claude Code session you've ever had by full message content, then hop into the Exploration Browser and back:
+
+- `umwelten search` — interactive two-pane TUI with live debounced re-scan
+- Open a hit in the dashboard with Enter; `q` bounces back to your results
+- `--json` and `--no-tui` stdout modes for scripting and piping
+- Powered by ripgrep — sub-second cold scans, no index to maintain
+
+**Time Required:** 5 minutes
+**Prerequisites:** ripgrep (`rg`) on PATH, Claude Code sessions on disk
+
 ### [Session Analysis Walkthrough](./session-analysis-walkthrough.md)
 
 Learn how to use the session management tools to understand your Claude Code work:

--- a/docs/walkthroughs/session-search-walkthrough.md
+++ b/docs/walkthroughs/session-search-walkthrough.md
@@ -1,0 +1,101 @@
+# Session Search Walkthrough
+
+`umwelten search` is system-wide full-content search across every Source Session
+on disk — every Claude Code conversation you've had, in any project, searchable
+by what was actually said. It shells out to [ripgrep](https://github.com/BurntSushi/ripgrep)
+for the scan (see [ADR 0002](../adr/0002-session-search-shells-out-to-ripgrep.md)),
+so cold searches over gigabytes of session history come back in under a second
+with no index to build or maintain.
+
+```
+type query ──▶ debounced rg scan ──▶ hit list + preview
+                                          │ Enter
+                                          ▼
+                          Exploration Browser dashboard
+                            (digest, beats, transcript)
+                                          │ q
+                                          ▼
+                          back to your results, same row
+```
+
+## Prerequisites
+
+- Node.js 20+, pnpm, the repo installed (`pnpm install`)
+- **ripgrep on PATH** — `brew install ripgrep` (macOS), `apt install ripgrep`
+  (Debian/Ubuntu). If `rg` is missing, `umwelten search` prints install
+  instructions and exits before anything else happens.
+- Claude Code sessions under `~/.claude/projects` (the v1 search root)
+
+**Time required:** 5 minutes
+
+## Quick orientation
+
+| Command                            | What you get                                    |
+| ---------------------------------- | ----------------------------------------------- |
+| `umwelten search`                  | empty TUI, type to search                       |
+| `umwelten search "query"`          | TUI pre-populated, scan already running         |
+| `umwelten search "query" --json`   | structured `SessionHit[]` JSON, no TUI          |
+| `umwelten search "query" --no-tui` | flat rows for `grep`/`less` piping, no TUI      |
+| `--case-sensitive`                 | exact-case match (default is case-insensitive)  |
+
+## Step 1: Search interactively
+
+```bash
+dotenvx run -- pnpm run cli search "rate limit"
+```
+
+The two-pane TUI opens with your query pre-populated and the scan already
+running: matching messages in the top pane (newest first, one row per hit —
+timestamp, project, role, snippet), the full matched message in the lower
+preview pane.
+
+Keys:
+
+| Key          | Action                                            |
+| ------------ | ------------------------------------------------- |
+| type         | edit the query — results re-scan live (debounced) |
+| `↑` / `↓`    | move through hits                                 |
+| `Enter`      | open the hit in the Exploration Browser dashboard |
+| `Esc` / `Ctrl+C` | exit                                          |
+
+Note that `q` is just a letter here — queries contain `q`s. Esc is how you leave.
+
+## Step 2: Open a hit, then bounce back
+
+Press `Enter` on a hit. The search TUI hands the terminal to the **Exploration
+Browser dashboard**, scoped to that hit's project with the session pre-selected
+— from there you can view the digest, run beats, or open the full transcript
+(see the dashboard keys in `umwelten browse`).
+
+Press `q` in the dashboard and you're **back in your search results** — same
+query, same hit list, same highlighted row, no re-scan. The round trip repeats
+as many times as you like: search once, explore many. `Ctrl+C` in the dashboard
+is the hard exit.
+
+## Step 3: Pipe it
+
+For scripting, two stdout modes that never mount a TUI (both require a query):
+
+```bash
+# Human-readable rows: timestamp · project · role · snippet
+dotenvx run -- pnpm run cli search "rate limit" --no-tui | less
+
+# Count hits per project
+dotenvx run -- pnpm run cli search "rate limit" --no-tui | cut -d'·' -f2 | sort | uniq -c
+
+# Full structured hits for programmatic use
+dotenvx run -- pnpm run cli search "rate limit" --json | jq '.[].projectName'
+```
+
+`--no-tui` is presentation, `--json` is structure: the JSON form carries every
+`SessionHit` field (`projectPath`, `sessionId`, `filePath`, `fullMessageContent`,
+…) for downstream tooling.
+
+## How it relates to the rest of the system
+
+Search is the fast path into the [knowledge pipeline](./knowledge-pipeline-walkthrough.md):
+find the conversation where a decision happened, open it in the dashboard, and
+digest or reflect on it from there. The search layer itself lives in
+`@umwelten/core/interaction/search/` (scanner → hit parser → noise filters),
+and the same noise filtering the Claude Code adapter uses keeps tool spam and
+sidechain sessions out of your results.

--- a/packages/core/src/interaction/search/index.ts
+++ b/packages/core/src/interaction/search/index.ts
@@ -16,6 +16,7 @@
 
 export { searchSessions } from "./searcher.js";
 export { scanWithRipgrep, defaultSearchRoots } from "./ripgrep-scanner.js";
+export { ripgrepAvailable } from "./ripgrep-available.js";
 export {
 	parseHit,
 	decodeProjectDirName,

--- a/packages/core/src/interaction/search/ripgrep-available.test.ts
+++ b/packages/core/src/interaction/search/ripgrep-available.test.ts
@@ -1,0 +1,27 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { ripgrepAvailable } from "./ripgrep-available.js";
+
+const HAS_RG = (() => {
+	const result = spawnSync("rg", ["--version"], { stdio: "ignore" });
+	return result.status === 0;
+})();
+
+describe("ripgrepAvailable", () => {
+	it("resolves false for a binary that does not exist", async () => {
+		await expect(
+			ripgrepAvailable("definitely-not-a-real-binary-92xq"),
+		).resolves.toBe(false);
+	});
+
+	it.skipIf(!HAS_RG)("resolves true when rg is on PATH", async () => {
+		await expect(ripgrepAvailable()).resolves.toBe(true);
+	});
+
+	it("never rejects — missing binaries resolve, not throw", async () => {
+		// The CLI preflight relies on this: a missing rg must produce the
+		// friendly install hint, not an unhandled spawn error.
+		const result = ripgrepAvailable("also-not-a-binary-92xq");
+		await expect(result).resolves.toBeTypeOf("boolean");
+	});
+});

--- a/packages/core/src/interaction/search/ripgrep-available.ts
+++ b/packages/core/src/interaction/search/ripgrep-available.ts
@@ -1,0 +1,39 @@
+/**
+ * Preflight check for the `rg` binary (slice 9, #91).
+ *
+ * The scanner already throws RipgrepNotFoundError mid-scan when `rg` is
+ * missing, but by then the TUI may already own the terminal. The CLI runs
+ * this check once per `umwelten search` invocation, before any TUI mount
+ * or scan, so the install hint lands on a clean stderr with a non-zero
+ * exit. See ADR docs/adr/0002-session-search-shells-out-to-ripgrep.md.
+ */
+import { spawn } from "node:child_process";
+
+/**
+ * Resolve true when the binary can be spawned and reports a version,
+ * false otherwise. Never rejects — absence is an expected condition the
+ * caller turns into the RipgrepNotFoundError install hint.
+ */
+export async function ripgrepAvailable(bin = "rg"): Promise<boolean> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const settle = (ok: boolean) => {
+			if (settled) return;
+			settled = true;
+			resolve(ok);
+		};
+
+		let child: ReturnType<typeof spawn>;
+		try {
+			child = spawn(bin, ["--version"], {
+				stdio: ["ignore", "ignore", "ignore"],
+			});
+		} catch {
+			settle(false);
+			return;
+		}
+
+		child.on("error", () => settle(false));
+		child.on("close", (code) => settle(code === 0));
+	});
+}

--- a/packages/sessions/src/search-format.test.ts
+++ b/packages/sessions/src/search-format.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { SessionHit } from "@umwelten/core/interaction/search/index.js";
+import { formatHitRow, formatHitRows } from "./search-format.js";
+
+function makeHit(overrides: Partial<SessionHit> = {}): SessionHit {
+	return {
+		projectPath: "/Users/me/projects/umwelten",
+		projectName: "umwelten",
+		sessionId: "abc-123",
+		filePath: "/Users/me/.claude/projects/x/abc-123.jsonl",
+		messageTimestamp: "2026-06-10T13:31:00.000Z",
+		role: "user",
+		snippet: "…the score industry baseline was…",
+		fullMessageContent: "long body",
+		...overrides,
+	};
+}
+
+describe("formatHitRow", () => {
+	it("renders timestamp · project · role · snippet", () => {
+		expect(formatHitRow(makeHit())).toBe(
+			"2026-06-10T13:31:00.000Z · umwelten · user · …the score industry baseline was…",
+		);
+	});
+
+	it("flattens newlines and tabs in the snippet so rows stay one line", () => {
+		const row = formatHitRow(
+			makeHit({ snippet: "line one\nline two\tand more" }),
+		);
+		expect(row).not.toMatch(/[\n\t]/);
+		expect(row).toContain("line one line two and more");
+	});
+
+	it("renders every role verbatim", () => {
+		for (const role of ["user", "assistant", "tool", "system"] as const) {
+			expect(formatHitRow(makeHit({ role }))).toContain(` · ${role} · `);
+		}
+	});
+});
+
+describe("formatHitRows", () => {
+	it("joins rows with newlines and ends with a trailing newline", () => {
+		const out = formatHitRows([
+			makeHit({ snippet: "first" }),
+			makeHit({ snippet: "second" }),
+		]);
+		const lines = out.split("\n");
+		expect(out.endsWith("\n")).toBe(true);
+		expect(lines).toHaveLength(3); // 2 rows + empty string after final \n
+		expect(lines[0]).toContain("first");
+		expect(lines[1]).toContain("second");
+	});
+
+	it("returns an empty string for zero hits (nothing to pipe)", () => {
+		expect(formatHitRows([])).toBe("");
+	});
+});

--- a/packages/sessions/src/search-format.ts
+++ b/packages/sessions/src/search-format.ts
@@ -1,0 +1,38 @@
+/**
+ * Plain-text row formatting for `umwelten search --no-tui` (slice 9, #91).
+ *
+ * One hit → one line, `grep`/`less`-friendly:
+ *
+ *   2026-06-10T13:31:00.000Z · umwelten · user · …the matching snippet…
+ *
+ * This is the human-readable sibling of `--json`: same hits, presentation
+ * instead of structure. Programmatic consumers should use `--json`, which
+ * prints the full SessionHit[] shape.
+ */
+import type { SessionHit } from "@umwelten/core/interaction/search/index.js";
+
+const SEPARATOR = " · ";
+
+/** Collapse any whitespace runs (incl. newlines/tabs) so a row is one line. */
+function oneLine(text: string): string {
+	return text.replace(/\s+/g, " ").trim();
+}
+
+/** Format a single hit as `timestamp · project · role · snippet`. */
+export function formatHitRow(hit: SessionHit): string {
+	return [
+		hit.messageTimestamp,
+		hit.projectName,
+		hit.role,
+		oneLine(hit.snippet),
+	].join(SEPARATOR);
+}
+
+/**
+ * Format all hits, one row per line, with a trailing newline when there
+ * are any rows. Zero hits → empty string (nothing lands on stdout).
+ */
+export function formatHitRows(hits: SessionHit[]): string {
+	if (hits.length === 0) return "";
+	return hits.map(formatHitRow).join("\n") + "\n";
+}

--- a/packages/sessions/src/search.ts
+++ b/packages/sessions/src/search.ts
@@ -2,26 +2,34 @@
  * `umwelten search` — system-wide full-content search across every
  * Source Session on disk.
  *
- * Slice 5 (#87): the no-arg form drops into the TUI with an empty query;
- * the TUI's query is now editable with debounced live re-scan. `--json`
- * still requires a query and short-circuits to stdout output.
- *
- * Output matrix per PRD #82:
+ * Slice 9 (#91) finalizes the CLI contract per PRD #82:
  *
  *   umwelten search               → empty TUI w/ editable query (slice 5)
  *   umwelten search "q"           → pre-populated TUI (slice 4)
- *   umwelten search "q" --json    → JSON to stdout, no TUI
- *   umwelten search "q" --no-tui  → plain rows to stdout, no TUI (slice 9)
+ *   umwelten search "q" --json    → structured SessionHit[] to stdout, no TUI
+ *   umwelten search "q" --no-tui  → flat human-readable rows to stdout, no TUI
+ *
+ * `--no-tui` prints one `timestamp · project · role · snippet` row per hit
+ * (grep/less-friendly); `--json` is the programmatic shape. Both require a
+ * query and never mount the TUI.
+ *
+ * Every invocation preflights for ripgrep before doing anything else, so a
+ * missing `rg` produces the install hint on a clean stderr (exit 127)
+ * instead of dying after the TUI owns the terminal.
  */
 
 import { Command } from "commander";
 import {
-	searchSessions,
+	ripgrepAvailable,
 	RipgrepNotFoundError,
+	searchSessions,
 } from "@umwelten/core/interaction/search/index.js";
+import { formatHitRows } from "./search-format.js";
 
 interface SearchActionOptions {
 	json?: boolean;
+	/** Commander negated flag: `--no-tui` sets this to false. */
+	tui?: boolean;
 	caseSensitive?: boolean;
 }
 
@@ -34,28 +42,77 @@ export const searchCommand = new Command("search")
 	.argument(
 		"[query]",
 		"Optional search query. When omitted, the TUI launches with an empty " +
-			"editable query. Required with --json.",
+			"editable query. Required with --json or --no-tui.",
 	)
-	.option("--json", "Print results as a JSON array to stdout, no TUI.")
+	.option(
+		"--json",
+		"Print results as a structured JSON array (SessionHit[]) to stdout, " +
+			"no TUI. For programmatic consumers.",
+	)
+	.option(
+		"--no-tui",
+		"Print human-readable rows (timestamp · project · role · snippet), " +
+			"one per line, to stdout — no TUI. Suitable for grep/less piping.",
+	)
 	.option(
 		"--case-sensitive",
 		"Match the query case-sensitively (default: case-insensitive).",
 	)
+	.addHelpText(
+		"after",
+		[
+			"",
+			"Output modes:",
+			"  umwelten search                     empty TUI, type to search",
+			'  umwelten search "query"             TUI pre-populated, scan pre-run',
+			'  umwelten search "query" --json      SessionHit[] JSON to stdout',
+			'  umwelten search "query" --no-tui    flat rows: timestamp · project · role · snippet',
+			"",
+			"In the TUI: type to refine the query, ↑/↓ to move, Enter opens the",
+			"hit in the Exploration Browser dashboard (q there bounces back to",
+			"your results), Esc/Ctrl+C exits.",
+			"",
+			"Requires ripgrep (`rg`) on PATH — e.g. `brew install ripgrep`.",
+			"More: https://github.com/BurntSushi/ripgrep#installation",
+		].join("\n"),
+	)
 	.action(async (query: string | undefined, options: SearchActionOptions) => {
 		try {
-			if (options.json) {
-				// JSON path needs a query — there's nothing to scan otherwise.
+			// Preflight once per invocation, before any scan or TUI mount,
+			// so the install hint never fights a half-mounted alt screen.
+			if (!(await ripgrepAvailable())) {
+				process.stderr.write(new RipgrepNotFoundError().message + "\n");
+				process.exit(127); // conventional "command not found" exit
+			}
+
+			const noTui = options.tui === false;
+
+			if (options.json && noTui) {
+				process.stderr.write(
+					"umwelten search: --json and --no-tui are mutually exclusive.\n",
+				);
+				process.exit(2);
+			}
+
+			if (options.json || noTui) {
+				// Both stdout modes need a query — there's nothing to scan
+				// otherwise.
 				if (!query) {
+					const flag = options.json ? "--json" : "--no-tui";
 					process.stderr.write(
-						"umwelten search --json: a query argument is required.\n" +
-							"  Usage: umwelten search 'your query' --json\n",
+						`umwelten search ${flag}: a query argument is required.\n` +
+							`  Usage: umwelten search 'your query' ${flag}\n`,
 					);
 					process.exit(2);
 				}
 				const hits = await searchSessions(query, {
 					caseSensitive: options.caseSensitive ?? false,
 				});
-				process.stdout.write(JSON.stringify(hits, null, 2) + "\n");
+				process.stdout.write(
+					options.json
+						? JSON.stringify(hits, null, 2) + "\n"
+						: formatHitRows(hits),
+				);
 				return;
 			}
 
@@ -70,7 +127,7 @@ export const searchCommand = new Command("search")
 		} catch (err) {
 			if (err instanceof RipgrepNotFoundError) {
 				process.stderr.write(err.message + "\n");
-				process.exit(127); // conventional "command not found" exit
+				process.exit(127);
 			}
 			process.stderr.write(
 				`umwelten search failed: ${err instanceof Error ? err.message : String(err)}\n`,


### PR DESCRIPTION
Closes #91. Parent PRD: #82 — **this is the final slice of the Session Search epic.**

## What this builds

The `umwelten search` CLI contract is now complete per the PRD matrix:

```
umwelten search                    # empty TUI, type to search
umwelten search "score industry"   # TUI pre-populated, scan pre-run
umwelten search "foo" --json       # structured SessionHit[] to stdout, no TUI
umwelten search "foo" --no-tui     # flat human-readable rows to stdout, no TUI
```

- **`--no-tui`** (new): one `timestamp · project · role · snippet` row per hit, grep/less-friendly. Formatting lives in `packages/sessions/src/search-format.ts` (pure, unit-tested); snippets are whitespace-flattened so a row is always one line. Mutually exclusive with `--json` (exit 2); requires a query (exit 2).
- **ripgrep preflight** (new): `ripgrepAvailable()` in `packages/core/src/interaction/search/ripgrep-available.ts` runs once per invocation before any scan or TUI mount. Missing `rg` → install hint on stderr, exit 127, never a half-mounted alt screen. Never rejects — absence resolves `false`.
- **Help text**: `search --help` documents every flag, the full output-mode matrix, the TUI keys, and the `rg` dependency with install pointer.
- **Docs**: README install block notes the `rg` requirement; new `docs/walkthroughs/session-search-walkthrough.md` covers search → open hit → `q` bounce-back (the slice-7 round trip), linked from `docs/walkthroughs/index.md` with the existing Time/Prerequisites convention.

## Tests

8 new unit tests, all green; full suite **1312 passed**, lint 0 errors.

- `packages/sessions/src/search-format.test.ts` — row shape, whitespace flattening, role rendering, trailing newline, zero-hit empty output.
- `packages/core/src/interaction/search/ripgrep-available.test.ts` — false for missing binary, true when `rg` present (skipped if absent), never-rejects guarantee.

## Acceptance criteria from #91, with validation steps

**1. `umwelten search --help` documents every supported flag and the ripgrep dependency.**
```bash
dotenvx run -- pnpm run cli search --help
```
Expect: `--json`, `--no-tui`, `--case-sensitive` in Options; an "Output modes" matrix; "Requires ripgrep (`rg`) on PATH" with install link.

**2. `umwelten search` (no args) launches the empty TUI.**
```bash
dotenvx run -- pnpm run cli search
```
Empty two-pane TUI, type to search. (Unchanged from slice 5; preflight now runs first.)

**3. `umwelten search "q"` launches the pre-populated TUI.**
```bash
dotenvx run -- pnpm run cli search "ripgrep"
```

**4. `umwelten search "q" --json` prints JSON to stdout, no TUI.**
```bash
dotenvx run -- pnpm run cli search "ripgrep" --json | tail -n +2 | head -5
```

**5. `umwelten search "q" --no-tui` prints human-readable rows to stdout, no TUI.**
```bash
dotenvx run -- pnpm run cli search "ripgrep" --no-tui
```
Expect rows like `2026-06-10T16:51:39.373Z · umwelten · user · …snippet…`. Also: `npx vitest run packages/sessions/src/search-format.test.ts`

**6. Missing `rg` shows the install hint before any TUI mount attempt, with a non-zero exit.**
```bash
PATH="/usr/bin:/bin:$(dirname $(which node))" npx tsx packages/cli/src/entry.ts search "anything"; echo "exit=$?"
```
Expect the brew/apt/dnf install hint and `exit=127`, no TUI flash. Also: `npx vitest run packages/core/src/interaction/search/ripgrep-available.test.ts`

**7. README's installation section mentions the `rg` dependency.**
```bash
grep -n ripgrep README.md
```

**8. Walkthrough doc covers the end-to-end search → open hit → return-to-search flow.**
See `docs/walkthroughs/session-search-walkthrough.md` (Steps 1–3) and its entry in `docs/walkthroughs/index.md` under Session Management.

## Verified live

`--help`, `--json`, `--no-tui` (real hits), missing-query (exit 2), conflicting flags (exit 2), and stripped-PATH missing-rg (hint + exit 127) all exercised against real session data in this branch's worktree. Interactive TUI paths (criteria 2–3) are unchanged code from slices 5–7 — worth one human smoke test before merge.

## Worth knowing / further work

- **dotenvx banner on stdout**: `dotenvx run` prints its injection banner to stdout, which pollutes `--json | jq` piping in dev. Not a contract issue (`npx umwelten search` has no dotenvx; `dotenvx run -q` silences it) — just use `-q` when piping in dev.
- **Zero hits with `--no-tui`** prints nothing and exits 0 (clean for piping). A grep-style exit 1 on no-match was considered and skipped — not in the contract.
- **`--no-tui` flag semantics**: Commander negated-flag convention means the option key is `tui` defaulting `true`; the action checks `options.tui === false`.
- **Epic complete**: with this slice merged, every slice of PRD #82 (1–9) has landed. #82 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)