### PR TITLE
feat(habitat): pi runtime runner for habitat channels (#122)

### DIFF
--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -32,6 +32,7 @@ import { listArtifacts } from "./tools/artifact-tools.js";
 import { createA2AHandler, type A2AHandler } from "./a2a-handler.js";
 import { buildAgentStimulus } from "./habitat-agent.js";
 import { createClaudeSdkRuntimeRunner } from "./claude-sdk-runner.js";
+import { createPiRuntimeRunner } from "./pi-runner.js";
 import { ChannelBridge } from "./bridge/channel-bridge.js";
 import { WebAdapter } from "./web/WebAdapter.js";
 import { devAuth } from "./web/auth/dev-auth.js";
@@ -182,7 +183,10 @@ export async function startContainerServer(
 			"Do NOT copy files to /files/ — that path is a virtual mount, not a real directory. Files are served directly from /data/.",
 		].join("\n"),
 		buildAgentStimulus,
-		runtimeRunners: { 'claude-sdk': createClaudeSdkRuntimeRunner() },
+		runtimeRunners: {
+			'claude-sdk': createClaudeSdkRuntimeRunner(),
+			pi: createPiRuntimeRunner(),
+		},
 	});
 
 	// Wrap bridge.handleMessage to log chat activity and track session

--- a/packages/habitat/src/index.ts
+++ b/packages/habitat/src/index.ts
@@ -55,6 +55,20 @@ export type {
 	ClaudeSDKProgress,
 } from "./claude-sdk-runner.js";
 
