### PR TITLE
feat(gaia): per-entry Docker image for registry entries (#115)

### DIFF
--- a/packages/habitat/src/tools/gaia/docker-image.test.ts
+++ b/packages/habitat/src/tools/gaia/docker-image.test.ts
@@ -1,0 +1,135 @@
+/**
+ * DockerManager image-selection tests (#115) — exec layer mocked, no real
+ * Docker. Mock pattern follows fnox.test.ts: callback-based execFile mock
+ * compatible with util.promisify.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+type CallbackFn = (
+  error: Error | null,
+  result: { stdout: string; stderr: string },
+) => void;
+
+interface RecordedCall {
+  cmd: string;
+  args: string[];
+}
+
+let recordedCalls: RecordedCall[] = [];
+/** Image names that `docker image inspect` should report as present. */
+let existingImages: Set<string> = new Set();
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual('node:child_process');
+  return {
+    ...actual,
+    execFile: vi
+      .fn()
+      .mockImplementation(
+        (
+          cmd: string,
+          args?: string[] | CallbackFn,
+          options?: Record<string, unknown> | CallbackFn,
+          cb?: CallbackFn,
+        ) => {
+          let callback: CallbackFn | undefined;
+          if (typeof args === 'function') {
+            callback = args;
+          } else if (typeof options === 'function') {
+            callback = options;
+          } else {
+            callback = cb;
+          }
+          const argv = Array.isArray(args) ? args : [];
+          recordedCalls.push({ cmd, args: argv });
+          if (callback) {
+            if (argv[0] === 'image' && argv[1] === 'inspect') {
+              if (existingImages.has(argv[2])) {
+                callback(null, { stdout: '[]', stderr: '' });
+              } else {
+                callback(new Error(`No such image: ${argv[2]}`), {
+                  stdout: '',
+                  stderr: `Error: No such image: ${argv[2]}`,
+                });
+              }
+            } else {
+              callback(null, { stdout: '', stderr: '' });
+            }
+          }
+          return {} as never;
+        },
+      ),
+  };
+});
+
+import { DockerManager, DEFAULT_IMAGE_NAME } from './docker.js';
+import type { GaiaHabitatEntry } from './types.js';
+
+function makeEntry(overrides: Partial<GaiaHabitatEntry> = {}): GaiaHabitatEntry {
+  return {
+    id: 'test-hab',
+    name: 'Test Hab',
+    config: { name: 'Test Hab', agents: [] },
+    secretBindings: [],
+    apiKey: 'gaia_testkey',
+    createdAt: '2026-06-10T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function runCalls(): RecordedCall[] {
+  return recordedCalls.filter((c) => c.cmd === 'docker' && c.args[0] === 'run');
+}
+
+describe('DockerManager — per-entry image', () => {
+  let docker: DockerManager;
+
+  beforeEach(() => {
+    recordedCalls = [];
+    existingImages = new Set([DEFAULT_IMAGE_NAME]);
+    docker = new DockerManager('/tmp/gaia-data', '/tmp/project');
+  });
+
+  it('runs the default image when the entry has no image field', async () => {
+    const port = await docker.startContainer(makeEntry(), '', []);
+    expect(port).toBeGreaterThan(0);
+    const run = runCalls();
+    expect(run).toHaveLength(1);
+    expect(run[0].args[run[0].args.length - 1]).toBe(DEFAULT_IMAGE_NAME);
+  });
+
+  it('runs the entry image when set and present', async () => {
+    existingImages.add('habitat-coding');
+    await docker.startContainer(makeEntry({ image: 'habitat-coding' }), '', []);
+    const run = runCalls();
+    expect(run).toHaveLength(1);
+    expect(run[0].args[run[0].args.length - 1]).toBe('habitat-coding');
+  });
+
+  it('throws a clear error for a missing custom image — no silent fallback, no docker run', async () => {
+    await expect(
+      docker.startContainer(makeEntry({ image: 'ghost-image' }), '', []),
+    ).rejects.toThrow(/ghost-image.*test-hab|test-hab.*ghost-image/);
+    expect(runCalls()).toHaveLength(0);
+  });
+
+  it('preserves volume, network, port, and api-key wiring for custom images', async () => {
+    existingImages.add('habitat-coding');
+    await docker.startContainer(makeEntry({ image: 'habitat-coding' }), '', []);
+    const args = runCalls()[0].args;
+    expect(args).toContain('gaia-test-hab-data:/data');
+    expect(args).toContain('HABITAT_API_KEY=gaia_testkey');
+    expect(args.join(' ')).toContain('--network');
+  });
+
+  it('imageExists checks the given image, defaulting to the standard image', async () => {
+    existingImages = new Set(['habitat-coding']);
+    expect(await docker.imageExists('habitat-coding')).toBe(true);
+    expect(await docker.imageExists()).toBe(false); // default image absent
+    const inspected = recordedCalls
+      .filter((c) => c.args[0] === 'image' && c.args[1] === 'inspect')
+      .map((c) => c.args[2]);
+    expect(inspected).toEqual(['habitat-coding', DEFAULT_IMAGE_NAME]);
+  });
+});

--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -44,7 +44,8 @@ function spawnWithStdin(
 }
 
 const NETWORK_NAME = "gaia-net";
-const IMAGE_NAME = "habitat";
+/** Default image every habitat runs unless its registry entry says otherwise. */
+export const DEFAULT_IMAGE_NAME = "habitat";
 const CONTAINER_PREFIX = "gaia-";
 
 /** First port in the habitat container range. */
@@ -80,7 +81,7 @@ export class DockerManager {
   async buildImage(): Promise<string> {
     const { stdout, stderr } = await execFile(
       "docker",
-      ["build", "-t", IMAGE_NAME, "."],
+      ["build", "-t", DEFAULT_IMAGE_NAME, "."],
       { cwd: this.projectRoot, maxBuffer: 10 * 1024 * 1024 },
     );
     return stdout + stderr;
@@ -115,6 +116,16 @@ export class DockerManager {
     const name = containerName(entry.id);
     const volume = volumeName(entry.id);
 
+    // Per-entry image: a missing custom image is a hard error, never a
+    // silent fallback to the default.
+    const image = entry.image ?? DEFAULT_IMAGE_NAME;
+    if (entry.image && !(await this.imageExists(entry.image))) {
+      throw new Error(
+        `Image "${entry.image}" for habitat "${entry.id}" not found. ` +
+          `Build or pull it first — the Gaia build task only builds the default "${DEFAULT_IMAGE_NAME}" image.`,
+      );
+    }
+
     // Stop + remove if already exists
     await this.stopContainer(entry.id).catch(() => {});
 
@@ -128,7 +139,7 @@ export class DockerManager {
       "-v", `${volume}:/data`,
       "--env", `HABITAT_API_KEY=${entry.apiKey}`,
       "-p", `127.0.0.1:${hostPort}:8080`,
-      IMAGE_NAME,
+      image,
     ];
 
     await execFile("docker", args);
@@ -245,10 +256,10 @@ export class DockerManager {
     }
   }
 
-  /** Check if the habitat image exists. */
-  async imageExists(): Promise<boolean> {
+  /** Check if an image exists (default: the standard habitat image). */
+  async imageExists(image: string = DEFAULT_IMAGE_NAME): Promise<boolean> {
     try {
-      await execFile("docker", ["image", "inspect", IMAGE_NAME]);
+      await execFile("docker", ["image", "inspect", image]);
       return true;
     } catch {
       return false;

--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -94,6 +94,12 @@ export function createHabitatLifecycleTools(
 					.describe(
 						"Git repos for skills (e.g. 'typefully/agent-skills'). Cloned on container start.",
 					),
+				image: z
+					.string()
+					.optional()
+					.describe(
+						"Docker image for this habitat's container (default: the standard habitat image). Must exist locally — specialized images are built out of band.",
+					),
 			}),
 			execute: async (params) => {
 				// Validate capability bindings before creating
@@ -433,6 +439,7 @@ export function createHabitatLifecycleTools(
 					name: entry.name,
 					config: entry.config,
 					secretBindings: entry.secretBindings,
+					...(entry.image ? { image: entry.image } : {}),
 					requiredSecrets: entry.secretBindings.map((name) => ({
 						name,
 						present: vault.get(name) !== undefined,
@@ -486,6 +493,7 @@ export function createHabitatLifecycleTools(
 					gitBranch: parsed.config.gitBranch,
 					secretBindings: parsed.secretBindings ?? [],
 					skillsFromGit: parsed.config.skillsFromGit,
+					...(typeof parsed.image === "string" ? { image: parsed.image } : {}),
 				});
 				// Preserve agents, scopeTemplates, requiredSecrets, etc.
 				entry.config = { ...entry.config, ...parsed.config, name: entry.name };

--- a/packages/habitat/src/tools/gaia/registry-image.test.ts
+++ b/packages/habitat/src/tools/gaia/registry-image.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Registry round-trip tests for the per-entry image field (#115).
+ * Real filesystem in a tmp dir — the registry is plain JSON on disk.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GaiaRegistryManager } from './registry.js';
+
+describe('GaiaRegistryManager — image field', () => {
+  let dataDir: string;
+  let registry: GaiaRegistryManager;
+
+  beforeEach(async () => {
+    dataDir = await mkdtemp(join(tmpdir(), 'umwl-gaia-reg-'));
+    registry = new GaiaRegistryManager(dataDir);
+    await registry.load();
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it('persists the image field when provided', async () => {
+    const entry = await registry.create({
+      id: 'coding-agent',
+      name: 'Coding Agent',
+      image: 'habitat-coding',
+    });
+    expect(entry.image).toBe('habitat-coding');
+
+    const raw = JSON.parse(
+      await readFile(join(dataDir, 'registry.json'), 'utf-8'),
+    );
+    expect(raw.habitats[0].image).toBe('habitat-coding');
+
+    // Survives a reload from disk
+    const fresh = new GaiaRegistryManager(dataDir);
+    await fresh.load();
+    expect(fresh.get('coding-agent')?.image).toBe('habitat-coding');
+  });
+
+  it('omits the image key entirely when not provided (no behavior change)', async () => {
+    const entry = await registry.create({ id: 'plain', name: 'Plain' });
+    expect(entry.image).toBeUndefined();
+    expect('image' in entry).toBe(false);
+
+    const raw = JSON.parse(
+      await readFile(join(dataDir, 'registry.json'), 'utf-8'),
+    );
+    expect('image' in raw.habitats[0]).toBe(false);
+  });
+
+  it('loads pre-existing registries without an image field (back compat)', async () => {
+    await registry.create({ id: 'old-style', name: 'Old Style' });
+    const fresh = new GaiaRegistryManager(dataDir);
+    await fresh.load();
+    const entry = fresh.get('old-style');
+    expect(entry).toBeDefined();
+    expect(entry?.image).toBeUndefined();
+  });
+
+  it('allows updating the image after creation', async () => {
+    await registry.create({ id: 'upgradeable', name: 'Upgradeable' });
+    const updated = await registry.update('upgradeable', {
+      image: 'habitat-oura',
+    });
+    expect(updated.image).toBe('habitat-oura');
+
+    const fresh = new GaiaRegistryManager(dataDir);
+    await fresh.load();
+    expect(fresh.get('upgradeable')?.image).toBe('habitat-oura');
+  });
+});

--- a/packages/habitat/src/tools/gaia/registry.ts
+++ b/packages/habitat/src/tools/gaia/registry.ts
@@ -100,6 +100,7 @@ export class GaiaRegistryManager {
 			},
 			secretBindings: options.secretBindings ?? [],
 			apiKey: generateApiKey(),
+			...(options.image ? { image: options.image } : {}),
 			createdAt: new Date().toISOString(),
 		};
 
@@ -119,7 +120,7 @@ export class GaiaRegistryManager {
 		updates: Partial<
 			Pick<
 				GaiaHabitatEntry,
-				"name" | "config" | "secretBindings" | "containerPort"
+				"name" | "config" | "secretBindings" | "containerPort" | "image"
 			>
 		>,
 	): Promise<GaiaHabitatEntry> {
@@ -135,6 +136,7 @@ export class GaiaRegistryManager {
 			entry.secretBindings = updates.secretBindings;
 		if (updates.containerPort !== undefined)
 			entry.containerPort = updates.containerPort;
+		if (updates.image !== undefined) entry.image = updates.image;
 
 		await this.save();
 		return entry;

--- a/packages/habitat/src/tools/gaia/types.ts
+++ b/packages/habitat/src/tools/gaia/types.ts
@@ -16,6 +16,12 @@ export interface GaiaHabitatEntry {
 	secretBindings: string[];
 	/** Auto-generated per-container API key */
 	apiKey: string;
+	/**
+	 * Docker image this habitat's container runs.
+	 * Omitted ⇒ the default habitat image. Specialized images (coding agent,
+	 * packaged Oura/Twitter agents) are built out of band.
+	 */
+	image?: string;
 	/** Assigned host port (127.0.0.1 only) — set after container starts */
 	containerPort?: number;
 	/** ISO timestamp */
@@ -54,6 +60,8 @@ export interface CreateHabitatOptions {
 	skillsFromGit?: string[];
 	/** Capability-to-credential bindings for the habitat. */
 	capabilities?: CapabilityBinding[];
+	/** Docker image for the container (default: the standard habitat image). */
+	image?: string;
 }
 
 /** Status of a credential (whether it's known to be working). */

--- a/reports/2026-06-10-gaia-per-entry-image.md
+++ b/reports/2026-06-10-gaia-per-entry-image.md
@@ -1,0 +1,55 @@
+# Gaia per-entry Docker image — codebase research (issue #115)
+
+Date: 2026-06-10. Scope: add an optional `image` field to Gaia registry entries
+so specialized agents run their own Docker image. No new external technology —
+the Docker CLI is driven via `execFile` exactly as today; prior art for mocking
+it lives in `fnox.test.ts`.
+
+## Current state
+
+- **Hardcoded image**: `packages/habitat/src/tools/gaia/docker.ts:47` —
+  `const IMAGE_NAME = "habitat"`. Used in `buildImage()` (build tag),
+  `startContainer()` (final `docker run` arg), and `imageExists()`
+  (`docker image inspect`).
+- **Registry**: `packages/habitat/src/tools/gaia/types.ts` —
+  `GaiaHabitatEntry` has no image field; `GaiaRegistry` is unversioned JSON
+  (`registry.json` in the data dir), so an optional field is backward
+  compatible with zero migration.
+- **Entry creation sites** that need to accept the field:
+  1. `GaiaRegistryManager.create()` (registry.ts:76) — builds the entry.
+  2. `POST /api/habitats` (routes.ts:195) — passes the JSON body straight to
+     `registry.create()`, so it works once the type/creation accept it.
+  3. `create_habitat` tool (gaia-tools/habitats.ts:59) — zod schema needs the
+     field; params pass through to `registry.create()`.
+  4. `export_habitat` / `import_habitat` (habitats.ts:421/445) — the export
+     blob must carry the image so a recreated habitat keeps it.
+- **`registry.update()`** (registry.ts:117) whitelists updatable fields via a
+  `Pick` — `image` must be added there to be settable after creation.
+- **Lifecycle flows** (`/start`, `/rebuild` routes; `start_habitat`,
+  `rebuild_habitat` tools) all funnel through `DockerManager.startContainer(entry, ...)`,
+  which already receives the full entry — one change point.
+- **Error surfacing**: the start route wraps `startContainer` in try/catch →
+  `{ error }` 500; rebuild and tools propagate to the container-server's
+  global catch. A thrown Error with a clear message is enough.
+- **Build task** (`buildImage()`, `build_image` tool, `GET /api/docker/status`)
+  stays about the default image only — specialized images are built out of
+  band per the PRD.
+
+## Plan
+
+- `image?: string` on `GaiaHabitatEntry` + `CreateHabitatOptions`.
+- `DEFAULT_IMAGE_NAME` exported from docker.ts; `imageExists(image = DEFAULT_IMAGE_NAME)`;
+  `startContainer` runs `entry.image ?? DEFAULT_IMAGE_NAME` and **pre-checks
+  existence when a custom image is set**, throwing a clear error instead of
+  silently falling back.
+- Thread the field through registry create/update, the create_habitat zod
+  schema, and the export/import blob.
+
+## Testing
+
+- Registry round-trip with real fs in a tmp dir (`GaiaRegistryManager` takes a
+  dataDir; `load()` → `create()` → re-`load()`).
+- Docker arg construction with `node:child_process` mocked at module level
+  (fnox.test.ts pattern: callback-based `execFile` mock compatible with
+  `promisify`), asserting the image positional arg and the missing-image error
+  with no `docker run` issued.


### PR DESCRIPTION
Closes #115. Parent PRD: #113. Together with the merged RuntimeRunner seam (#127), this unblocks #123 (coding-agent image).

## What this builds

Each Gaia registry entry can now declare which Docker image it runs, so specialized agents (coding agent, packaged Oura/Twitter agents) run side by side with generic habitats in one fleet:

- **`GaiaHabitatEntry.image?` / `CreateHabitatOptions.image?`** — optional; omitted ⇒ the default `habitat` image, byte-identical behavior for existing registries (the key isn't even written to `registry.json` when unset). The registry is unversioned JSON, so this is migration-free.
- **`DockerManager`** — `DEFAULT_IMAGE_NAME` exported; `startContainer` runs `entry.image ?? DEFAULT_IMAGE_NAME` with the same volume seeding, network, port assignment, and bearer-token wiring; `imageExists(image = DEFAULT_IMAGE_NAME)` is per-entry-capable. A set-but-missing custom image **throws a clear error before any `docker run`** — no silent fallback to the default.
- **Threading** — `create_habitat` tool schema accepts `image`; `export_habitat` blobs carry it; `import_habitat` restores it; `registry.update()` allows changing it; `POST /api/habitats` passes it through (body → `registry.create()`). `buildImage()` / `build_image` / `GET /api/docker/status` intentionally stay about the default image only — specialized images are built out of band per the PRD.

## Tests

9 new unit tests; full suite **1361 passed**, lint 0 errors.

- `registry-image.test.ts` — round-trip with the field, key omitted when unset, back-compat load of image-less registries, post-creation update.
- `docker-image.test.ts` — exec layer mocked (fnox.test.ts pattern): `docker run` names the default image when unset and the entry image when set; missing custom image → clear error and zero `docker run` calls; volume/network/api-key wiring preserved; `imageExists` per-image.

## Acceptance criteria from #115, with validation steps

**1. Optional image field; omitted ⇒ default image, no behavior change.**
```bash
npx vitest run packages/habitat/src/tools/gaia/registry-image.test.ts
```

**2. Start/rebuild/status flows use the entry's image.**
All lifecycle paths (routes `/start` + `/rebuild`, `start_habitat` / `rebuild_habitat` tools) funnel through `DockerManager.startContainer(entry, …)`, which now resolves the image from the entry.
```bash
npx vitest run packages/habitat/src/tools/gaia/docker-image.test.ts
```

**3. Per-entry existence check; missing custom image ⇒ clear error, not silent fallback.**
Verified live (below) and by the "throws a clear error" test — the run args list is asserted empty after the rejection.

**4. Unit tests with exec layer mocked.** — the two files above.

**5. `pnpm test:run` passes.** — 1361 passed.

## Verified live (real Docker, real Gaia orchestrator)

```bash
dotenvx run -- pnpm run cli habitat gaia --data-dir /tmp/gaia-image-demo -p google -m gemini-3-flash-preview

# missing custom image → clear 500, no container
curl -s -X POST localhost:7420/api/habitats -H 'Content-Type: application/json' \
  -d '{"id":"img-missing","name":"Img Missing","image":"umwl-no-such-image"}'
curl -s -X POST localhost:7420/api/habitats/img-missing/start
# → {"error":"Image \"umwl-no-such-image\" for habitat \"img-missing\" not found. Build or pull it first — the Gaia build task only builds the default \"habitat\" image."}

# custom image + default image side by side
docker tag habitat umwl-custom-demo
curl -s -X POST localhost:7420/api/habitats -d '{"id":"img-custom","name":"Img Custom","image":"umwl-custom-demo"}' ...
curl -s -X POST localhost:7420/api/habitats -d '{"id":"img-default","name":"Img Default"}' ...
curl -s -X POST localhost:7420/api/habitats/img-custom/start
curl -s -X POST localhost:7420/api/habitats/img-default/start
docker inspect gaia-img-custom gaia-img-default --format '{{.Name}} → {{.Config.Image}}'
# → /gaia-img-custom → umwl-custom-demo
# → /gaia-img-default → habitat
```

Both `docker run` invocations carried identical `-v gaia-<id>-data:/data`, `--network gaia-net`, `HABITAT_API_KEY`, and `-p 127.0.0.1:<port>:8080` wiring — only the image differs.

## Worth knowing / further work

- **Pre-existing port-allocation gap surfaced during the live demo** (not introduced or worsened here): `findAvailablePort()` only consults the *current registry's* entries, so a second Gaia instance (or any container already bound to 7440+) causes `docker run` to fail with "port is already allocated". Both my demo containers hit this identically because another Gaia's `gaia-a2a-probe` held 7440. The docstring claims it "checks which ports are already bound by running containers" but it doesn't. Worth a small follow-up issue.
- **The existence pre-check only runs for custom images.** Default-image startup keeps today's exact behavior (the build-check / `GET /api/docker/status` flow owns that), avoiding an extra `docker image inspect` on every start.
- **`update` can change `image`** but doesn't support clearing it back to default (same `!== undefined` semantics as every other updatable field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)