### PR TITLE
feat(habitat): context retrieval routes — GET /api/contexts/:contextId (+ /transcript) (#116)

### DIFF
--- a/packages/habitat/src/context-resolver.test.ts
+++ b/packages/habitat/src/context-resolver.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveContextSession } from './context-resolver.js';
+
+function userLine(content: string): string {
+  return (
+    JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content },
+      timestamp: '2026-06-10T12:00:00.000Z',
+      uuid: `u-${content}`,
+    }) + '\n'
+  );
+}
+
+function assistantLine(content: string): string {
+  return (
+    JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content },
+      timestamp: '2026-06-10T12:00:01.000Z',
+      uuid: `a-${content}`,
+    }) + '\n'
+  );
+}
+
+async function writeSession(
+  sessionsDir: string,
+  contextId: string,
+  opts: {
+    meta?: Record<string, unknown> | null;
+    transcript?: string;
+  } = {},
+): Promise<string> {
+  const dir = join(sessionsDir, contextId);
+  await mkdir(dir, { recursive: true });
+  const meta =
+    opts.meta === undefined
+      ? {
+          sessionId: contextId,
+          created: '2026-06-10T11:00:00.000Z',
+          lastUsed: '2026-06-10T12:00:00.000Z',
+          type: 'a2a',
+        }
+      : opts.meta;
+  if (meta !== null) {
+    await writeFile(join(dir, 'meta.json'), JSON.stringify(meta, null, 2), 'utf-8');
+  }
+  if (opts.transcript !== undefined) {
+    await writeFile(join(dir, 'transcript.jsonl'), opts.transcript, 'utf-8');
+  }
+  return dir;
+}
+
+describe('resolveContextSession', () => {
+  let sessionsDir: string;
+
+  beforeEach(async () => {
+    sessionsDir = await mkdtemp(join(tmpdir(), 'umwl-ctx-'));
+  });
+
+  afterEach(async () => {
+    await rm(sessionsDir, { recursive: true, force: true });
+  });
+
+  it('resolves an existing a2a session by contextId', async () => {
+    const dir = await writeSession(sessionsDir, 'ctx-abc', {
+      transcript: userLine('hello') + assistantLine('hi there'),
+    });
+
+    const resolved = await resolveContextSession(sessionsDir, 'ctx-abc');
+    expect(resolved).not.toBeNull();
+    expect(resolved?.contextId).toBe('ctx-abc');
+    expect(resolved?.sessionDir).toBe(dir);
+    expect(resolved?.metadata?.sessionId).toBe('ctx-abc');
+    expect(resolved?.metadata?.type).toBe('a2a');
+    expect(resolved?.transcriptReadPaths).toEqual([join(dir, 'transcript.jsonl')]);
+    expect(resolved?.nativeSessionRef).toBeUndefined();
+  });
+
+  it('orders frozen segments before the live transcript', async () => {
+    const dir = await writeSession(sessionsDir, 'ctx-seg', {
+      transcript: userLine('live'),
+    });
+    await writeFile(
+      join(dir, 'transcript.2026-06-01T00-00-00.000Z.jsonl'),
+      userLine('old'),
+      'utf-8',
+    );
+
+    const resolved = await resolveContextSession(sessionsDir, 'ctx-seg');
+    expect(resolved?.transcriptReadPaths.map((p) => p.split('/').pop())).toEqual([
+      'transcript.2026-06-01T00-00-00.000Z.jsonl',
+      'transcript.jsonl',
+    ]);
+  });
+
+  it('returns null for an unknown contextId', async () => {
+    expect(await resolveContextSession(sessionsDir, 'nope')).toBeNull();
+  });
+
+  it('returns null for an empty directory (no meta, no transcript)', async () => {
+    await mkdir(join(sessionsDir, 'ctx-empty'), { recursive: true });
+    expect(await resolveContextSession(sessionsDir, 'ctx-empty')).toBeNull();
+  });
+
+  it('rejects path-traversal contextIds without touching the filesystem', async () => {
+    await writeSession(sessionsDir, 'ctx-real', { transcript: userLine('x') });
+    for (const evil of ['..', '.', '../ctx-real', 'a/b', 'a\\b', '', 'ctx\0id']) {
+      expect(await resolveContextSession(sessionsDir, evil)).toBeNull();
+    }
+  });
+
+  it('still resolves when meta.json is missing but a transcript exists', async () => {
+    await writeSession(sessionsDir, 'ctx-nometa', {
+      meta: null,
+      transcript: userLine('hello'),
+    });
+    const resolved = await resolveContextSession(sessionsDir, 'ctx-nometa');
+    expect(resolved).not.toBeNull();
+    expect(resolved?.metadata).toBeNull();
+    expect(resolved?.transcriptReadPaths.length).toBe(1);
+  });
+
+  it('surfaces a top-level nativeSessionRef from meta.json', async () => {
+    const ref = {
+      runtime: 'claude-sdk',
+      nativeSessionId: 'sdk-123',
+      nativeSessionPath: '/data/claude/projects/x/sdk-123.jsonl',
+    };
+    await writeSession(sessionsDir, 'ctx-native', {
+      meta: {
+        sessionId: 'ctx-native',
+        created: '2026-06-10T11:00:00.000Z',
+        lastUsed: '2026-06-10T12:00:00.000Z',
+        type: 'a2a',
+        nativeSessionRef: ref,
+      },
+      transcript: userLine('hello'),
+    });
+    const resolved = await resolveContextSession(sessionsDir, 'ctx-native');
+    expect(resolved?.nativeSessionRef).toEqual(ref);
+  });
+
+  it('surfaces a nativeSessionRef nested under the metadata record', async () => {
+    const ref = {
+      runtime: 'pi',
+      nativeSessionId: 'pi-9',
+      nativeSessionPath: '/data/pi/sessions/pi-9',
+    };
+    await writeSession(sessionsDir, 'ctx-nested', {
+      meta: {
+        sessionId: 'ctx-nested',
+        created: '2026-06-10T11:00:00.000Z',
+        lastUsed: '2026-06-10T12:00:00.000Z',
+        type: 'a2a',
+        metadata: { nativeSessionRef: ref },
+      },
+      transcript: userLine('hello'),
+    });
+    const resolved = await resolveContextSession(sessionsDir, 'ctx-nested');
+    expect(resolved?.nativeSessionRef).toEqual(ref);
+  });
+
+  it('ignores a malformed nativeSessionRef', async () => {
+    await writeSession(sessionsDir, 'ctx-bad', {
+      meta: {
+        sessionId: 'ctx-bad',
+        created: '2026-06-10T11:00:00.000Z',
+        lastUsed: '2026-06-10T12:00:00.000Z',
+        type: 'a2a',
+        nativeSessionRef: 'not-an-object',
+      },
+      transcript: userLine('hello'),
+    });
+    const resolved = await resolveContextSession(sessionsDir, 'ctx-bad');
+    expect(resolved).not.toBeNull();
+    expect(resolved?.nativeSessionRef).toBeUndefined();
+  });
+
+  it('treats unparseable meta.json as missing metadata, not an error', async () => {
+    const dir = join(sessionsDir, 'ctx-garbage');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'meta.json'), '{ not json', 'utf-8');
+    await writeFile(join(dir, 'transcript.jsonl'), userLine('hello'), 'utf-8');
+    const resolved = await resolveContextSession(sessionsDir, 'ctx-garbage');
+    expect(resolved).not.toBeNull();
+    expect(resolved?.metadata).toBeNull();
+  });
+});