+// ── pi runner ───────────────────────────────────────────────────────────
+export {
+	runPi,
+	createPiRuntimeRunner,
+	piNativeSessionPath,
+	piProjectDirName,
+	piSessionFileName,
+} from "./pi-runner.js";
+export type {
+	PiRunnerOptions,
+	PiRunResult,
+	PiProgress,
+} from "./pi-runner.js";
+
 // ── Tool sets ───────────────────────────────────────────────────────────
 export type { ToolSet } from "./tool-sets.js";
 export {

--- a/packages/habitat/src/pi-runner.test.ts
+++ b/packages/habitat/src/pi-runner.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Unit tests for the pi runtime runner (#122): JSON-lines event parsing →
+ * progress callbacks, native session ref extraction, error paths. The
+ * subprocess layer is stubbed via spawnFn — no real pi, no network.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createPiRuntimeRunner,
+  piNativeSessionPath,
+  piProjectDirName,
+  piSessionFileName,
+  runPi,
+  type PiProgress,
+  type PiRunResult,
+} from './pi-runner.js';
+import type { RuntimeContext } from './bridge/types.js';
+import type { AgentEntry } from './types.js';
+
+// ── Stubbed subprocess ────────────────────────────────────────────────
+
+interface FakeSpawnOptions {
+  /** stdout payloads, emitted as separate data chunks. */
+  chunks: string[];
+  exitCode?: number;
+  stderr?: string;
+  /** Emit a spawn error (e.g. ENOENT) instead of running. */
+  error?: Error;
+}
+
+function makeSpawnFn(opts: FakeSpawnOptions): {
+  spawnFn: any;
+  calls: Array<{ cmd: string; args: string[]; options: any }>;
+} {
+  const calls: Array<{ cmd: string; args: string[]; options: any }> = [];
+  const spawnFn = (cmd: string, args: string[], options: any) => {
+    calls.push({ cmd, args, options });
+    const proc = new EventEmitter() as any;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    setImmediate(() => {
+      if (opts.error) {
+        proc.emit('error', opts.error);
+        return;
+      }
+      for (const chunk of opts.chunks) {
+        proc.stdout.emit('data', Buffer.from(chunk));
+      }
+      if (opts.stderr) proc.stderr.emit('data', Buffer.from(opts.stderr));
+      proc.emit('close', opts.exitCode ?? 0);
+    });
+    return proc;
+  };
+  return { spawnFn, calls };
+}
+
+const SESSION_LINE = JSON.stringify({
+  type: 'session',
+  version: 3,
+  id: '019eb2f1-6c1b-7188-8978-6ce07381931d',
+  timestamp: '2026-06-10T19:10:26.843Z',
+  cwd: '/data/agents/coder/repo',
+});
+
+function textDelta(delta: string): string {
+  return JSON.stringify({
+    type: 'message_update',
+    assistantMessageEvent: { type: 'text_delta', contentIndex: 1, delta },
+  });
+}
+
+function thinkingDelta(delta: string): string {
+  return JSON.stringify({
+    type: 'message_update',
+    assistantMessageEvent: { type: 'thinking_delta', contentIndex: 0, delta },
+  });
+}
+
+const TOOL_START = JSON.stringify({
+  type: 'tool_execution_start',
+  toolCallId: 'tc-1',
+  toolName: 'read',
+  args: { path: 'note.txt' },
+});
+
+const TOOL_END = JSON.stringify({
+  type: 'tool_execution_end',
+  toolCallId: 'tc-1',
+  toolName: 'read',
+  result: { content: [{ type: 'text', text: 'hello from probe\n' }] },
+  isError: false,
+});
+
+const ASSISTANT_END = JSON.stringify({
+  type: 'message_end',
+  message: {
+    role: 'assistant',
+    content: [
+      { type: 'thinking', thinking: 'pondering' },
+      { type: 'text', text: 'pi probe ok' },
+    ],
+  },
+});
+
+function happyPathChunks(): string[] {
+  return [
+    [
+      SESSION_LINE,
+      thinkingDelta('pond'),
+      thinkingDelta('ering'),
+      TOOL_START,
+      TOOL_END,
+      textDelta('pi probe'),
+      textDelta(' ok'),
+      ASSISTANT_END,
+      JSON.stringify({ type: 'agent_end', messages: [] }),
+      '',
+    ].join('\n'),
+  ];
+}
+
+describe('runPi (stubbed subprocess)', () => {
+  it('spawns pi in JSON print mode in the agent cwd', async () => {
+    const { spawnFn, calls } = makeSpawnFn({ chunks: happyPathChunks() });
+    await runPi('do the thing', { cwd: '/data/agents/coder/repo', spawnFn });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toBe('pi');
+    expect(calls[0].args).toContain('--mode');
+    expect(calls[0].args).toContain('json');
+    expect(calls[0].args).toContain('-p');
+    expect(calls[0].args[calls[0].args.length - 1]).toBe('do the thing');
+    expect(calls[0].options.cwd).toBe('/data/agents/coder/repo');
+    // piped stdin makes pi wait for EOF and hang — must be ignored
+    expect(calls[0].options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+  });
+
+  it('extracts the native session id and computes its path', async () => {
+    const { spawnFn } = makeSpawnFn({ chunks: happyPathChunks() });
+    const result = await runPi('go', {
+      cwd: '/data/agents/coder/repo',
+      env: { PI_CODING_AGENT_DIR: '/data/pi-agent' },
+      spawnFn,
+    });
+    expect(result.success).toBe(true);
+    expect(result.sessionId).toBe('019eb2f1-6c1b-7188-8978-6ce07381931d');
+    expect(result.sessionPath).toBe(
+      '/data/pi-agent/sessions/--data-agents-coder-repo--/2026-06-10T19-10-26-843Z_019eb2f1-6c1b-7188-8978-6ce07381931d.jsonl',
+    );
+  });
+
+  it('streams text, reasoning, and tool activity as progress', async () => {
+    const { spawnFn } = makeSpawnFn({ chunks: happyPathChunks() });
+    const updates: PiProgress[] = [];
+    await runPi('go', {
+      cwd: '/x',
+      spawnFn,
+      onProgress: (u) => updates.push(u),
+    });
+    expect(updates.map((u) => u.type)).toEqual([
+      'reasoning',
+      'reasoning',
+      'tool_use',
+      'tool_result',
+      'text',
+      'text',
+    ]);
+    expect(updates.filter((u) => u.type === 'text').map((u) => u.content)).toEqual([
+      'pi probe',
+      ' ok',
+    ]);
+    const toolUse = updates.find((u) => u.type === 'tool_use');
+    expect(toolUse?.toolName).toBe('read');
+    expect(toolUse?.input).toEqual({ path: 'note.txt' });
+    const toolResult = updates.find((u) => u.type === 'tool_result');
+    expect(toolResult?.toolName).toBe('read');
+    expect(toolResult?.content).toBe('hello from probe\n');
+    expect(toolResult?.isError).toBe(false);
+  });
+
+  it('takes the final content from the last assistant message_end', async () => {
+    const { spawnFn } = makeSpawnFn({ chunks: happyPathChunks() });
+    const result = await runPi('go', { cwd: '/x', spawnFn });
+    expect(result.content).toBe('pi probe ok');
+  });
+
+  it('handles JSON lines split across stdout chunks', async () => {
+    const whole = happyPathChunks()[0];
+    const cut = Math.floor(whole.indexOf('pi probe') + 3);
+    const { spawnFn } = makeSpawnFn({
+      chunks: [whole.slice(0, cut), whole.slice(cut)],
+    });
+    const result = await runPi('go', { cwd: '/x', spawnFn });
+    expect(result.success).toBe(true);
+    expect(result.content).toBe('pi probe ok');
+    expect(result.sessionId).toBe('019eb2f1-6c1b-7188-8978-6ce07381931d');
+  });
+
+  it('reports a clear error on non-zero exit, carrying stderr', async () => {
+    const { spawnFn } = makeSpawnFn({
+      chunks: [SESSION_LINE + '\n'],
+      exitCode: 1,
+      stderr: 'Error: no provider configured',
+    });
+    const result = await runPi('go', { cwd: '/x', spawnFn });
+    expect(result.success).toBe(false);
+    expect(result.errors.join(' ')).toContain('exited with code 1');
+    expect(result.errors.join(' ')).toContain('no provider configured');
+    // session id still carried for debugging
+    expect(result.sessionId).toBe('019eb2f1-6c1b-7188-8978-6ce07381931d');
+  });
+
+  it('resolves (not hangs/throws) with a clear error when the binary is missing', async () => {
+    const err = Object.assign(new Error('spawn pi ENOENT'), {
+      code: 'ENOENT',
+    });
+    const { spawnFn } = makeSpawnFn({ chunks: [], error: err });
+    const result = await runPi('go', { cwd: '/x', spawnFn });
+    expect(result.success).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/pi.*not found|not found.*pi/i);
+  });
+
+  it('ignores non-JSON stdout noise', async () => {
+    const { spawnFn } = makeSpawnFn({
+      chunks: [
+        'Warning: No models match pattern "x"\n' + happyPathChunks()[0],
+      ],
+    });
+    const result = await runPi('go', { cwd: '/x', spawnFn });
+    expect(result.success).toBe(true);
+    expect(result.content).toBe('pi probe ok');
+  });
+});
+
+describe('pi native session path helpers', () => {
+  it('encodes the cwd with pi dash convention', () => {
+    expect(piProjectDirName('/private/tmp/pi-probe/proj')).toBe(
+      '--private-tmp-pi-probe-proj--',
+    );
+  });
+
+  it('builds the session file name from timestamp and id', () => {
+    expect(
+      piSessionFileName('2026-06-10T19:10:26.843Z', 'abc-123'),
+    ).toBe('2026-06-10T19-10-26-843Z_abc-123.jsonl');
+  });
+
+  it('defaults to ~/.pi/agent/sessions/<encoded-cwd>/', () => {
+    expect(piNativeSessionPath('/a/b', 'id1', '2026-06-10T19:10:26.843Z', {})).toBe(
+      join(
+        homedir(),
+        '.pi',
+        'agent',
+        'sessions',
+        '--a-b--',
+        '2026-06-10T19-10-26-843Z_id1.jsonl',
+      ),
+    );
+  });
+
+  it('honors PI_CODING_AGENT_DIR (nested under sessions/<encoded-cwd>)', () => {
+    expect(
+      piNativeSessionPath('/a/b', 'id1', '2026-06-10T19:10:26.843Z', {
+        PI_CODING_AGENT_DIR: '/data/pi-agent',
+      }),
+    ).toBe(
+      '/data/pi-agent/sessions/--a-b--/2026-06-10T19-10-26-843Z_id1.jsonl',
+    );
+  });
+
+  it('honors PI_CODING_AGENT_SESSION_DIR (flat, like --session-dir)', () => {
+    expect(
+      piNativeSessionPath('/a/b', 'id1', '2026-06-10T19:10:26.843Z', {
+        PI_CODING_AGENT_SESSION_DIR: '/data/pi-sessions',
+        PI_CODING_AGENT_DIR: '/ignored',
+      }),
+    ).toBe('/data/pi-sessions/2026-06-10T19-10-26-843Z_id1.jsonl');
+  });
+});
+
+describe('createPiRuntimeRunner', () => {
+  const ctx: RuntimeContext = {
+    agent: {
+      id: 'coder',
+      name: 'Coder',
+      projectPath: '/data/agents/coder/repo',
+    } as AgentEntry,
+    sessionId: 'sess-1',
+    sessionDir: '/tmp/sessions/sess-1',
+    channelKey: 'a2a:ctx-1',
+  };
+
+  it('returns content and the pi nativeSessionRef', async () => {
+    const runFn = vi.fn(
+      async (): Promise<PiRunResult> => ({
+        content: 'done',
+        success: true,
+        errors: [],
+        sessionId: 'pi-id-1',
+        sessionPath: '/data/pi-agent/sessions/--x--/file.jsonl',
+      }),
+    );
+    const runner = createPiRuntimeRunner(runFn as any);
+    const result = await runner.run('task', ctx, { onDone: async () => {} });
+    expect(runFn).toHaveBeenCalledWith(
+      'task',
+      expect.objectContaining({ cwd: '/data/agents/coder/repo' }),
+    );
+    expect(result.content).toBe('done');
+    expect(result.success).toBe(true);
+    expect(result.nativeSessionRef).toEqual({
+      runtime: 'pi',
+      nativeSessionId: 'pi-id-1',
+      nativeSessionPath: '/data/pi-agent/sessions/--x--/file.jsonl',
+    });
+  });
+
+  it('omits nativeSessionRef when pi reported no session', async () => {
+    const runFn = vi.fn(
+      async (): Promise<PiRunResult> => ({
+        content: 'done',
+        success: true,
+        errors: [],
+      }),
+    );
+    const runner = createPiRuntimeRunner(runFn as any);
+    const result = await runner.run('task', ctx, { onDone: async () => {} });
+    expect(result.nativeSessionRef).toBeUndefined();
+  });
+
+  it('forwards progress to bridge event handlers', async () => {
+    const runFn = vi.fn(async (_prompt: string, opts: any): Promise<PiRunResult> => {
+      opts.onProgress({ type: 'text', content: 'hi' });
+      opts.onProgress({ type: 'reasoning', content: 'hmm' });
+      opts.onProgress({
+        type: 'tool_use',
+        content: 'Using read',
+        toolName: 'read',
+        input: { path: 'x' },
+      });
+      opts.onProgress({
+        type: 'tool_result',
+        content: 'output',
+        toolName: 'read',
+        isError: true,
+      });
+      return { content: 'hi', success: true, errors: [] };
+    });
+    const onText = vi.fn();
+    const onReasoning = vi.fn();
+    const onToolCall = vi.fn();
+    const onToolResult = vi.fn();
+    const runner = createPiRuntimeRunner(runFn as any);
+    await runner.run('task', ctx, {
+      onText,
+      onReasoning,
+      onToolCall,
+      onToolResult,
+      onDone: async () => {},
+    });
+    expect(onText).toHaveBeenCalledWith('hi');
+    expect(onReasoning).toHaveBeenCalledWith('hmm');
+    expect(onToolCall).toHaveBeenCalledWith('read', { path: 'x' });
+    expect(onToolResult).toHaveBeenCalledWith('read', 'output', true);
+  });
+
+  it('propagates failure with errors', async () => {
+    const runFn = vi.fn(
+      async (): Promise<PiRunResult> => ({
+        content: '',
+        success: false,
+        errors: ['pi exited with code 1'],
+      }),
+    );
+    const runner = createPiRuntimeRunner(runFn as any);
+    const result = await runner.run('task', ctx, { onDone: async () => {} });
+    expect(result.success).toBe(false);
+    expect(result.errors).toEqual(['pi exited with code 1']);
+  });
+});

--- a/packages/habitat/src/pi-runner.ts
+++ b/packages/habitat/src/pi-runner.ts
@@ -1,0 +1,342 @@
+/**
+ * pi Runtime Runner (#122)
+ *
+ * Spawns the pi coding agent (`pi --mode json -p`) as an agentic subprocess
+ * against an agent's project, translates its JSON-lines progress into bridge
+ * events, and links the habitat session to pi's native session log via
+ * nativeSessionRef — the pi peer of claude-sdk-runner.ts.
+ *
+ * Hard rule: no output-token caps anywhere in this runner.
+ */
+
+import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type {
+  BridgeEventHandlers,
+  RuntimeContext,
+  RuntimeResult,
+  RuntimeRunner,
+} from "./bridge/types.js";
+
+export interface PiRunnerOptions {
+  /** Working directory for pi (typically the agent's projectPath). */
+  cwd: string;
+  /** Extra env merged over process.env (PI_CODING_AGENT_DIR etc.). */
+  env?: Record<string, string | undefined>;
+  /** Callback for streaming progress updates. */
+  onProgress?: (update: PiProgress) => void;
+  /** pi binary name/path (default: "pi" on PATH). */
+  binary?: string;
+  /**
+   * Injectable spawn for tests — lets unit tests drive the JSON-lines
+   * loop (session-id extraction, event translation, error paths) with
+   * the subprocess layer stubbed.
+   */
+  spawnFn?: typeof spawn;
+}
+
+export interface PiProgress {
+  type: "text" | "reasoning" | "tool_use" | "tool_result" | "status";
+  content: string;
+  toolName?: string;
+  input?: unknown;
+  isError?: boolean;
+}
+
+export interface PiRunResult {
+  /** Final assistant text. */
+  content: string;
+  /** Whether the run completed successfully (exit 0). */
+  success: boolean;
+  /** Error details when success is false. */
+  errors: string[];
+  /** pi's native session id, from the stream's `session` event. */
+  sessionId?: string;
+  /** Absolute path to pi's native session JSONL, when a session was seen. */
+  sessionPath?: string;
+}
+
+// ── Native session location (PRD #113 co-location) ───────────────────
+
+/**
+ * pi's project-directory encoding for global session storage:
+ * `--` + cwd with slashes dashed + `--` (the core PiAdapter decodes the
+ * same convention at read time).
+ */
+export function piProjectDirName(cwd: string): string {
+  const normalized = cwd.replace(/\/$/, "");
+  return "--" + normalized.replace(/\//g, "-").replace(/^-/, "") + "--";
+}
+
+/** pi session file name: `<timestamp with [:.]→"-">_<sessionId>.jsonl`. */
+export function piSessionFileName(
+  timestampIso: string,
+  sessionId: string,
+): string {
+  return `${timestampIso.replace(/[:.]/g, "-")}_${sessionId}.jsonl`;
+}
+
+/**
+ * Where pi wrote the native session JSONL for a run.
+ *
+ * - `PI_CODING_AGENT_SESSION_DIR` (pi's --session-dir equivalent) wins and
+ *   is flat — files land directly in it.
+ * - Otherwise `$PI_CODING_AGENT_DIR/sessions/<encoded-cwd>/`, falling back
+ *   to `~/.pi/agent/sessions/<encoded-cwd>/`.
+ *
+ * The container image sets the env override beneath the data volume
+ * (same posture as CLAUDE_CONFIG_DIR for claude-sdk); this helper only
+ * reads the environment — runners never invent paths.
+ */
+export function piNativeSessionPath(
+  cwd: string,
+  sessionId: string,
+  timestampIso: string,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const file = piSessionFileName(timestampIso, sessionId);
+  const sessionDirOverride = env.PI_CODING_AGENT_SESSION_DIR?.trim();
+  if (sessionDirOverride) return join(sessionDirOverride, file);
+  const agentDir =
+    env.PI_CODING_AGENT_DIR?.trim() || join(homedir(), ".pi", "agent");
+  return join(agentDir, "sessions", piProjectDirName(cwd), file);
+}
+
+// ── JSON-lines event translation ──────────────────────────────────────
+
+function textFromBlocks(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return (content as Array<Record<string, unknown>>)
+    .filter((b) => b.type === "text" && typeof b.text === "string")
+    .map((b) => b.text as string)
+    .join("\n");
+}
+
+interface PiStreamState {
+  sessionId?: string;
+  sessionTimestamp?: string;
+  finalText: string;
+}
+
+/**
+ * Handle one parsed pi JSON event. Exported shape is internal to the
+ * runner; kept as a function so the line loop stays trivial.
+ */
+function handleEvent(
+  event: Record<string, unknown>,
+  state: PiStreamState,
+  onProgress?: (update: PiProgress) => void,
+): void {
+  switch (event.type) {
+    case "session": {
+      if (typeof event.id === "string") state.sessionId = event.id;
+      if (typeof event.timestamp === "string")
+        state.sessionTimestamp = event.timestamp;
+      break;
+    }
+    case "message_update": {
+      const ev = event.assistantMessageEvent as
+        | { type?: string; delta?: string }
+        | undefined;
+      if (!ev) break;
+      if (ev.type === "text_delta" && typeof ev.delta === "string") {
+        onProgress?.({ type: "text", content: ev.delta });
+      } else if (ev.type === "thinking_delta" && typeof ev.delta === "string") {
+        onProgress?.({ type: "reasoning", content: ev.delta });
+      }
+      break;
+    }
+    case "tool_execution_start": {
+      const toolName =
+        typeof event.toolName === "string" ? event.toolName : "tool";
+      onProgress?.({
+        type: "tool_use",
+        content: `Using ${toolName}`,
+        toolName,
+        input: event.args,
+      });
+      break;
+    }
+    case "tool_execution_end": {
+      const toolName =
+        typeof event.toolName === "string" ? event.toolName : "tool";
+      const result = event.result as { content?: unknown } | undefined;
+      onProgress?.({
+        type: "tool_result",
+        content: textFromBlocks(result?.content),
+        toolName,
+        isError: event.isError === true,
+      });
+      break;
+    }
+    case "message_end": {
+      const message = event.message as
+        | { role?: string; content?: unknown }
+        | undefined;
+      if (message?.role === "assistant") {
+        const text = textFromBlocks(message.content);
+        if (text) state.finalText = text;
+      }
+      break;
+    }
+  }
+}
+
+// ── Runner ────────────────────────────────────────────────────────────
+
+/**
+ * Run a prompt through pi in non-interactive JSON mode.
+ * Resolves on process exit — missing binary and non-zero exits resolve to
+ * `{ success: false, errors: [...] }` rather than throwing or hanging.
+ */
+export function runPi(
+  prompt: string,
+  options: PiRunnerOptions,
+): Promise<PiRunResult> {
+  const spawnFn = options.spawnFn ?? spawn;
+  const binary = options.binary ?? "pi";
+  // --no-extensions / --no-skills keep subprocess startup deterministic;
+  // provider/model resolution stays with pi's own settings and env.
+  const args = [
+    "--mode",
+    "json",
+    "-p",
+    "--no-extensions",
+    "--no-skills",
+    prompt,
+  ];
+
+  return new Promise((resolve) => {
+    const state: PiStreamState = { finalText: "" };
+    let stdoutBuffer = "";
+    let stderrTail = "";
+
+    const proc = spawnFn(binary, args, {
+      cwd: options.cwd,
+      env: { ...process.env, ...options.env },
+      // stdin MUST be ignored: with a piped stdin, pi waits for EOF before
+      // processing the prompt and the run hangs forever (observed live).
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const consumeLine = (line: string) => {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("{")) return; // startup warnings etc.
+      try {
+        const event = JSON.parse(trimmed) as Record<string, unknown>;
+        handleEvent(event, state, options.onProgress);
+      } catch {
+        /* partial or non-JSON line — ignore */
+      }
+    };
+
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      stdoutBuffer += chunk.toString();
+      let idx = stdoutBuffer.indexOf("\n");
+      while (idx !== -1) {
+        consumeLine(stdoutBuffer.slice(0, idx));
+        stdoutBuffer = stdoutBuffer.slice(idx + 1);
+        idx = stdoutBuffer.indexOf("\n");
+      }
+    });
+
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      stderrTail = (stderrTail + chunk.toString()).slice(-2000);
+    });
+
+    const finish = (success: boolean, errors: string[]) => {
+      const env = { ...process.env, ...options.env };
+      resolve({
+        content: state.finalText,
+        success,
+        errors,
+        sessionId: state.sessionId,
+        sessionPath:
+          state.sessionId && state.sessionTimestamp
+            ? piNativeSessionPath(
+                options.cwd,
+                state.sessionId,
+                state.sessionTimestamp,
+                env,
+              )
+            : undefined,
+      });
+    };
+
+    proc.on("error", (err: NodeJS.ErrnoException) => {
+      const hint =
+        err.code === "ENOENT"
+          ? `pi binary "${binary}" not found on PATH — install the pi coding agent (npm i -g @earendil-works/pi) or bake it into the container image.`
+          : `Failed to spawn pi: ${err.message}`;
+      finish(false, [hint]);
+    });
+
+    proc.on("close", (code: number | null) => {
+      if (stdoutBuffer) consumeLine(stdoutBuffer);
+      if (code === 0) {
+        finish(true, []);
+      } else {
+        const errors = [
+          `pi exited with code ${code ?? "null"}${stderrTail ? `: ${stderrTail.trim()}` : ""}`,
+        ];
+        finish(false, errors);
+      }
+    });
+  });
+}
+
+// ── RuntimeRunner adapter ─────────────────────────────────────────────
+
+/**
+ * Adapt pi to the bridge's RuntimeRunner contract. Streams progress into
+ * the bridge event handlers and, when pi reported a session, returns the
+ * nativeSessionRef pointing at its JSONL trace (read at projection time
+ * by the core PiAdapter per ADR 0001).
+ *
+ * `runFn` is injectable for tests; production uses runPi.
+ */
+export function createPiRuntimeRunner(
+  runFn: typeof runPi = runPi,
+): RuntimeRunner {
+  return {
+    async run(
+      prompt: string,
+      ctx: RuntimeContext,
+      events: BridgeEventHandlers,
+    ): Promise<RuntimeResult> {
+      const result = await runFn(prompt, {
+        cwd: ctx.agent.projectPath,
+        onProgress: (update) => {
+          if (update.type === "text") {
+            events.onText?.(update.content);
+          } else if (update.type === "reasoning") {
+            events.onReasoning?.(update.content);
+          } else if (update.type === "tool_use" && update.toolName) {
+            events.onToolCall?.(update.toolName, update.input);
+          } else if (update.type === "tool_result" && update.toolName) {
+            events.onToolResult?.(
+              update.toolName,
+              update.content,
+              update.isError === true,
+            );
+          }
+        },
+      });
+
+      return {
+        content: result.content,
+        success: result.success,
+        errors: result.errors.length ? result.errors : undefined,
+        nativeSessionRef:
+          result.sessionId && result.sessionPath
+            ? {
+                runtime: "pi",
+                nativeSessionId: result.sessionId,
+                nativeSessionPath: result.sessionPath,
+              }
+            : undefined,
+      };
+    },
+  };
+}

