### PR TITLE
feat(habitat): RuntimeRunner seam + claude-sdk native session linkage (#118)

### DIFF
--- a/packages/habitat/Dockerfile
+++ b/packages/habitat/Dockerfile
@@ -63,6 +63,11 @@ VOLUME /data
 ENV NODE_ENV=production
 ENV HABITAT_WORK_DIR=/data
 ENV PORT=8080
+# Session co-location (#118 / PRD #113): every runtime's native logs live
+# under the data volume. Claude Code (claude-sdk runtime) honors
+# CLAUDE_CONFIG_DIR, so its projects/<cwd>/<session>.jsonl traces land in
+# /data/claude-config/ — reachable by session egress like habitat sessions.
+ENV CLAUDE_CONFIG_DIR=/data/claude-config
 
 EXPOSE 8080
 

--- a/packages/habitat/src/bridge/channel-bridge-runtime.test.ts
+++ b/packages/habitat/src/bridge/channel-bridge-runtime.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the RuntimeRunner seam in ChannelBridge (#118):
+ * dispatch through registered runners, nativeSessionRef persistence to
+ * session metadata, missing-runner errors, and the pi mode in routing.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ChannelBridge } from "./channel-bridge.js";
+import { coerceChannelBinding } from "./routing.js";
+import type { RuntimeResult, RuntimeRunner } from "./types.js";
+import type { AgentHost } from "../types.js";
+
+// ── Fixture: a workDir with routing.json + a fake host ───────────────
+
+async function makeFixture(runtime: "claude-sdk" | "pi") {
+  const workDir = await mkdtemp(join(tmpdir(), "bridge-runtime-"));
+  const sessionDir = join(workDir, "sessions", "sess-1");
+  await mkdir(sessionDir, { recursive: true });
+  await writeFile(
+    join(workDir, "routing.json"),
+    JSON.stringify({
+      channels: { "web:abc": { agentId: "coder", runtime } },
+    }),
+  );
+
+  const updateSessionMetadata = vi.fn(async () => {});
+  const host = {
+    workDir,
+    getAgent: (id: string) =>
+      id === "coder"
+        ? { id: "coder", name: "Coder", projectPath: "/data/agents/coder/repo" }
+        : undefined,
+    getOrCreateSession: async () => ({ sessionId: "sess-1", sessionDir }),
+    updateSessionMetadata,
+  } as unknown as AgentHost;
+
+  return { workDir, sessionDir, host, updateSessionMetadata };
+}
+
+function makeRunner(result: Partial<RuntimeResult>): RuntimeRunner & {
+  calls: Array<{ prompt: string; ctx: unknown }>;
+} {
+  const calls: Array<{ prompt: string; ctx: unknown }> = [];
+  return {
+    calls,
+    async run(prompt, ctx) {
+      calls.push({ prompt, ctx });
+      return { content: "ran", success: true, ...result };
+    },
+  };
+}
+
+const REF = {
+  runtime: "claude-sdk",
+  nativeSessionId: "sdk-sess-7",
+  nativeSessionPath: "/data/claude-config/projects/-x/sdk-sess-7.jsonl",
+};
+
+describe("ChannelBridge runtime dispatch (#118)", () => {
+  it("dispatches through the registered runner and persists nativeSessionRef", async () => {
+    const { host, sessionDir, updateSessionMetadata } =
+      await makeFixture("claude-sdk");
+    const runner = makeRunner({ nativeSessionRef: REF });
+    const bridge = new ChannelBridge(host, {
+      runtimeRunners: { "claude-sdk": runner },
+    });
+
+    let done: unknown;
+    await bridge.handleMessage(
+      { channelKey: "web:abc", text: "fix the tests" },
+      { onDone: (r) => void (done = r) },
+    );
+
+    // Runner got the prompt + a full RuntimeContext.
+    expect(runner.calls).toHaveLength(1);
+    expect(runner.calls[0].prompt).toBe("fix the tests");
+    expect(runner.calls[0].ctx).toMatchObject({
+      sessionId: "sess-1",
+      sessionDir,
+      channelKey: "web:abc",
+      agent: { id: "coder" },
+    });
+
+    // The linkage landed in session metadata.
+    expect(updateSessionMetadata).toHaveBeenCalledWith("sess-1", {
+      nativeSessionRef: REF,
+    });
+
+    // Envelope summary transcript was written.
+    const transcript = await readFile(join(sessionDir, "transcript.jsonl"), "utf-8");
+    expect(transcript).toContain("fix the tests");
+    expect(transcript).toContain("ran");
+
+    expect(done).toMatchObject({ content: "ran", sessionId: "sess-1" });
+  });
+
+  it("skips the metadata update when the runner returns no ref", async () => {
+    const { host, updateSessionMetadata } = await makeFixture("claude-sdk");
+    const runner = makeRunner({});
+    const bridge = new ChannelBridge(host, {
+      runtimeRunners: { "claude-sdk": runner },
+    });
+
+    await bridge.handleMessage(
+      { channelKey: "web:abc", text: "hi" },
+      { onDone: () => {} },
+    );
+    expect(updateSessionMetadata).not.toHaveBeenCalled();
+  });
+
+  it("errors cleanly when no runner is registered for the runtime", async () => {
+    const { host } = await makeFixture("pi");
+    const bridge = new ChannelBridge(host, {});
+
+    let error: string | undefined;
+    await bridge.handleMessage(
+      { channelKey: "web:abc", text: "hi" },
+      { onDone: () => {}, onError: (e) => void (error = e) },
+    );
+    expect(error).toContain('No runner registered for runtime "pi"');
+  });
+
+  it("still supports the legacy runClaudeSdk injection (wrapped, no ref)", async () => {
+    const { host, updateSessionMetadata } = await makeFixture("claude-sdk");
+    const legacy = vi.fn(async () => ({
+      content: "legacy ran",
+      success: true,
+      errors: [] as string[],
+    }));
+    const bridge = new ChannelBridge(host, { runClaudeSdk: legacy });
+
+    let done: unknown;
+    await bridge.handleMessage(
+      { channelKey: "web:abc", text: "task" },
+      { onDone: (r) => void (done = r) },
+    );
+
+    expect(legacy).toHaveBeenCalledWith(
+      "task",
+      expect.objectContaining({ cwd: "/data/agents/coder/repo" }),
+    );
+    expect(done).toMatchObject({ content: "legacy ran" });
+    expect(updateSessionMetadata).not.toHaveBeenCalled();
+  });
+});
+
+describe("routing accommodates the pi mode (#118)", () => {
+  it("coerces an explicit pi binding", () => {
+    expect(coerceChannelBinding({ agentId: "coder", runtime: "pi" })).toEqual({
+      agentId: "coder",
+      runtime: "pi",
+      infoMessageId: undefined,
+    });
+  });
+
+  it("still defaults unknown runtimes to default", () => {
+    expect(
+      coerceChannelBinding({ agentId: "coder", runtime: "warp-drive" as never }),
+    ).toEqual({ agentId: "coder", runtime: "default", infoMessageId: undefined });
+  });
+});

--- a/packages/habitat/src/bridge/channel-bridge.ts
+++ b/packages/habitat/src/bridge/channel-bridge.ts
@@ -26,6 +26,8 @@ import type {
   ChannelBridgeOptions,
   ChannelRuntimeMode,
   RouteResolution,
+  RuntimeContext,
+  RuntimeRunner,
 } from './types.js';
 
 // ── Cached interaction entry ─────────────────────────────────────────
@@ -49,13 +51,34 @@ export type BuildAgentStimulusFn = (
 ) => Promise<Stimulus>;
 
 /**
- * Callback to run a message through the Claude Agent SDK.
- * Injected by the caller so ChannelBridge doesn't import claude-sdk-runner.ts directly.
+ * Legacy callback to run a message through the Claude Agent SDK.
+ * Kept for callers that haven't moved to the RuntimeRunner seam (#118);
+ * the bridge wraps it into a RuntimeRunner internally. New code should
+ * register `runtimeRunners: { 'claude-sdk': createClaudeSdkRuntimeRunner() }`.
  */
 export type RunClaudeSdkFn = (
   prompt: string,
   options: { cwd: string; apiKey?: string; maxTurns?: number },
 ) => Promise<{ content: string; success: boolean; errors: string[] }>;
+
+/** Wrap the legacy claude-sdk callback in the RuntimeRunner contract. */
+function wrapLegacyClaudeSdkFn(fn: RunClaudeSdkFn): RuntimeRunner {
+  return {
+    async run(prompt, ctx) {
+      const result = await fn(prompt, {
+        cwd: ctx.agent.projectPath,
+        apiKey: process.env.ANTHROPIC_API_KEY,
+        maxTurns: 25,
+      });
+      // The legacy fn surfaces no native session id — no ref to record.
+      return {
+        content: result.content,
+        success: result.success,
+        errors: result.errors,
+      };
+    },
+  };
+}
 
 export class ChannelBridge {
   private host: AgentHost;
@@ -64,14 +87,17 @@ export class ChannelBridge {
   private platformInstruction?: string;
   private routingPath?: string;
   private buildAgentStimulusFn?: BuildAgentStimulusFn;
-  private runClaudeSdkFn?: RunClaudeSdkFn;
+  private runtimeRunners = new Map<ChannelRuntimeMode, RuntimeRunner>();
 
   constructor(
     host: AgentHost,
     options?: ChannelBridgeOptions & {
       routingPath?: string;
       buildAgentStimulus?: BuildAgentStimulusFn;
+      /** Legacy seam — wrapped into a claude-sdk RuntimeRunner. */
       runClaudeSdk?: RunClaudeSdkFn;
+      /** Runners for non-default runtimes (#118). Takes precedence. */
+      runtimeRunners?: Partial<Record<ChannelRuntimeMode, RuntimeRunner>>;
     },
   ) {
     this.host = host;
@@ -79,7 +105,12 @@ export class ChannelBridge {
     this.platformInstruction = options?.platformInstruction;
     this.routingPath = options?.routingPath;
     this.buildAgentStimulusFn = options?.buildAgentStimulus;
-    this.runClaudeSdkFn = options?.runClaudeSdk;
+    if (options?.runClaudeSdk) {
+      this.runtimeRunners.set('claude-sdk', wrapLegacyClaudeSdkFn(options.runClaudeSdk));
+    }
+    for (const [mode, runner] of Object.entries(options?.runtimeRunners ?? {})) {
+      if (runner) this.runtimeRunners.set(mode as ChannelRuntimeMode, runner);
+    }
   }
 
   // ── Public API ───────────────────────────────────────────────────
@@ -97,10 +128,10 @@ export class ChannelBridge {
     events: BridgeEventHandlers,
   ): Promise<void> {
     try {
-      // Check if this channel routes to claude-sdk
+      // Non-default runtimes dispatch through the RuntimeRunner seam (#118)
       const route = await this.resolveRoute(msg.channelKey, msg.parentChannelKey);
-      if (route.kind === 'agent' && route.runtime === 'claude-sdk') {
-        return await this.handleClaudeSdk(msg, route.agentId, events);
+      if (route.kind === 'agent' && route.runtime !== 'default') {
+        return await this.handleRuntime(msg, route.agentId, route.runtime, events);
       }
 
       const entry = await this.getOrCreateEntry(msg);
@@ -241,27 +272,33 @@ export class ChannelBridge {
     return this.host.getAgents().map(a => ({ id: a.id, name: a.name }));
   }
 
-  // ── Claude SDK pass-through ────────────────────────────────────────
+  // ── Non-default runtime dispatch (#118) ────────────────────────────
 
   /**
-   * Handle a message via Claude Agent SDK.
-   * Spawns a Claude Code subprocess with full tools against the agent's project.
+   * Handle a message via a registered RuntimeRunner (claude-sdk, pi, …).
+   *
+   * The runner does the work; the bridge owns the envelope: it creates
+   * the habitat session, writes the minimal user/assistant transcript
+   * pair, and records the runner's nativeSessionRef in the session
+   * metadata so the full native trace is linked from the Source Session.
    */
-  private async handleClaudeSdk(
+  private async handleRuntime(
     msg: ChannelMessage,
     agentId: string,
+    runtime: ChannelRuntimeMode,
     events: BridgeEventHandlers,
   ): Promise<void> {
     const agent = this.host.getAgent(agentId);
     if (!agent) {
-      const err = `Agent "${agentId}" not found for Claude SDK pass-through`;
+      const err = `Agent "${agentId}" not found for ${runtime} runtime`;
       if (events.onError) events.onError(err);
       else console.error(`[ChannelBridge] ${err}`);
       return;
     }
 
-    if (!this.runClaudeSdkFn) {
-      const err = 'Claude SDK pass-through not available (runClaudeSdk not injected)';
+    const runner = this.runtimeRunners.get(runtime);
+    if (!runner) {
+      const err = `No runner registered for runtime "${runtime}" (channel ${msg.channelKey})`;
       if (events.onError) events.onError(err);
       else console.error(`[ChannelBridge] ${err}`);
       return;
@@ -273,25 +310,39 @@ export class ChannelBridge {
       const identifier = msg.channelKey.slice(msg.channelKey.indexOf(':') + 1);
       const session = await this.host.getOrCreateSession(platform as any, identifier);
 
-      const result = await this.runClaudeSdkFn(msg.text, {
-        cwd: agent.projectPath,
-        apiKey: process.env.ANTHROPIC_API_KEY,
-        maxTurns: 25,
-      });
+      const ctx: RuntimeContext = {
+        agent,
+        sessionId: session.sessionId,
+        sessionDir: session.sessionDir,
+        channelKey: msg.channelKey,
+      };
 
+      const result = await runner.run(msg.text, ctx, events);
       const content = result.content;
 
-      // Write a minimal transcript (user + assistant)
+      // Write the envelope summary (user + assistant). For non-default
+      // runtimes this is a summary alongside a link, not the only record.
       await writeSessionTranscript(session.sessionDir, [
         { role: 'user', content: msg.text },
         { role: 'assistant', content: content || '(no text)' },
       ]);
 
+      // Record the native session linkage in meta.json (#118).
+      if (result.nativeSessionRef) {
+        await this.host
+          .updateSessionMetadata(session.sessionId, {
+            nativeSessionRef: result.nativeSessionRef,
+          })
+          .catch(() => {
+            /* non-fatal — linkage is best-effort */
+          });
+      }
+
       if (!result.success && events.onError) {
-        const hint = result.errors.length > 0
+        const hint = result.errors?.length
           ? result.errors.join('; ')
-          : 'Claude SDK returned no content';
-        events.onError(`Claude SDK pass-through: ${hint}. Check ANTHROPIC_API_KEY.`);
+          : `${runtime} returned no content`;
+        events.onError(`${runtime} runtime: ${hint}. Check ANTHROPIC_API_KEY.`);
         return;
       }
 
@@ -303,9 +354,9 @@ export class ChannelBridge {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (events.onError) {
-        events.onError(`Claude SDK pass-through failed: ${message}`);
+        events.onError(`${runtime} runtime failed: ${message}`);
       } else {
-        console.error(`[ChannelBridge] Claude SDK error for ${msg.channelKey}:`, err);
+        console.error(`[ChannelBridge] ${runtime} error for ${msg.channelKey}:`, err);
       }
     }
   }

--- a/packages/habitat/src/bridge/routing.ts
+++ b/packages/habitat/src/bridge/routing.ts
@@ -30,7 +30,9 @@ export function coerceChannelBinding(
     const agentId = value.agentId.trim();
     if (!agentId) return null;
     const runtime: ChannelRuntimeMode =
-      value.runtime === 'claude-sdk' ? 'claude-sdk' : 'default';
+      value.runtime === 'claude-sdk' || value.runtime === 'pi'
+        ? value.runtime
+        : 'default';
     const infoMessageId = typeof value.infoMessageId === 'string' && value.infoMessageId.trim()
       ? value.infoMessageId.trim() : undefined;
     return { agentId, runtime, infoMessageId };

--- a/packages/habitat/src/bridge/types.ts
+++ b/packages/habitat/src/bridge/types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { CoreMessage } from 'ai';
+import type { AgentEntry, NativeSessionRef } from '../types.js';
 
 // ── Inbound message ──────────────────────────────────────────────────
 
@@ -70,10 +71,62 @@ export interface BridgeResult {
   reasoning?: string;
 }
 
-// ── Routing ──────────────────────────────────────────────────────────
+// ── Runtime seam (#118) ──────────────────────────────────────────────
 
-/** How a bound channel's messages are executed. */
-export type ChannelRuntimeMode = 'default' | 'claude-sdk';
+/**
+ * How a bound channel's messages are executed.
+ *
+ * - `default`    — the base Interaction tool-loop; full transcript written.
+ * - `claude-sdk` — Claude Agent SDK subprocess against the agent's project.
+ * - `pi`         — pi agentic runtime (runner lands in #122; the mode is
+ *                  part of the contract now so routing/config don't churn).
+ *
+ * Non-default modes dispatch through a registered RuntimeRunner.
+ */
+export type ChannelRuntimeMode = 'default' | 'claude-sdk' | 'pi';
+
+/** What a RuntimeRunner gets to work with, beyond the prompt itself. */
+export interface RuntimeContext {
+  /** The agent the channel is bound to (cwd source for subprocess runtimes). */
+  agent: AgentEntry;
+  /** Habitat session id the run is recorded under. */
+  sessionId: string;
+  /** Habitat session directory (transcript + meta.json live here). */
+  sessionDir: string;
+  /** The originating channel key (e.g. "discord:123"). */
+  channelKey: string;
+}
+
+/** Outcome of a RuntimeRunner.run — the PRD #113 contract shape. */
+export interface RuntimeResult {
+  /** Final assistant text for the channel. */
+  content: string;
+  /** Whether the run completed successfully. */
+  success: boolean;
+  /** Error details when success is false. */
+  errors?: string[];
+  /**
+   * Link to the runtime's native session (id + on-disk log), recorded in
+   * the habitat session's metadata so the full tool-call trace is
+   * reachable from the Source Session envelope.
+   */
+  nativeSessionRef?: NativeSessionRef;
+}
+
+/**
+ * The contract every non-default runtime implements (#118). The bridge
+ * dispatches through this seam — adding a runtime means registering a
+ * runner, not touching the bridge, the transcript writer, or A2A.
+ */
+export interface RuntimeRunner {
+  run(
+    prompt: string,
+    ctx: RuntimeContext,
+    events: BridgeEventHandlers,
+  ): Promise<RuntimeResult>;
+}
+
+// ── Routing ──────────────────────────────────────────────────────────
 
 /** A channel → agent binding in routing.json. */
 export interface ChannelBinding {

--- a/packages/habitat/src/claude-sdk-runner.test.ts
+++ b/packages/habitat/src/claude-sdk-runner.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for the claude-sdk runner's #118 surface: init-message
+ * session-id extraction (subprocess stubbed via queryFn), native session
+ * path computation, and the RuntimeRunner adapter.
+ */
+import { describe, expect, it } from "vitest";
+import { join } from "node:path";
+import {
+  claudeNativeSessionPath,
+  claudeProjectDirName,
+  createClaudeSdkRuntimeRunner,
+  runClaudeSDK,
+  type ClaudeSDKResult,
+} from "./claude-sdk-runner.js";
+import type { RuntimeContext } from "./bridge/types.js";
+import type { AgentEntry } from "./types.js";
+
+// ── Stubbed SDK stream ────────────────────────────────────────────────
+
+function makeQueryFn(messages: unknown[]): any {
+  return () =>
+    (async function* () {
+      for (const m of messages) yield m;
+    })();
+}
+
+const INIT_MESSAGE = {
+  type: "system",
+  subtype: "init",
+  session_id: "sdk-sess-1234",
+  cwd: "/data/agents/coder/repo",
+};
+
+const ASSISTANT_MESSAGE = {
+  type: "assistant",
+  message: { content: [{ type: "text", text: "All done." }] },
+};
+
+const SUCCESS_RESULT = {
+  type: "result",
+  subtype: "success",
+  result: "All done.",
+  num_turns: 3,
+  duration_ms: 1200,
+};
+
+describe("runClaudeSDK session-id extraction (stubbed subprocess)", () => {
+  it("extracts the native session id from the init message", async () => {
+    const result = await runClaudeSDK("do the thing", {
+      cwd: "/tmp/x",
+      queryFn: makeQueryFn([INIT_MESSAGE, ASSISTANT_MESSAGE, SUCCESS_RESULT]),
+    });
+    expect(result.success).toBe(true);
+    expect(result.content).toBe("All done.");
+    expect(result.sessionId).toBe("sdk-sess-1234");
+  });
+
+  it("carries the session id on error results too", async () => {
+    const result = await runClaudeSDK("do the thing", {
+      cwd: "/tmp/x",
+      queryFn: makeQueryFn([
+        INIT_MESSAGE,
+        { type: "result", subtype: "error_max_turns", num_turns: 25 },
+      ]),
+    });
+    expect(result.success).toBe(false);
+    expect(result.sessionId).toBe("sdk-sess-1234");
+  });
+
+  it("leaves sessionId undefined when no init message arrives", async () => {
+    const result = await runClaudeSDK("do the thing", {
+      cwd: "/tmp/x",
+      queryFn: makeQueryFn([ASSISTANT_MESSAGE, SUCCESS_RESULT]),
+    });
+    expect(result.sessionId).toBeUndefined();
+  });
+});
+
+describe("claudeNativeSessionPath", () => {
+  it("encodes the cwd with Claude Code's dash convention", () => {
+    expect(claudeProjectDirName("/data/agents/coder/repo")).toBe(
+      "-data-agents-coder-repo",
+    );
+    expect(claudeProjectDirName("/Users/me/my.project_x")).toBe(
+      "-Users-me-my-project-x",
+    );
+  });
+
+  it("uses CLAUDE_CONFIG_DIR when set (container data volume)", () => {
+    const path = claudeNativeSessionPath("/data/agents/coder/repo", "sess-1", {
+      CLAUDE_CONFIG_DIR: "/data/claude-config",
+    });
+    expect(path).toBe(
+      "/data/claude-config/projects/-data-agents-coder-repo/sess-1.jsonl",
+    );
+  });
+
+  it("falls back to ~/.claude when the override is unset", () => {
+    const path = claudeNativeSessionPath("/tmp/p", "sess-2", {});
+    expect(path).toContain(join(".claude", "projects"));
+    expect(path.endsWith("sess-2.jsonl")).toBe(true);
+  });
+});
+
+describe("createClaudeSdkRuntimeRunner", () => {
+  const agent: AgentEntry = {
+    id: "coder",
+    name: "Coder",
+    projectPath: "/data/agents/coder/repo",
+  };
+  const ctx: RuntimeContext = {
+    agent,
+    sessionId: "habitat-sess",
+    sessionDir: "/tmp/habitat-sess",
+    channelKey: "web:abc",
+  };
+
+  function fakeRun(result: Partial<ClaudeSDKResult>): typeof runClaudeSDK {
+    return async (_prompt, opts) => {
+      // Mimic the real runner's progress stream so event wiring is pinned.
+      opts.onProgress?.({ type: "text", content: "working…" });
+      opts.onProgress?.({ type: "tool_use", content: "Using Bash", toolName: "Bash" });
+      return {
+        content: "done",
+        success: true,
+        numTurns: 1,
+        durationMs: 10,
+        messages: [],
+        errors: [],
+        ...result,
+      };
+    };
+  }
+
+  it("returns a nativeSessionRef pointing at the JSONL trace", async () => {
+    const runner = createClaudeSdkRuntimeRunner(
+      fakeRun({ sessionId: "sdk-sess-9" }),
+    );
+    const result = await runner.run("task", ctx, { onDone: async () => {} });
+    expect(result.success).toBe(true);
+    expect(result.nativeSessionRef).toMatchObject({
+      runtime: "claude-sdk",
+      nativeSessionId: "sdk-sess-9",
+    });
+    expect(result.nativeSessionRef?.nativeSessionPath).toContain(
+      "-data-agents-coder-repo/sdk-sess-9.jsonl",
+    );
+  });
+
+  it("omits the ref when the SDK reported no session id", async () => {
+    const runner = createClaudeSdkRuntimeRunner(fakeRun({}));
+    const result = await runner.run("task", ctx, { onDone: async () => {} });
+    expect(result.nativeSessionRef).toBeUndefined();
+  });
+
+  it("streams progress into the bridge event handlers", async () => {
+    const texts: string[] = [];
+    const tools: string[] = [];
+    const runner = createClaudeSdkRuntimeRunner(fakeRun({}));
+    await runner.run("task", ctx, {
+      onDone: async () => {},
+      onText: (d) => texts.push(d),
+      onToolCall: (name) => tools.push(name),
+    });
+    expect(texts).toEqual(["working…"]);
+    expect(tools).toEqual(["Bash"]);
+  });
+});

--- a/packages/habitat/src/claude-sdk-runner.ts
+++ b/packages/habitat/src/claude-sdk-runner.ts
@@ -6,6 +6,8 @@
  * coding tasks to Claude's full toolset (Read, Edit, Bash, Grep, etc.).
  */
 
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import type {
   SDKMessage,
@@ -13,6 +15,12 @@ import type {
   SDKAssistantMessage,
   Options,
 } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  BridgeEventHandlers,
+  RuntimeContext,
+  RuntimeResult,
+  RuntimeRunner,
+} from "./bridge/types.js";
 
 export interface ClaudeSDKRunnerOptions {
   /** Working directory for Claude Code (typically agent's projectPath) */
@@ -37,6 +45,12 @@ export interface ClaudeSDKRunnerOptions {
   permissionMode?: "default" | "plan" | "auto";
   /** Additional env vars to pass */
   env?: Record<string, string | undefined>;
+  /**
+   * Injectable query function for tests (defaults to the real SDK's
+   * query). Lets unit tests drive the message loop — init session-id
+   * extraction, result handling — with the subprocess layer stubbed.
+   */
+  queryFn?: typeof query;
 }
 
 export interface ClaudeSDKProgress {
@@ -58,6 +72,40 @@ export interface ClaudeSDKResult {
   messages: SDKAssistantMessage[];
   /** Errors if any */
   errors: string[];
+  /**
+   * The SDK's native session id, extracted from the stream's init
+   * message (#118). Links the habitat session envelope to the full
+   * Claude Code JSONL trace on disk.
+   */
+  sessionId?: string;
+}
+
+// ── Native session location (#118) ───────────────────────────────────
+
+/**
+ * Claude Code's project-directory encoding: every non-alphanumeric
+ * character of the cwd becomes a dash (lossy by design — see #109; the
+ * read side prefers the JSONL's own `cwd` field for decoding).
+ */
+export function claudeProjectDirName(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+/**
+ * Where Claude Code wrote the native JSONL for a run: under
+ * `$CLAUDE_CONFIG_DIR/projects/<encoded-cwd>/<sessionId>.jsonl`, falling
+ * back to `~/.claude` when the override is unset. The container image
+ * sets CLAUDE_CONFIG_DIR beneath the data volume (PRD #113 session
+ * co-location); this helper only reads the environment — runners never
+ * invent paths.
+ */
+export function claudeNativeSessionPath(
+  cwd: string,
+  sessionId: string,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const configDir = env.CLAUDE_CONFIG_DIR?.trim() || join(homedir(), ".claude");
+  return join(configDir, "projects", claudeProjectDirName(cwd), `${sessionId}.jsonl`);
 }
 
 /**
@@ -118,8 +166,10 @@ export async function runClaudeSDK(
   }
 
   let resultMessage: SDKResultMessage | undefined;
+  let nativeSessionId: string | undefined;
+  const queryFn = options.queryFn ?? query;
 
-  for await (const message of query({ prompt, options: queryOptions })) {
+  for await (const message of queryFn({ prompt, options: queryOptions })) {
     switch (message.type) {
       case "assistant": {
         const assistantMsg = message as SDKAssistantMessage;
@@ -155,8 +205,13 @@ export async function runClaudeSDK(
       }
 
       case "system": {
+        const sysMsg = message as { subtype?: string; session_id?: string };
+        // The init message carries the SDK's session id — the link from
+        // the habitat session envelope to the native JSONL trace (#118).
+        if (sysMsg.subtype === "init" && sysMsg.session_id) {
+          nativeSessionId = sysMsg.session_id;
+        }
         if (options.onProgress) {
-          const sysMsg = message as { subtype?: string };
           options.onProgress({
             type: "status",
             content: `system: ${sysMsg.subtype ?? "unknown"}`,
@@ -176,6 +231,7 @@ export async function runClaudeSDK(
       durationMs: resultMessage.duration_ms ?? 0,
       messages: assistantMessages,
       errors,
+      sessionId: nativeSessionId,
     };
   }
 
@@ -195,5 +251,56 @@ export async function runClaudeSDK(
     durationMs: errorResult?.duration_ms ?? 0,
     messages: assistantMessages,
     errors: [...errors, errorText],
+    sessionId: nativeSessionId,
+  };
+}
+
+// ── RuntimeRunner adapter (#118) ──────────────────────────────────────
+
+/**
+ * Adapt the SDK runner to the bridge's RuntimeRunner contract. Streams
+ * progress into the bridge event handlers and, when the SDK reported a
+ * session id, returns the nativeSessionRef pointing at the JSONL trace.
+ *
+ * `runFn` is injectable for tests; production uses runClaudeSDK.
+ */
+export function createClaudeSdkRuntimeRunner(
+  runFn: typeof runClaudeSDK = runClaudeSDK,
+): RuntimeRunner {
+  return {
+    async run(
+      prompt: string,
+      ctx: RuntimeContext,
+      events: BridgeEventHandlers,
+    ): Promise<RuntimeResult> {
+      const result = await runFn(prompt, {
+        cwd: ctx.agent.projectPath,
+        apiKey: process.env.ANTHROPIC_API_KEY,
+        maxTurns: 25,
+        onProgress: (update) => {
+          if (update.type === "text") {
+            events.onText?.(update.content);
+          } else if (update.type === "tool_use" && update.toolName) {
+            events.onToolCall?.(update.toolName, undefined);
+          }
+        },
+      });
+
+      return {
+        content: result.content,
+        success: result.success,
+        errors: result.errors,
+        nativeSessionRef: result.sessionId
+          ? {
+              runtime: "claude-sdk",
+              nativeSessionId: result.sessionId,
+              nativeSessionPath: claudeNativeSessionPath(
+                ctx.agent.projectPath,
+                result.sessionId,
+              ),
+            }
+          : undefined,
+      };
+    },
   };
 }

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -31,7 +31,7 @@ import { resolveProjectDir, saveConfig, fileExists } from "./config.js";
 import { listArtifacts } from "./tools/artifact-tools.js";
 import { createA2AHandler, type A2AHandler } from "./a2a-handler.js";
 import { buildAgentStimulus } from "./habitat-agent.js";
-import { runClaudeSDK } from "./claude-sdk-runner.js";
+import { createClaudeSdkRuntimeRunner } from "./claude-sdk-runner.js";
 import { ChannelBridge } from "./bridge/channel-bridge.js";
 import { WebAdapter } from "./web/WebAdapter.js";
 import { devAuth } from "./web/auth/dev-auth.js";
@@ -182,7 +182,7 @@ export async function startContainerServer(
 			"Do NOT copy files to /files/ — that path is a virtual mount, not a real directory. Files are served directly from /data/.",
 		].join("\n"),
 		buildAgentStimulus,
-		runClaudeSdk: runClaudeSDK,
+		runtimeRunners: { 'claude-sdk': createClaudeSdkRuntimeRunner() },
 	});
 
 	// Wrap bridge.handleMessage to log chat activity and track session

--- a/packages/habitat/src/tools/agent-runner/ask-claude.ts
+++ b/packages/habitat/src/tools/agent-runner/ask-claude.ts
@@ -8,7 +8,10 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { Tool } from "ai";
-import { runClaudeSDK } from "../../claude-sdk-runner.js";
+import {
+	claudeNativeSessionPath,
+	runClaudeSDK,
+} from "../../claude-sdk-runner.js";
 import type { AgentRunnerToolsContext } from "./context.js";
 
 export function createAgentAskClaudeTool(
@@ -76,6 +79,18 @@ export function createAgentAskClaudeTool(
 					numTurns: result.numTurns,
 					durationMs: result.durationMs,
 					errors: result.errors.length > 0 ? result.errors : undefined,
+					// Same linkage as channel-bound claude-sdk runs (#118): the
+					// full tool-call trace is reachable from the calling session.
+					nativeSessionRef: result.sessionId
+						? {
+								runtime: "claude-sdk",
+								nativeSessionId: result.sessionId,
+								nativeSessionPath: claudeNativeSessionPath(
+									agent.projectPath,
+									result.sessionId,
+								),
+							}
+						: undefined,
 				};
 			} catch (err: any) {
 				return {

--- a/packages/habitat/src/types.ts
+++ b/packages/habitat/src/types.ts
@@ -382,6 +382,24 @@ export type HabitatSessionType =
 	| string;
 
 /**
+ * Pointer from a habitat session to the native session a non-default
+ * runtime (claude-sdk, pi) created while handling a message (#118).
+ *
+ * The habitat transcript keeps only the user/assistant envelope summary;
+ * the full tool-call trace lives in the runtime's own log format at
+ * `nativeSessionPath`. Normalization happens at read time via the
+ * existing adapters (PRD #113) — this ref is the link, not the data.
+ */
+export interface NativeSessionRef {
+	/** Runtime that produced the native session (e.g. "claude-sdk", "pi"). */
+	runtime: string;
+	/** The runtime's own session identifier (e.g. the SDK session UUID). */
+	nativeSessionId: string;
+	/** Absolute path to the runtime's native log (e.g. the Claude Code JSONL). */
+	nativeSessionPath: string;
+}
+
+/**
  * Session metadata stored in meta.json within each session directory.
  */
 export interface HabitatSessionMetadata {
@@ -402,6 +420,8 @@ export interface HabitatSessionMetadata {
 	agentId?: string;
 	/** Stable routing signature (e.g. `agent:my-agent:default` or `main`) for Discord. */
 	routeSignature?: string;
+	/** Link to the native runtime session for the most recent non-default run (#118). */
+	nativeSessionRef?: NativeSessionRef;
 	metadata?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
Closes #118. Parent PRD: #113 (packaged agents) — this is the foundational slice; it unblocks #122 (pi runtime runner).

## What this builds

The channel bridge's informal claude-sdk special case becomes a formal **RuntimeRunner seam**, and claude-sdk runs stop being observability black holes: every run now records *which* native session it created, so the full tool-call trace is reachable from the habitat session envelope.

- **`RuntimeRunner` / `RuntimeContext` / `RuntimeResult`** contracts in `packages/habitat/src/bridge/types.ts`, exactly the PRD shape. The bridge dispatches any non-default runtime through a runner registry (`runtimeRunners` option) — adding pi later means registering a runner, not touching the bridge, transcript writer, or A2A handler.
- **`ChannelRuntimeMode` widens to `'default' | 'claude-sdk' | 'pi'`**; routing coercion whitelists `pi`. A bound-but-unregistered runtime errors cleanly (`No runner registered for runtime "pi"`) instead of crashing.
- **Native session linkage**: `runClaudeSDK` extracts the SDK session id from the stream's `init` message; `createClaudeSdkRuntimeRunner` turns it into a `nativeSessionRef { runtime, nativeSessionId, nativeSessionPath }`. The bridge persists it into the session's `meta.json` (`HabitatSessionMetadata.nativeSessionRef`). The minimal user/assistant transcript pair is still written — now a summary alongside a link, not the only record.
- **`agent_ask_claude`** returns the same `nativeSessionRef` in its tool result, so delegated coding runs aren't blind spots.
- **Container config**: `Dockerfile` sets `CLAUDE_CONFIG_DIR=/data/claude-config`, so Claude Code's `projects/<cwd>/<session>.jsonl` traces land under the data volume (PRD session co-location). The runner only reads the env — it never invents paths.
- **Back-compat**: the legacy `runClaudeSdk` constructor option still works (wrapped into a runner, no ref recorded). `container-server` is upgraded to the new injection; the other two `ChannelBridge` constructors never injected claude-sdk and are unaffected.

## Tests

15 new unit tests, subprocess layer stubbed (injectable `queryFn` / `runFn`); full suite **1319 passed**, lint 0 errors. Pre-existing tsc noise in `beat-replay.ts` / `gaia/fnox.ts` is untouched (present on main).

- `claude-sdk-runner.test.ts` — init-message session-id extraction (success, error, and no-init paths), Claude Code cwd→dash path encoding, `CLAUDE_CONFIG_DIR` override + `~/.claude` fallback, runner adapter ref construction, progress→bridge-event wiring.
- `bridge/channel-bridge-runtime.test.ts` — dispatch through a registered runner with full `RuntimeContext`, `nativeSessionRef` persisted to metadata (and skipped when absent), envelope transcript written, missing-runner error, legacy injection wrap, pi routing coercion.

## Acceptance criteria from #118, with validation steps

**1. Bridge dispatches non-default runtimes through the RuntimeRunner contract; runtime mode type accommodates a future pi mode.**
```bash
npx vitest run packages/habitat/src/bridge/channel-bridge-runtime.test.ts
grep -n "'default' | 'claude-sdk' | 'pi'" packages/habitat/src/bridge/types.ts
```

**2. claude-sdk runs record nativeSessionRef (runtime, native session id, native log path) in session metadata.**
```bash
npx vitest run packages/habitat/src/bridge/channel-bridge-runtime.test.ts -t "persists nativeSessionRef"
```
Live demo (needs ANTHROPIC_API_KEY): start `dotenvx run -- pnpm run cli habitat serve`, bind a channel to claude-sdk (`/switch-claude <agent>` from chat, or set `routing.json`: `{"channels": {"web:demo": {"agentId": "<agent>", "runtime": "claude-sdk"}}}`), send a task, then inspect the session's `meta.json` — it contains `nativeSessionRef` whose `nativeSessionPath` is a complete Claude Code JSONL trace.

**3. Claude Code logs land under the data volume in the container image configuration.**
```bash
grep -n CLAUDE_CONFIG_DIR packages/habitat/Dockerfile
npx vitest run packages/habitat/src/claude-sdk-runner.test.ts -t "CLAUDE_CONFIG_DIR"
```

**4. agent_ask_claude runs get the same linkage.**
```bash
grep -n -A8 "nativeSessionRef" packages/habitat/src/tools/agent-runner/ask-claude.ts
```

**5. Unit tests: init-message session-id extraction and metadata persistence with the subprocess layer stubbed.**
```bash
npx vitest run packages/habitat/src/claude-sdk-runner.test.ts packages/habitat/src/bridge/channel-bridge-runtime.test.ts
```

**6. `pnpm test:run` passes; no token caps introduced.**
```bash
pnpm test:run   # 1319 passed
npx vitest run packages/core/src/cognition/request-options.test.ts   # cap regression tests untouched
```
No `maxTokens` / `maxOutputTokens` appears anywhere in this diff.

## Worth knowing / further work

- **The ref records the most recent non-default run** per session (meta.json merge semantics). If per-message granularity is ever needed, the transcript itself would need per-pair annotations — out of scope here and not required by the PRD.
- **Path computation vs. observation**: `nativeSessionPath` is computed from Claude Code's documented `projects/` dash-encoding convention rather than globbed from disk. The encoding is lossy by design (#109); the read side already prefers the JSONL's own `cwd` field, and the session id makes the filename unambiguous.
- **The legacy `runClaudeSdk` option records no ref** (the old callback shape has no session id). Both remaining non-container callers never injected it, so nothing regresses; the option can be deleted once external callers are confirmed clear.
- **`/switch-pi` command + pi runner** are deliberately not here — that's #122, which this unblocks. Binding a channel to `pi` today yields a clean "no runner registered" error.
- **Live end-to-end demo** (criterion 2) needs a real ANTHROPIC_API_KEY claude-sdk run — done as a unit-level simulation here; worth one human run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)