--- a/packages/habitat/src/context-resolver.ts
+++ b/packages/habitat/src/context-resolver.ts
@@ -1,0 +1,110 @@
+/**
+ * Resolve an A2A contextId to its Source Session on disk.
+ *
+ * A2A conversations key their habitat session by the channel-key convention
+ * `a2a:${contextId}` (a2a-handler.ts), which the session manager maps to a
+ * session directory named exactly `contextId`. This module exposes that
+ * mapping as a pure function over (sessionsDir, contextId) so the HTTP
+ * routes — and anything else — can resolve a conversation without a server.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { listHabitatTranscriptReadPaths } from '@umwelten/core/session-record/transcript-segments.js';
+import type { HabitatSessionMetadata } from './types.js';
+
+/**
+ * Link to a native runtime's own session log (claude-sdk, pi), recorded in
+ * the habitat session metadata by non-default runtimes. Read structurally
+ * here because the writing side lands separately (issue #118).
+ */
+export interface NativeSessionRef {
+  runtime: string;
+  nativeSessionId: string;
+  nativeSessionPath: string;
+}
+
+export interface ResolvedContext {
+  contextId: string;
+  sessionDir: string;
+  /** Parsed meta.json, or null when missing/unreadable. */
+  metadata: HabitatSessionMetadata | null;
+  /** Frozen segments in order, then the live transcript. */
+  transcriptReadPaths: string[];
+  nativeSessionRef?: NativeSessionRef;
+}
+
+/**
+ * contextIds become path segments; reject anything that could escape the
+ * sessions directory before any filesystem access happens.
+ */
+function isSafeContextId(contextId: string): boolean {
+  if (!contextId) return false;
+  if (contextId === '.' || contextId === '..') return false;
+  if (/[/\\\0]/.test(contextId)) return false;
+  return true;
+}
+
+function asNativeSessionRef(value: unknown): NativeSessionRef | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const ref = value as Record<string, unknown>;
+  if (
+    typeof ref.runtime === 'string' &&
+    typeof ref.nativeSessionId === 'string' &&
+    typeof ref.nativeSessionPath === 'string'
+  ) {
+    return {
+      runtime: ref.runtime,
+      nativeSessionId: ref.nativeSessionId,
+      nativeSessionPath: ref.nativeSessionPath,
+    };
+  }
+  return undefined;
+}
+
+function extractNativeSessionRef(
+  metadata: HabitatSessionMetadata | null,
+): NativeSessionRef | undefined {
+  if (!metadata) return undefined;
+  const meta = metadata as unknown as Record<string, unknown>;
+  return (
+    asNativeSessionRef(meta.nativeSessionRef) ??
+    asNativeSessionRef(
+      (meta.metadata as Record<string, unknown> | undefined)?.nativeSessionRef,
+    )
+  );
+}
+
+/**
+ * Resolve (sessionsDir, contextId) → session, or null when the contextId is
+ * unsafe or no session exists for it. A directory counts as a session when it
+ * has a readable meta.json or at least one transcript segment.
+ */
+export async function resolveContextSession(
+  sessionsDir: string,
+  contextId: string,
+): Promise<ResolvedContext | null> {
+  if (!isSafeContextId(contextId)) return null;
+
+  const sessionDir = join(sessionsDir, contextId);
+
+  let metadata: HabitatSessionMetadata | null;
+  try {
+    metadata = JSON.parse(
+      await readFile(join(sessionDir, 'meta.json'), 'utf-8'),
+    ) as HabitatSessionMetadata;
+  } catch {
+    metadata = null;
+  }
+
+  const transcriptReadPaths = await listHabitatTranscriptReadPaths(sessionDir);
+  if (!metadata && transcriptReadPaths.length === 0) return null;
+
+  return {
+    contextId,
+    sessionDir,
+    metadata,
+    transcriptReadPaths,
+    nativeSessionRef: extractNativeSessionRef(metadata),
+  };
+}