--- a/reports/2026-06-10-pi-runtime-runner.md
+++ b/reports/2026-06-10-pi-runtime-runner.md
@@ -1,0 +1,82 @@
+# pi runtime runner — research (issue #122)
+
+Date: 2026-06-10. Scope: implement the `pi` RuntimeRunner for habitat channels.
+Research was done against the locally installed pi
+(`@earendil-works/pi-coding-agent` 0.75.5) by running it in `--mode json` and
+reading its dist sources — these are observed facts, not docs paraphrase.
+
+## pi CLI invocation
+
+- `pi --mode json -p "<prompt>"` — non-interactive, JSON-lines events on stdout.
+- Positional args are the message; `--no-extensions --no-skills` keep startup
+  lean and deterministic for subprocess use.
+- pi resolves provider/model from its own settings/env — the runner passes
+  nothing model-related and **no token caps** (hard rule).
+
+## JSON event stream (observed)
+
+One JSON object per stdout line:
+
+- `{"type":"session","version":3,"id":"<uuidv7>","timestamp":"<ISO>","cwd":"<abs>"}` —
+  **first line**; carries the native session id.
+- `agent_start`, `turn_start`, `turn_end`, `agent_end` (final `messages` array).
+- `message_start` / `message_end` with `message.role` `user` | `assistant` |
+  `toolResult`. Assistant content blocks: `{type:"thinking"|"text"|"toolCall",...}`.
+- `message_update` with `assistantMessageEvent.type` ∈ `thinking_start`,
+  `thinking_delta` (`.delta`), `thinking_end`, `text_start`, `text_delta`
+  (`.delta`), `text_end`, `toolcall_start`, `toolcall_delta`, `toolcall_end`
+  (`.toolCall {id,name,arguments}`).
+- `tool_execution_start` `{toolCallId, toolName, args}` and
+  `tool_execution_end` `{toolCallId, toolName, result:{content:[{type:"text",text}]}, isError}`.
+
+Final assistant text: join the `text` blocks of the last assistant
+`message_end` (or `agent_end.messages`).
+
+## Session storage (observed + dist/config.js)
+
+- Default: `~/.pi/agent/sessions/<encoded-cwd>/<file>.jsonl`.
+- `PI_CODING_AGENT_DIR` (config.js `ENV_AGENT_DIR`) overrides the agent dir →
+  sessions at `$PI_CODING_AGENT_DIR/sessions/<encoded-cwd>/<file>.jsonl`.
+  **Verified live**: file landed under the override.
+- `PI_CODING_AGENT_SESSION_DIR` (`ENV_SESSION_DIR`, main.js:431) overrides the
+  sessions dir directly, equivalent to `--session-dir` — **flat**, no
+  encoded-cwd subdir (verified live with `--session-dir`).
+- Encoded cwd: `"--" + cwd.replace(/\//g,"-").replace(/^-/,"") + "--"` — same
+  convention the core `PiAdapter` already decodes (pi-adapter.ts).
+- File name: `<timestamp ISO with [:.]→"-">_<sessionId>.jsonl`, e.g.
+  `2026-06-10T19-10-26-843Z_019eb2f1-6c1b-7188-8978-6ce07381931d.jsonl`
+  (timestamp = the `session` event's `timestamp`).
+
+Per PRD #113 the container image sets the env override (same posture as
+`CLAUDE_CONFIG_DIR` for claude-sdk in #127); the runner only reads env.
+
+## RuntimeRunner seam (#127, merged)
+
+- Contracts: `packages/habitat/src/bridge/types.ts` — `RuntimeRunner.run(prompt, ctx, events)`,
+  `RuntimeContext {agent, sessionId, sessionDir, channelKey}`,
+  `RuntimeResult {content, success, errors?, nativeSessionRef?}`,
+  `BridgeEventHandlers {onText?, onReasoning?, onToolCall?, onToolResult?, onDone, onError?}`.
+- Bridge: `channel-bridge.ts` `handleRuntime()` — writes the envelope pair,
+  persists `nativeSessionRef` into meta.json, clean error for unregistered
+  runtimes. `ChannelRuntimeMode` already includes `'pi'`; routing.ts already
+  whitelists it.
+- Registration: `container-server.ts:185` `runtimeRunners: { 'claude-sdk': createClaudeSdkRuntimeRunner() }`.
+- Prior art to mirror: `claude-sdk-runner.ts` (`runClaudeSDK` + injectable
+  `queryFn`, `claudeNativeSessionPath(env)`, `createClaudeSdkRuntimeRunner`)
+  and its tests `claude-sdk-runner.test.ts` (stubbed stream generator) and
+  `bridge/channel-bridge-runtime.test.ts` (bridge-level dispatch fixtures).
+
+## Design
+
+`packages/habitat/src/pi-runner.ts`:
+- `runPi(prompt, {cwd, env?, onProgress?, spawnFn?, binary?})` — spawns
+  `pi --mode json -p --no-extensions --no-skills <prompt>`, line-buffers
+  stdout, maps events → progress callbacks, collects stderr.
+- Pure helpers `piProjectDirName`, `piSessionFileName`,
+  `piNativeSessionPath(cwd, sessionId, timestamp, env)` honoring both env
+  overrides.
+- `createPiRuntimeRunner(runFn = runPi)` → RuntimeRunner; nativeSessionRef
+  `{runtime:'pi', nativeSessionId, nativeSessionPath}`.
+- Missing binary (spawn ENOENT) and non-zero exit resolve to
+  `{success:false, errors:[clear message]}` — never hang, never throw raw.
+- Register `pi: createPiRuntimeRunner()` in container-server.ts.


### PR DESCRIPTION
Closes #122. Parent PRD: #113. Builds directly on the RuntimeRunner seam (#127); the runtime mode, routing whitelist, bridge dispatch, and meta.json persistence were already in place — this PR supplies the runner.

## What this builds

`packages/habitat/src/pi-runner.ts` — the pi peer of `claude-sdk-runner.ts`:

- **`runPi(prompt, opts)`** spawns `pi --mode json -p --no-extensions --no-skills <prompt>` in the agent's `projectPath`, line-buffers stdout, and translates pi's JSON-lines events: `text_delta` → text, `thinking_delta` → reasoning, `tool_execution_start` → tool call (with args), `tool_execution_end` → tool result (text + isError), assistant `message_end` → final content. Provider/model resolution stays entirely with pi's own settings — **no token caps anywhere** (hard rule).
- **Native session linkage**: pi's first JSON event (`{"type":"session","id","timestamp","cwd"}`) carries the session id; `piNativeSessionPath()` computes the on-disk path honoring `PI_CODING_AGENT_SESSION_DIR` (flat, pi's `--session-dir` equivalent) then `PI_CODING_AGENT_DIR` (nested `sessions/<encoded-cwd>/`), falling back to `~/.pi/agent/sessions/…`. Same posture as `CLAUDE_CONFIG_DIR` in #127: the container image/serve env sets the override; the runner only reads env. The encoded-cwd and filename conventions were verified against real pi output and match what the core `PiAdapter` already decodes at read time (ADR 0001).
- **`createPiRuntimeRunner()`** adapts it to the `RuntimeRunner` contract and is registered in `container-server.ts` next to claude-sdk, so `routing.json` channels with `"runtime": "pi"` dispatch through the seam.
- **The hang that wasn't in the plan**: pi spawned with a piped stdin produces zero output and waits forever for EOF — found live when the first A2A demo hung for 4 minutes. The runner spawns with `stdio: ["ignore","pipe","pipe"]` and a regression test asserts it.

Research (live probes of pi 0.75.5's JSON stream, session storage, env overrides) is written up in `reports/2026-06-10-pi-runtime-runner.md`.

## Tests

17 new unit tests (subprocess stubbed via injectable `spawnFn`); full suite **1378 passed**, lint 0 errors.

- JSON-lines parsing → progress events (text/reasoning/tool activity, order and payloads)
- session-id extraction + path computation (all three env configurations)
- final-content selection, chunk-split line buffering, non-JSON noise tolerance
- error paths: non-zero exit carries stderr; ENOENT resolves with a clear "pi binary not found" message (no hang, no throw)
- `createPiRuntimeRunner`: RuntimeResult shape, nativeSessionRef, event forwarding, failure propagation
- stdin-ignored spawn contract

## Acceptance criteria from #122, with validation steps

**1. Runtime mode `pi` is bindable per channel and dispatches through the RuntimeRunner contract.**
`routing.json`: `{"channels":{"a2a:<ctx>":{"agentId":"coder","runtime":"pi"}}}` — dispatch + 'pi' whitelist were landed by #127 (`channel-bridge-runtime.test.ts` covers both); this PR registers the live runner in `container-server.ts`.

**2. pi progress streams to bridge events.**
```bash
npx vitest run packages/habitat/src/pi-runner.test.ts -t "streams text"
```
Live: `message/stream` over A2A showed word-level deltas as working status updates (observed: `"The" " contents" " of" "hello" ".txt"…`).

**3. Session metadata records nativeSessionRef pointing at pi's native session under the data volume.**
Live demo (full transcript below): `sessions/ctx-pi-demo/meta.json` gained
`{"runtime":"pi","nativeSessionId":"019eb31b-…","nativeSessionPath":"/tmp/pi-demo-habitat/data-pi-sessions/2026-06-10T19-56-42-056Z_019eb31b-….jsonl"}` and that file exists (2.8 KB of native trace). Bonus: `GET /api/contexts/ctx-pi-demo` (#128) surfaces the same ref.

**4. Missing pi binary or non-zero exit produces a clear bridge error, not a hang.**
```bash
npx vitest run packages/habitat/src/pi-runner.test.ts -t "resolves (not hangs"
npx vitest run packages/habitat/src/pi-runner.test.ts -t "non-zero exit"
```
Plus the stdin fix above, which removed the one real-world hang we hit.

**5/6. Unit tests with subprocess stubbed; `pnpm test:run` passes.** — 17 tests, 1378 total.

## Verified live (the demo from the issue)

```bash
# work dir with an agent + a pi-bound a2a channel
cat routing.json  # {"channels":{"a2a:ctx-pi-demo":{"agentId":"coder","runtime":"pi"}}}
HABITAT_API_KEY=test-key-123 PI_CODING_AGENT_SESSION_DIR=/tmp/pi-demo-habitat/data-pi-sessions \
  dotenvx run -- pnpm run cli habitat serve --work-dir /tmp/pi-demo-habitat --port 7432

# coding task over A2A
curl -s -X POST localhost:7432/a2a -H 'Authorization: Bearer test-key-123' -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"kind":"message","messageId":"m1","role":"user","parts":[{"kind":"text","text":"Create a file named hello.txt containing exactly: hello from pi. Then confirm."}],"contextId":"ctx-pi-demo"}}}'
# → "Created `hello.txt` in the current directory with the content \"hello from pi.\" (14 bytes)."

cat /tmp/pi-demo-habitat/project/hello.txt                      # hello from pi.
cat /tmp/pi-demo-habitat/sessions/ctx-pi-demo/meta.json         # nativeSessionRef present
ls  /tmp/pi-demo-habitat/data-pi-sessions/                      # the linked native JSONL exists
curl -s -H 'Authorization: Bearer test-key-123' localhost:7432/api/contexts/ctx-pi-demo  # ref surfaced over HTTP
```

## Worth knowing / further work

- **pi + piped stdin hangs** — now documented in code and pinned by a test; anyone spawning pi elsewhere (e.g. a future `agent_ask_pi` tool) must ignore stdin.
- **No `agent_ask_pi` tool yet** — `agent_ask_claude` has no pi sibling; the issue scoped linkage to channel-bound runs. Trivial to add later on top of `runPi`.
- **First run against a fresh `PI_CODING_AGENT_DIR` is flaky** (pi does first-run setup, may produce an empty response or skip the session write). With a persistent data volume this is a once-per-container event; worth knowing for the coding-agent image (#123).
- **`--no-extensions --no-skills`** keeps subprocess startup deterministic. If a deployment wants pi extensions in-container, that can become configurable later.
- **Container image env** (`PI_CODING_AGENT_SESSION_DIR` beneath the data volume) is #123's job, per the PRD's "runners do not invent paths" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)