--- a/packages/habitat/src/index.ts
+++ b/packages/habitat/src/index.ts
@@ -79,6 +79,10 @@ export {
 export { HabitatSessionManager } from "./session-manager.js";
 export type { SessionManagerSessionOptions } from "./session-manager.js";
 
+// ── Context retrieval (A2A contextId → Source Session) ──────────────────
+export { resolveContextSession } from "./context-resolver.js";
+export type { ResolvedContext, NativeSessionRef } from "./context-resolver.js";
+
 // ── Discord ─────────────────────────────────────────────────────────────
 // Discord channel → agent routing was unified with the platform-agnostic
 // bridge/routing.ts in Wave E. Use loadRouting / saveRouting / setChannelRoute

--- a/packages/habitat/src/tools/gaia/proxy-target.test.ts
+++ b/packages/habitat/src/tools/gaia/proxy-target.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { resolveProxyTarget } from './routes.js';
+
+describe('resolveProxyTarget', () => {
+  it('maps the contexts metadata route through to the container', () => {
+    expect(resolveProxyTarget('/api/habitats/h1/contexts/ctx-abc')).toEqual({
+      id: 'h1',
+      targetPath: '/api/contexts/ctx-abc',
+    });
+  });
+
+  it('maps the contexts transcript route through to the container', () => {
+    expect(
+      resolveProxyTarget('/api/habitats/h1/contexts/ctx-abc/transcript'),
+    ).toEqual({
+      id: 'h1',
+      targetPath: '/api/contexts/ctx-abc/transcript',
+    });
+  });
+
+  it('keeps the existing static mappings', () => {
+    expect(resolveProxyTarget('/api/habitats/h2/artifacts')).toEqual({
+      id: 'h2',
+      targetPath: '/api/artifacts',
+    });
+    expect(resolveProxyTarget('/api/habitats/h2/agent-card')).toEqual({
+      id: 'h2',
+      targetPath: '/.well-known/agent-card.json',
+    });
+  });
+
+  it('keeps the files wildcard mapping', () => {
+    expect(resolveProxyTarget('/api/habitats/h3/files/a/b.txt')).toEqual({
+      id: 'h3',
+      targetPath: '/files/a/b.txt',
+    });
+  });
+
+  it('forwards an empty wildcard remainder as-is (parity with /files/*)', () => {
+    expect(resolveProxyTarget('/api/habitats/h1/contexts')).toEqual({
+      id: 'h1',
+      targetPath: '/api/contexts/',
+    });
+  });
+
+  it('returns null for non-proxied paths', () => {
+    expect(resolveProxyTarget('/api/habitats/h1/logs')).toBeNull();
+    expect(resolveProxyTarget('/api/secrets')).toBeNull();
+  });
+});

--- a/packages/habitat/src/tools/gaia/routes.ts
+++ b/packages/habitat/src/tools/gaia/routes.ts
@@ -100,6 +100,44 @@ function sendJson(res: ServerResponse, data: unknown, status = 200): void {
 	res.end(JSON.stringify(data));
 }
 
+/**
+ * Proxy allowlist: /api/habitats/:id/<route> → path on the container.
+ * Wildcard patterns (`/*`) append the remainder to the target.
+ */
+const PROXY_ROUTES: Array<{ pattern: string; target: string }> = [
+	{ pattern: "/api/habitats/:id/health", target: "/health" },
+	{ pattern: "/api/habitats/:id/chat", target: "/api/chat" },
+	{ pattern: "/api/habitats/:id/mcp", target: "/mcp" },
+	{ pattern: "/api/habitats/:id/a2a", target: "/a2a" },
+	{
+		pattern: "/api/habitats/:id/agent-card",
+		target: "/.well-known/agent-card.json",
+	},
+	{ pattern: "/api/habitats/:id/status", target: "/api/status" },
+	{ pattern: "/api/habitats/:id/sessions", target: "/api/sessions" },
+	{ pattern: "/api/habitats/:id/artifacts", target: "/api/artifacts" },
+	{ pattern: "/api/habitats/:id/contexts/*", target: "/api/contexts/" },
+	{ pattern: "/api/habitats/:id/files/*", target: "/files/" },
+];
+
+/**
+ * Pure mapping from an incoming Gaia path to the habitat entry id and the
+ * container-side target path, or null when the path is not proxied.
+ */
+export function resolveProxyTarget(
+	path: string,
+): { id: string; targetPath: string } | null {
+	for (const route of PROXY_ROUTES) {
+		const params = matchRoute(route.pattern, path);
+		if (!params) continue;
+		const targetPath = route.pattern.endsWith("/*")
+			? `${route.target}${params["*"] ?? ""}`
+			: route.target;
+		return { id: params.id, targetPath };
+	}
+	return null;
+}
+
 function readBody(req: IncomingMessage): Promise<string> {
 	return new Promise((resolve, reject) => {
 		let data = "";
@@ -277,36 +315,15 @@ export async function handleGaiaRoute(
 	// ── Proxy to running containers ──────────────────────────────
 
 	// Map /api/habitats/:id/<target> → /<targetPath> on container
-	const proxyRoutes: Array<{ pattern: string; target: string }> = [
-		{ pattern: "/api/habitats/:id/health", target: "/health" },
-		{ pattern: "/api/habitats/:id/chat", target: "/api/chat" },
-		{ pattern: "/api/habitats/:id/mcp", target: "/mcp" },
-		{ pattern: "/api/habitats/:id/a2a", target: "/a2a" },
-		{
-			pattern: "/api/habitats/:id/agent-card",
-			target: "/.well-known/agent-card.json",
-		},
-		{ pattern: "/api/habitats/:id/status", target: "/api/status" },
-		{ pattern: "/api/habitats/:id/sessions", target: "/api/sessions" },
-		{ pattern: "/api/habitats/:id/artifacts", target: "/api/artifacts" },
-		{ pattern: "/api/habitats/:id/files/*", target: "/files/" },
-	];
-
-	for (const route of proxyRoutes) {
-		params = matchRoute(route.pattern, path);
-		if (params) {
-			const entry = ctx.registry.get(params.id);
-			if (!entry) {
-				sendJson(res, { error: "Not found" }, 404);
-				return true;
-			}
-			const targetPath =
-				route.target === "/files/"
-					? `/files/${params["*"] ?? ""}`
-					: route.target;
-			await proxyRequest(entry, targetPath, req, res);
+	const proxied = resolveProxyTarget(path);
+	if (proxied) {
+		const entry = ctx.registry.get(proxied.id);
+		if (!entry) {
+			sendJson(res, { error: "Not found" }, 404);
 			return true;
 		}
+		await proxyRequest(entry, proxied.targetPath, req, res);
+		return true;
 	}
 
 	// ── Master secrets ───────────────────────────────────────────

--- a/packages/habitat/src/web/routes/contexts.test.ts
+++ b/packages/habitat/src/web/routes/contexts.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { contextShowRoute, contextTranscriptRoute } from './contexts.js';
+import { defaultRoutes } from './index.js';
+import type { RouteContext } from '../types.js';
+
+function userLine(content: string): string {
+  return (
+    JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content },
+      timestamp: '2026-06-10T12:00:00.000Z',
+      uuid: `u-${content}`,
+    }) + '\n'
+  );
+}
+
+function assistantLine(content: string): string {
+  return (
+    JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content },
+      timestamp: '2026-06-10T12:00:01.000Z',
+      uuid: `a-${content}`,
+    }) + '\n'
+  );
+}
+
+interface FakeRes {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+function fakeCtx(sessionsDir: string): { ctx: RouteContext; res: FakeRes } {
+  const res: FakeRes = { status: 0, headers: {}, body: '' };
+  const ctx = {
+    habitat: { getSessionsDir: () => sessionsDir },
+    bridge: {},
+    user: { userId: 'test-user' },
+    req: {},
+    res: {
+      writeHead(status: number, headers?: Record<string, string>) {
+        res.status = status;
+        if (headers) res.headers = { ...res.headers, ...headers };
+        return this;
+      },
+      end(chunk?: string) {
+        if (chunk) res.body += chunk;
+      },
+    },
+    path: '',
+    query: {},
+  } as unknown as RouteContext;
+  return { ctx, res };
+}
+
+describe('context routes', () => {
+  let sessionsDir: string;
+
+  beforeEach(async () => {
+    sessionsDir = await mkdtemp(join(tmpdir(), 'umwl-ctxroute-'));
+  });
+
+  afterEach(async () => {
+    await rm(sessionsDir, { recursive: true, force: true });
+  });
+
+  async function seedSession(
+    contextId: string,
+    extraMeta: Record<string, unknown> = {},
+  ): Promise<string> {
+    const dir = join(sessionsDir, contextId);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, 'meta.json'),
+      JSON.stringify({
+        sessionId: contextId,
+        created: '2026-06-10T11:00:00.000Z',
+        lastUsed: '2026-06-10T12:00:00.000Z',
+        type: 'a2a',
+        ...extraMeta,
+      }),
+      'utf-8',
+    );
+    await writeFile(
+      join(dir, 'transcript.jsonl'),
+      userLine('hello') + assistantLine('hi there'),
+      'utf-8',
+    );
+    return dir;
+  }
+
+  describe('GET /api/contexts/:contextId', () => {
+    it('returns metadata and normalized messages', async () => {
+      await seedSession('ctx-1');
+      const { ctx, res } = fakeCtx(sessionsDir);
+
+      await contextShowRoute.handle(ctx, { contextId: 'ctx-1' });
+
+      expect(res.status).toBe(200);
+      expect(res.headers['Content-Type']).toContain('application/json');
+      const body = JSON.parse(res.body);
+      expect(body.contextId).toBe('ctx-1');
+      expect(body.sessionId).toBe('ctx-1');
+      expect(body.type).toBe('a2a');
+      expect(body.created).toBe('2026-06-10T11:00:00.000Z');
+      expect(body.lastUsed).toBe('2026-06-10T12:00:00.000Z');
+      expect(body.messageCount).toBe(2);
+      expect(body.messages).toHaveLength(2);
+      expect(body.messages[0]).toMatchObject({ role: 'user', content: 'hello' });
+      expect(body.messages[1]).toMatchObject({
+        role: 'assistant',
+        content: 'hi there',
+      });
+      expect(body.nativeSessionRef).toBeUndefined();
+    });
+
+    it('includes nativeSessionRef when the session has one', async () => {
+      const ref = {
+        runtime: 'claude-sdk',
+        nativeSessionId: 'sdk-42',
+        nativeSessionPath: '/data/claude/projects/p/sdk-42.jsonl',
+      };
+      await seedSession('ctx-native', { nativeSessionRef: ref });
+      const { ctx, res } = fakeCtx(sessionsDir);
+
+      await contextShowRoute.handle(ctx, { contextId: 'ctx-native' });
+
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body).nativeSessionRef).toEqual(ref);
+    });
+
+    it('404s on an unknown contextId', async () => {
+      const { ctx, res } = fakeCtx(sessionsDir);
+      await contextShowRoute.handle(ctx, { contextId: 'missing' });
+      expect(res.status).toBe(404);
+      expect(JSON.parse(res.body).error).toBeTruthy();
+    });
+
+    it('404s on a traversal contextId', async () => {
+      await seedSession('ctx-1');
+      const { ctx, res } = fakeCtx(sessionsDir);
+      await contextShowRoute.handle(ctx, { contextId: '../ctx-1' });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('GET /api/contexts/:contextId/transcript', () => {
+    it('returns the raw transcript JSONL', async () => {
+      await seedSession('ctx-1');
+      const { ctx, res } = fakeCtx(sessionsDir);
+
+      await contextTranscriptRoute.handle(ctx, { contextId: 'ctx-1' });
+
+      expect(res.status).toBe(200);
+      expect(res.headers['Content-Type']).toBe('application/x-ndjson');
+      const lines = res.body.split('\n').filter((l) => l.trim());
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0]).message.content).toBe('hello');
+      expect(JSON.parse(lines[1]).message.content).toBe('hi there');
+    });
+
+    it('concatenates frozen segments before the live transcript', async () => {
+      const dir = await seedSession('ctx-seg');
+      await writeFile(
+        join(dir, 'transcript.2026-06-01T00-00-00.000Z.jsonl'),
+        userLine('frozen-first'),
+        'utf-8',
+      );
+      const { ctx, res } = fakeCtx(sessionsDir);
+
+      await contextTranscriptRoute.handle(ctx, { contextId: 'ctx-seg' });
+
+      const lines = res.body.split('\n').filter((l) => l.trim());
+      expect(lines).toHaveLength(3);
+      expect(JSON.parse(lines[0]).message.content).toBe('frozen-first');
+      expect(JSON.parse(lines[2]).message.content).toBe('hi there');
+    });
+
+    it('404s on an unknown contextId', async () => {
+      const { ctx, res } = fakeCtx(sessionsDir);
+      await contextTranscriptRoute.handle(ctx, { contextId: 'missing' });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('registration and auth gating', () => {
+    it('both routes are GET and bearer-gated (no skipAuth)', () => {
+      for (const route of [contextShowRoute, contextTranscriptRoute]) {
+        expect(route.method).toBe('GET');
+        expect(route.skipAuth).toBeFalsy();
+      }
+    });
+
+    it('defaultRoutes registers transcript before show so :contextId does not swallow it', () => {
+      const paths = defaultRoutes().map((r) => r.path);
+      const transcriptIdx = paths.indexOf('/api/contexts/:contextId/transcript');
+      const showIdx = paths.indexOf('/api/contexts/:contextId');
+      expect(transcriptIdx).toBeGreaterThanOrEqual(0);
+      expect(showIdx).toBeGreaterThanOrEqual(0);
+      expect(transcriptIdx).toBeLessThan(showIdx);
+    });
+  });
+});

--- a/packages/habitat/src/web/routes/contexts.ts
+++ b/packages/habitat/src/web/routes/contexts.ts
@@ -1,0 +1,83 @@
+/**
+ * Context retrieval routes — fetch an A2A conversation by its contextId.
+ *
+ * A2A defines no history-retrieval method, so these are extensions alongside
+ * the protocol, same posture as the artifacts routes. Resolution is the pure
+ * resolver in context-resolver.ts; these handlers only add HTTP concerns.
+ * Bearer gating comes from the shared registered-routes dispatch (neither
+ * route sets skipAuth).
+ */
+
+import { readFile } from 'node:fs/promises';
+import type { RouteHandler } from '../types.js';
+import { resolveContextSession } from '../../context-resolver.js';
+import { loadHabitatSessionTranscriptMessages } from '@umwelten/core/session-record/habitat-transcript-load.js';
+import { sessionMessagesToNormalized } from '@umwelten/core/interaction/persistence/session-parser.js';
+
+function json(res: any, data: unknown, status = 200) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+function notFound(res: any, contextId: string) {
+  json(res, { error: `Context "${contextId}" not found` }, 404);
+}
+
+/** GET /api/contexts/:contextId — session metadata + normalized messages. */
+export const contextShowRoute: RouteHandler = {
+  method: 'GET',
+  path: '/api/contexts/:contextId',
+  async handle(ctx, params) {
+    const resolved = await resolveContextSession(
+      ctx.habitat.getSessionsDir(),
+      params.contextId,
+    );
+    if (!resolved) return notFound(ctx.res, params.contextId);
+
+    const raw = await loadHabitatSessionTranscriptMessages(resolved.sessionDir);
+    const messages = sessionMessagesToNormalized(raw);
+
+    json(ctx.res, {
+      contextId: resolved.contextId,
+      sessionId: resolved.metadata?.sessionId ?? resolved.contextId,
+      type: resolved.metadata?.type ?? null,
+      created: resolved.metadata?.created ?? null,
+      lastUsed: resolved.metadata?.lastUsed ?? null,
+      agentId: resolved.metadata?.agentId,
+      messageCount: messages.length,
+      messages,
+      ...(resolved.nativeSessionRef && {
+        nativeSessionRef: resolved.nativeSessionRef,
+      }),
+    });
+  },
+};
+
+/** GET /api/contexts/:contextId/transcript — raw transcript JSONL. */
+export const contextTranscriptRoute: RouteHandler = {
+  method: 'GET',
+  path: '/api/contexts/:contextId/transcript',
+  async handle(ctx, params) {
+    const resolved = await resolveContextSession(
+      ctx.habitat.getSessionsDir(),
+      params.contextId,
+    );
+    if (!resolved) return notFound(ctx.res, params.contextId);
+
+    let body = '';
+    for (const path of resolved.transcriptReadPaths) {
+      try {
+        const chunk = await readFile(path, 'utf-8');
+        body += chunk.endsWith('\n') || chunk === '' ? chunk : `${chunk}\n`;
+      } catch {
+        // segment vanished between listing and read — skip
+      }
+    }
+
+    ctx.res.writeHead(200, {
+      'Content-Type': 'application/x-ndjson',
+      'Cache-Control': 'no-cache',
+    });
+    ctx.res.end(body);
+  },
+};

--- a/packages/habitat/src/web/routes/index.ts
+++ b/packages/habitat/src/web/routes/index.ts
@@ -8,6 +8,7 @@ import {
   sessionMessagesRoute,
   sessionBeatsRoute,
 } from './sessions.js';
+import { contextShowRoute, contextTranscriptRoute } from './contexts.js';
 
 /**
  * The default route set every web app gets for free.
@@ -24,5 +25,7 @@ export function defaultRoutes(): RouteHandler[] {
     sessionMessagesRoute,
     sessionBeatsRoute,
     sessionShowRoute,
+    contextTranscriptRoute,
+    contextShowRoute,
   ];
 }

--- a/reports/2026-06-10-context-retrieval-routes.md
+++ b/reports/2026-06-10-context-retrieval-routes.md
@@ -1,0 +1,81 @@
+# Context retrieval routes — codebase research (issue #116)
+
+Date: 2026-06-10. Scope: everything needed to expose `GET /api/contexts/{contextId}`
+and `GET /api/contexts/{contextId}/transcript` on the habitat container server,
+proxied by Gaia. No new external libraries are introduced; prior tech reports
+(`2026-05-04-a2a-mcp-skills-implementation.md`, `2026-05-07-acp-a2a-mcp-agent-protocols.md`,
+`2026-05-22-jsonl-persistence-nodejs.md`) cover A2A and JSONL persistence.
+
+## contextId → session mapping (the channel-key convention)
+
+- `packages/habitat/src/a2a-handler.ts:123` — every A2A message uses
+  `channelKey = \`a2a:${contextId}\``.
+- `packages/habitat/src/bridge/channel-bridge.ts:354-359` — splits the key into
+  platform `a2a` and identifier `contextId`, then calls
+  `host.getOrCreateSession('a2a', contextId)`.
+- `packages/habitat/src/session-manager.ts` (generic branch, ~line 150) — for
+  non-discord/telegram/cli types, `sessionId = String(identifier)`.
+
+**Therefore the session directory for a contextId is exactly
+`{sessionsDir}/{contextId}/`.** The resolver is a pure function over that.
+
+## Session directory layout
+
+- `meta.json` — `HabitatSessionMetadata` (`packages/habitat/src/types.ts:387-406`):
+  `sessionId`, `created`, `lastUsed`, `type`, optional `agentId`, `routeSignature`,
+  extensible `metadata` record. `nativeSessionRef` does **not** exist yet — issue
+  #118 adds it concurrently, so this slice reads it structurally (top-level or
+  under `metadata`) instead of changing the shared type.
+- Transcript: live `transcript.jsonl` plus frozen segments
+  `transcript.<ISO>.jsonl`, ordered by
+  `listHabitatTranscriptReadPaths()` (`packages/core/src/session-record/transcript-segments.ts`).
+- Message loading: `loadHabitatSessionTranscriptMessages(sessionDir)`
+  (`packages/core/src/session-record/habitat-transcript-load.ts`) reads all
+  segments, skips compaction markers. Normalization:
+  `sessionMessagesToNormalized()`
+  (`packages/core/src/interaction/persistence/session-parser.ts:497`).
+
+## Container server routing + auth
+
+- `packages/habitat/src/container-server.ts:242` — `const routes = defaultRoutes()`
+  from `packages/habitat/src/web/routes/index.ts`; dispatched in the
+  "Registered routes" loop (~line 980) which **applies bearer auth automatically**
+  when `HABITAT_API_KEY` is set and the route doesn't set `skipAuth`.
+- Bearer auth: `packages/habitat/src/web/auth/bearer-auth.ts` — parses
+  `Authorization: Bearer <token>`, 401 `{ error: "Unauthorized" }` on mismatch.
+- Route handler shape: `RouteHandler { method, path (':param' segments), handle(ctx, params), skipAuth? }`
+  (`packages/habitat/src/web/types.ts:63-70`). Prior art:
+  `packages/habitat/src/web/routes/sessions.ts`.
+
+So: registering the two contexts routes in `defaultRoutes()` gives us dispatch,
+`:contextId` extraction, and bearer gating for free.
+
+## Gaia proxy
+
+- `packages/habitat/src/tools/gaia/routes.ts:280-310` — explicit `proxyRoutes`
+  allowlist; nothing is forwarded automatically. Wildcard support exists
+  (`/api/habitats/:id/files/*` → `/files/` + remainder). `proxyRequest()`
+  (`tools/gaia/proxy.ts`) injects `Authorization: Bearer ${entry.apiKey}`.
+- Plan: add `{ pattern: "/api/habitats/:id/contexts/*", target: "/api/contexts/" }`
+  and generalize the wildcard target concatenation (currently special-cased to
+  `/files/`) into a pure exported helper so it's unit-testable.
+
+## Testing prior art
+
+- Fixture session dirs: `packages/habitat/src/adapters/habitat-session-adapter.test.ts`
+  (creates `meta.json` + `transcript.jsonl` in `mkdtemp` dirs) and
+  `packages/core/src/session-record/habitat-flow.test.ts` (frozen + live segments).
+- Handler-level tests without a real HTTP server:
+  `packages/habitat/src/web/WebAdapter.test.ts` — mock req (PassThrough +
+  headers) and res (accumulating writeHead/write/end object), call the handler
+  directly.
+- Gaia tests mock the exec layer (`gaia-tools-*.test.ts`) — no real Docker.
+
+## Risks / notes
+
+- Path traversal: `contextId` comes from the URL; the resolver must reject
+  separators and `..` before joining paths.
+- #118 lands `nativeSessionRef` concurrently — reading it structurally avoids a
+  merge conflict on `HabitatSessionMetadata`.
+- A2A defines no history-retrieval RPC; these routes are protocol-adjacent
+  extensions, same posture as `/api/artifacts`.


### PR DESCRIPTION
Closes #116. Parent PRD: #113.

## What this builds

Any A2A conversation is now retrievable by its `contextId` over HTTP, the same posture as the artifacts routes:

- **`GET /api/contexts/{contextId}`** → session metadata + normalized messages + `nativeSessionRef` when the session has one
- **`GET /api/contexts/{contextId}/transcript`** → raw transcript JSONL (`application/x-ndjson`), frozen segments concatenated in order before the live file

Three pieces:

- **Pure resolver** — `packages/habitat/src/context-resolver.ts`. A2A messages key their session as `a2a:${contextId}` (a2a-handler.ts), which the session manager maps to a directory named exactly `contextId`. `resolveContextSession(sessionsDir, contextId)` exposes that mapping with no server dependency. Rejects path-traversal contextIds (`..`, separators, NUL) before any filesystem access. Reads `nativeSessionRef` **structurally** (top-level or under `metadata`) rather than changing `HabitatSessionMetadata` — the writing side lands separately in #118, so this avoids a type-level merge conflict.
- **Routes** — `packages/habitat/src/web/routes/contexts.ts`, registered in `defaultRoutes()`. The container server's registered-routes dispatch applies bearer auth automatically when `HABITAT_API_KEY` is set (neither route sets `skipAuth`).
- **Gaia proxy** — `/api/habitats/:id/contexts/*` forwards to `/api/contexts/*` with token injection via the existing `proxyRequest()`. The proxy table is hoisted to a module const and the target computation extracted into a pure exported `resolveProxyTarget()` (the `/files/` special case is now the general wildcard rule — behavior preserved).

## Tests

25 new unit tests; full suite **1337 passed** (99 files), lint 0 errors.

- `packages/habitat/src/context-resolver.test.ts` — resolution, segment ordering, not-found, traversal rejection, missing/garbage meta.json resilience, nativeSessionRef (top-level, nested, malformed).
- `packages/habitat/src/web/routes/contexts.test.ts` — JSON shape, nativeSessionRef passthrough, 404s, raw JSONL shape + content type, segment concatenation order, auth-gating contract (no `skipAuth`), registration order.
- `packages/habitat/src/tools/gaia/proxy-target.test.ts` — contexts + transcript mapping, existing static/wildcard mappings preserved.

## Acceptance criteria from #116, with validation steps

**1. Context resolver is a pure function; unknown contextId returns a clean not-found (404 at the route).**
```bash
npx vitest run packages/habitat/src/context-resolver.test.ts
```
Live: `curl -s -o /dev/null -w '%{http_code}' -H 'Authorization: Bearer <key>' http://localhost:7430/api/contexts/does-not-exist` → `404`.

**2. Both routes require bearer auth when the API key is configured.**
```bash
HABITAT_API_KEY=test-key-123 dotenvx run -- pnpm run cli habitat serve --work-dir /tmp/ctx-demo --port 7431
curl -s http://localhost:7431/api/contexts/anything            # → {"error":"Unauthorized"} (401)
curl -s http://localhost:7431/api/contexts/anything/transcript # → {"error":"Unauthorized"} (401)
```
Also: the "registration and auth gating" tests in `contexts.test.ts`.

**3. Metadata route includes the nativeSessionRef field when the session has one.**
```bash
npx vitest run packages/habitat/src/web/routes/contexts.test.ts -t nativeSessionRef
```
(No writer exists yet — #118 lands it; the resolver reads it from `meta.json` top-level or nested under `metadata`.)

**4. Gaia proxy forwards the contexts routes with token injection.**
```bash
npx vitest run packages/habitat/src/tools/gaia/proxy-target.test.ts
```
`/api/habitats/:id/contexts/*` → `/api/contexts/*`; `proxyRequest()` injects `Authorization: Bearer ${entry.apiKey}` as for every proxied route.

**5. Unit tests: resolver over fixture session dirs; route auth gating; JSON and JSONL response shapes.** — the three test files above.

**6. `pnpm test:run` passes.** — 1337 passed.

## Verified live (the demo from the issue)

Chatted with a habitat over A2A using a contextId, then fetched the conversation back with the same contextId:

```bash
# 1. serve with a bearer key (openrouter model — see note below)
HABITAT_API_KEY=test-key-123 HABITAT_PROVIDER=openrouter HABITAT_MODEL=openai/gpt-4o-mini \
  dotenvx run -- pnpm run cli habitat serve --work-dir /tmp/ctx-demo --port 7431

# 2. A2A message with a fixed contextId
curl -s -X POST http://localhost:7431/a2a -H 'Authorization: Bearer test-key-123' \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"kind":"message","messageId":"m1","role":"user","parts":[{"kind":"text","text":"Reply with exactly: context routes work"}],"contextId":"ctx-demo-1"}}}'

# 3. fetch it back
curl -s -H 'Authorization: Bearer test-key-123' http://localhost:7431/api/contexts/ctx-demo-1
curl -s -H 'Authorization: Bearer test-key-123' http://localhost:7431/api/contexts/ctx-demo-1/transcript
```

Observed: metadata route returned `{contextId, sessionId, type: "a2a", created, lastUsed, messageCount: 2, messages: [...]}` with both turns; transcript route returned the two raw JSONL lines with `Content-Type: application/x-ndjson`; unknown contextId → 404; missing bearer → 401.

## Worth knowing / further work

- **gemini-3 over the native google provider is currently broken on main** (`Unsupported model version v3 ... AI SDK 5 only supports v2`) — unrelated to this PR; the `ai` v6 bump is open as #104. The live demo used openrouter instead.
- **Empty A2A sessions resolve with `messageCount: 0`**: the bridge only writes the transcript pair after a successful turn, but `meta.json` is written at session creation — so a failed first turn still yields a retrievable (empty) context. That seemed more useful than 404ing a conversation that exists.
- **`nativeSessionRef` in the route response is additive** — omitted entirely when absent, so #118 can land its writer without touching these routes. Surfacing linked native traces *as messages* (user story 14's full depth) stays with #118/#120.
- **Sessions with no `meta.json` but a transcript still resolve** (metadata fields null) — matches the known quirk that `createInteraction()` with an explicit sessionId doesn't write meta.json.
- The Gaia proxy wildcard rule is now general: any `/*` pattern appends its remainder to the target. `/files/` behavior is unchanged (covered by tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)