### PR TITLE
feat(habitat): coding-agent image — standards toolchain on the habitat base (#123)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -16,6 +16,17 @@ description = "Build the habitat Docker container"
 dir = "{{ config_root }}"
 run = "docker build -t habitat -f packages/habitat/Dockerfile ."
 
+[tasks."coding-agent-build"]
+description = "Build the coding-agent container (standards toolchain on the habitat base)"
+dir = "{{ config_root }}"
+run = "docker build -t habitat-coding -f packages/habitat/Dockerfile.coding-agent ."
+depends = ["habitat-build"]
+
+[tasks."coding-agent-smoke"]
+description = "Build + boot smoke check for the coding-agent image"
+dir = "{{ config_root }}"
+run = "scripts/smoke-coding-agent.sh"
+
 [tasks."habitat-run"]
 description = "Run the habitat container (port 8080, volume ./habitat-data:/data)"
 dir = "{{ config_root }}"

--- a/packages/habitat/Dockerfile
+++ b/packages/habitat/Dockerfile
@@ -40,8 +40,9 @@ WORKDIR /habitat
 
 COPY pnpm-workspace.yaml ./
 COPY packages/core/package.json ./packages/core/
+COPY packages/protocols/package.json ./packages/protocols/
+COPY packages/sessions/package.json ./packages/sessions/
 COPY packages/cli/package.json ./packages/cli/
-COPY packages/server/package.json ./packages/server/
 COPY packages/evaluation/package.json ./packages/evaluation/
 COPY packages/habitat/package.json ./packages/habitat/
 COPY packages/ui/package.json ./packages/ui/

--- a/packages/habitat/Dockerfile.coding-agent
+++ b/packages/habitat/Dockerfile.coding-agent
@@ -1,0 +1,98 @@
+# syntax=docker/dockerfile:1.4
+#
+# Coding Agent Container — the standards toolchain on the habitat base (#123).
+#
+# Layers onto the habitat serve image (build that first):
+#   - The-Focus-AI standards corpus at a fixed path (/opt/standards)
+#   - gh CLI, pi, and Claude Code toolchains (mise ships with the base)
+#   - Non-root execution: the server runs as the `node` user (uid 1000);
+#     the entrypoint wrapper does volume ownership as root, then drops.
+#   - Session co-location: CLAUDE_CONFIG_DIR comes from the base
+#     (/data/claude-config); this image adds PI_CODING_AGENT_DIR=/data/pi-agent
+#     so pi's settings AND session traces live on the data volume too.
+#   - Seed persona + routing: first boot with an empty volume gets a
+#     STIMULUS.md pointed at the standards corpus and a routing.json that
+#     binds a2a/web channels to the `workspace` agent on the claude-sdk
+#     runtime. Existing volume files are never overwritten.
+#
+# CMD is unchanged from the base — the container server (A2A + MCP + chat).
+#
+# Build (from monorepo root):
+#   docker build -t habitat -f packages/habitat/Dockerfile .
+#   docker build -t habitat-coding -f packages/habitat/Dockerfile.coding-agent .
+#
+# Smoke check:
+#   scripts/smoke-coding-agent.sh
+#
+# Deploy via Gaia: create a registry entry with "image": "habitat-coding"
+# and bind ANTHROPIC_API_KEY (claude-sdk runtime), GITHUB_TOKEN (gh), and
+# optionally OP_SERVICE_ACCOUNT_TOKEN. Or fly.io: volume at /data,
+# HABITAT_API_KEY + provider keys as fly secrets.
+
+ARG BASE_IMAGE=habitat
+FROM ${BASE_IMAGE}
+
+# Pinned toolchain versions — bump deliberately.
+ARG GH_VERSION=2.94.0
+ARG PI_PACKAGE=@earendil-works/pi-coding-agent@0.79.1
+ARG CLAUDE_PACKAGE=@anthropic-ai/claude-code@2.1.173
+ARG STANDARDS_REPO_URL=https://github.com/The-Focus-AI/standards.git
+ARG STANDARDS_REPO_BRANCH=main
+
+USER root
+
+# gosu: the entrypoint wrapper fixes /data ownership as root, then drops to
+# the node user before starting the server.
+RUN apt-get update && apt-get install -y --no-install-recommends gosu \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI (static release, arch-matched)
+RUN ARCH="$(dpkg --print-architecture)" \
+    && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz" \
+      | tar xz -C /tmp \
+    && install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${ARCH}/bin/gh" /usr/local/bin/gh \
+    && rm -rf /tmp/gh_*
+
+# pi and Claude Code CLIs, globally installed (root-owned, world-executable)
+RUN npm install -g "${PI_PACKAGE}" "${CLAUDE_PACKAGE}"
+
+# Standards corpus at a fixed path. Shallow clone — the agent reads it as a
+# reference; updating standards means rebuilding the image (out of band, per
+# PRD #113: the in-repo build task only covers the default habitat image).
+#
+# The repo is private: pass a token as a BuildKit secret —
+#   docker build --secret id=gh_token,env=GITHUB_TOKEN ...
+# The token is used only for this step and never lands in a layer. A public
+# STANDARDS_REPO_URL clones anonymously without the secret.
+RUN --mount=type=secret,id=gh_token \
+    set -e; \
+    if [ -s /run/secrets/gh_token ]; then \
+      AUTH_URL="$(echo "${STANDARDS_REPO_URL}" | sed "s#https://#https://x-access-token:$(cat /run/secrets/gh_token)@#")"; \
+    else \
+      AUTH_URL="${STANDARDS_REPO_URL}"; \
+    fi; \
+    GIT_TERMINAL_PROMPT=0 git clone --depth 1 --branch "${STANDARDS_REPO_BRANCH}" "${AUTH_URL}" /opt/standards; \
+    git -C /opt/standards remote set-url origin "${STANDARDS_REPO_URL}"
+
+# Non-root: the base installs mise behind /root (not traversable by node).
+# Re-home the binary and hand the mise data dir + standards corpus to node.
+RUN rm -f /usr/local/bin/mise \
+    && install -m 0755 /root/.local/bin/mise /usr/local/bin/mise \
+    && mkdir -p /opt/mise \
+    && chown -R node:node /opt/mise /opt/standards
+
+# pi co-location (#122): settings AND session traces under the data volume,
+# so they survive rebuilds and nativeSessionRef paths stay reachable.
+ENV PI_CODING_AGENT_DIR=/data/pi-agent
+ENV STANDARDS_DIR=/opt/standards
+
+# Seed assets + entrypoint wrapper
+COPY packages/habitat/coding-agent/STIMULUS.md \
+     packages/habitat/coding-agent/routing.json \
+     packages/habitat/coding-agent/seed-config.mjs \
+     /opt/coding-agent/
+COPY packages/habitat/coding-agent/entrypoint.sh /coding-agent-entrypoint.sh
+RUN chmod +x /coding-agent-entrypoint.sh
+
+ENTRYPOINT ["/coding-agent-entrypoint.sh"]
+CMD ["pnpm", "exec", "tsx", "packages/cli/src/entry.ts", "habitat", "serve", "--port", "8080", "--host", "0.0.0.0", "--skip-onboard"]

--- a/packages/habitat/coding-agent/STIMULUS.md
+++ b/packages/habitat/coding-agent/STIMULUS.md
@@ -1,0 +1,42 @@
+---
+role: self-healing coding agent for TheFocus.AI projects
+objective: scaffold, standardize, and maintain projects in the workspace so they comply with the TheFocus.AI standards corpus
+maxToolSteps: 50
+---
+
+You are the packaged TheFocus.AI coding agent. You live behind an A2A surface;
+people and other agents send you coding tasks over chat.
+
+## The standards corpus
+
+The TheFocus.AI standards live at `/opt/standards` (read-only reference —
+never edit it). Ground every decision in it:
+
+- `/opt/standards/AGENTS.md` — the entry document. Read it before your first
+  coding task in a session.
+- `/opt/standards/prompts/setup-project.md` — follow this when scaffolding a
+  new project.
+- `/opt/standards/prompts/standardize-project.md` — follow this when bringing
+  an existing project up to standard.
+- `/opt/standards/best-practices/` and `/opt/standards/templates/` — consult
+  for language- and tool-specific guidance.
+
+## Your workspace
+
+Projects live under `/data/workspace`. Coding tasks on your channel run
+through an agentic runtime (Claude Code or pi) with full tool access in that
+directory; its complete trace is linked from the session record.
+
+Toolchain available to you and the runtimes: `mise` (runtimes/deps), `gh`
+(GitHub), `git`, `pi`, `claude`, `rg`.
+
+## How to work
+
+1. For a new project: read the standards entry document, then apply
+   `setup-project.md`. Scaffold under `/data/workspace/<project-name>`.
+2. For an existing project: apply `standardize-project.md`; report what was
+   already compliant and what you changed.
+3. Self-apply the standards — don't ask permission for what the corpus
+   already mandates. Surface genuine ambiguities instead of guessing.
+4. Keep replies short: what you did, where it lives, what (if anything)
+   needs a human decision.

--- a/packages/habitat/coding-agent/entrypoint.sh
+++ b/packages/habitat/coding-agent/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -e
+
+# Coding-agent entrypoint wrapper (#123).
+#
+# Runs as root just long enough to (1) seed the volume with the default
+# persona, routing, and config agents — never overwriting what's already
+# there — and (2) hand the data volume to the node user. Then drops
+# privileges and chains into the base habitat entrypoint, which provisions
+# agents/skills and execs the container server as node (uid 1000).
+
+WORK_DIR="${HABITAT_WORK_DIR:-/data}"
+SEED_DIR=/opt/coding-agent
+
+mkdir -p "$WORK_DIR"
+
+# Persona: points the agent at the standards corpus (only when absent —
+# operators and Gaia seeds win).
+if [ ! -f "$WORK_DIR/STIMULUS.md" ]; then
+	cp "$SEED_DIR/STIMULUS.md" "$WORK_DIR/STIMULUS.md"
+	echo "[coding-agent] Seeded default STIMULUS.md (standards persona)."
+fi
+
+# Channel routing: bind a2a/web to the workspace agent on an agentic runtime.
+if [ ! -f "$WORK_DIR/routing.json" ]; then
+	cp "$SEED_DIR/routing.json" "$WORK_DIR/routing.json"
+	echo "[coding-agent] Seeded default routing.json (coding channel → claude-sdk)."
+fi
+
+# Config: ensure the workspace + standards-corpus agents exist (idempotent
+# merge — Gaia-seeded config.json fields are preserved).
+node "$SEED_DIR/seed-config.mjs" "$WORK_DIR/config.json"
+
+# Directories the runtimes expect under the volume.
+mkdir -p "$WORK_DIR/workspace" "$WORK_DIR/pi-agent" "$WORK_DIR/claude-config" "$WORK_DIR/sessions"
+
+# Hand the volume to the node user. Gaia re-seeds config/secrets as root on
+# every (re)start, so this must run every boot, not just the first.
+chown -R node:node "$WORK_DIR"
+
+exec gosu node /entrypoint.sh "$@"

--- a/packages/habitat/coding-agent/routing.json
+++ b/packages/habitat/coding-agent/routing.json
@@ -1,0 +1,7 @@
+{
+  "channels": {},
+  "platformDefaults": {
+    "a2a": { "agentId": "workspace", "runtime": "claude-sdk" },
+    "web": { "agentId": "workspace", "runtime": "claude-sdk" }
+  }
+}

--- a/packages/habitat/coding-agent/seed-config.mjs
+++ b/packages/habitat/coding-agent/seed-config.mjs
@@ -1,0 +1,62 @@
+/**
+ * Idempotent config.json seeder for the coding-agent image (#123).
+ *
+ * Ensures the two agents the seed routing/persona depend on exist:
+ *   - workspace        — write agent over /data/workspace (coding channel target)
+ *   - standards-corpus — read-only agent over /opt/standards (whitelists the
+ *                        corpus for file tools)
+ *
+ * Never overwrites existing fields: a Gaia-seeded config.json keeps its
+ * name, model, capabilities, and any agents it already declares. Creates a
+ * minimal config when the volume is empty (standalone docker run).
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+
+const configPath = process.argv[2];
+if (!configPath) {
+  console.error("usage: seed-config.mjs <path-to-config.json>");
+  process.exit(1);
+}
+
+const SEED_AGENTS = [
+  {
+    id: "workspace",
+    name: "Workspace",
+    projectPath: "/data/workspace",
+    mode: "write",
+  },
+  {
+    id: "standards-corpus",
+    name: "Standards Corpus",
+    projectPath: "/opt/standards",
+    mode: "read",
+  },
+];
+
+let config;
+try {
+  config = JSON.parse(readFileSync(configPath, "utf8"));
+} catch {
+  config = { name: "Coding Agent", agents: [] };
+}
+
+if (!Array.isArray(config.agents)) config.agents = [];
+
+let changed = false;
+for (const seed of SEED_AGENTS) {
+  if (!config.agents.some((a) => a && a.id === seed.id)) {
+    config.agents.push(seed);
+    changed = true;
+    console.log(`[coding-agent] Seeded agent "${seed.id}" into config.json.`);
+  }
+}
+
+let onDisk;
+try {
+  onDisk = readFileSync(configPath, "utf8");
+} catch {
+  onDisk = undefined;
+}
+if (changed || onDisk === undefined) {
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+}

--- a/reports/2026-06-11-coding-agent-image.md
+++ b/reports/2026-06-11-coding-agent-image.md
@@ -1,0 +1,73 @@
+# Coding-agent image — research (issue #123)
+
+Date: 2026-06-11. Scope: layer the standards toolchain onto the habitat serve
+image. Tech involved is established in-repo (Docker/entrypoint conventions,
+mise, the #127/#130 runtime env overrides); the new facts gathered here:
+
+## The standards corpus (verified via GitHub API)
+
+- `The-Focus-AI/standards` exists, **private**, default branch `main`.
+- Entry document `AGENTS.md`; the "setup/standardize prompts" are
+  `prompts/setup-project.md` and `prompts/standardize-project.md`; also
+  `best-practices/`, `templates/`, `mise.toml`, `.pi/`.
+- Its own README runs pi interactively in a throwaway container — this issue
+  puts the same corpus behind a persistent A2A habitat instead.
+- Private ⇒ image build needs credentials: BuildKit secret
+  (`--secret id=gh_token,env=GITHUB_TOKEN`) used only in the clone layer, with
+  the remote URL reset afterward so no token lands in the image.
+
+## Base image facts (packages/habitat/Dockerfile + entrypoint.sh)
+
+- `node:22-slim`, runs as **root**, work dir `/data` (volume), CMD
+  `habitat serve --port 8080 --skip-onboard`, `CLAUDE_CONFIG_DIR=/data/claude-config`
+  already set (#118 co-location). mise + docker CLI + git/ripgrep preinstalled;
+  mise binary lives behind `/root/.local` (not traversable by non-root).
+- entrypoint.sh provisions config.agents[] clones + skills, then `exec "$@"` —
+  a wrapper entrypoint can chain into it.
+- **The base Dockerfile was broken on main**: it still COPYs
+  `packages/server/package.json` (package deleted in the workspace split) and
+  misses `packages/protocols` / `packages/sessions`. The May 13 `habitat` tag
+  on this machine predates the RuntimeRunner seam entirely. Fixed in this
+  branch (verified: stale image lacked `web/routes/contexts.ts`).
+
+## Seeding + binding mechanics
+
+- `Habitat.create()` loads `/data/secrets.json` **values** into `process.env`
+  (fill-gaps) — so Gaia-vault secrets (ANTHROPIC_API_KEY, GITHUB_TOKEN) reach
+  the claude-sdk/pi runners and gh.
+- Gaia `buildSeedFiles()` seeds only `config.json` + `secrets.json`; persona
+  (`STIMULUS.md`) and `routing.json` are the image's to seed — copy-if-absent
+  in the wrapper entrypoint so operator/Gaia content always wins.
+- `config.agents[]` entries carry explicit `projectPath`; agent projectPaths
+  are added to the file-tools allowed roots, so a read-mode
+  `standards-corpus` agent over `/opt/standards` both names the corpus and
+  whitelists it.
+- routing fallback chain (bridge/routing.ts): exact channel → parent →
+  `platformDefaults[platform]` → `defaultAgentId` → main. Platform defaults
+  accept `{agentId, runtime}` — binding `a2a`/`web` to
+  `{workspace, claude-sdk}` makes every conversation a coding channel out of
+  the box without pinning specific contextIds.
+
+## Non-root
+
+- The node base image ships user `node` (uid 1000). The wrapper entrypoint
+  runs as root only to seed + `chown -R node:node /data` (required every boot:
+  Gaia re-seeds config/secrets as root on restart), then `exec gosu node`.
+- mise re-homed to a real `/usr/local/bin/mise` binary and `/opt/mise`
+  chowned, since the base's symlink target under `/root` is unreadable.
+
+## Toolchain pins (checked against registries 2026-06-11)
+
+- gh CLI v2.94.0 (static tarball, `dpkg --print-architecture` for
+  amd64/arm64 — the first build failed on this arm64 host with a hardcoded
+  amd64 URL).
+- `@earendil-works/pi-coding-agent@0.79.1`, `@anthropic-ai/claude-code@2.1.173`
+  (npm -g).
+- pi co-location: `PI_CODING_AGENT_DIR=/data/pi-agent` (settings AND sessions
+  under the volume — survives rebuilds; #130's runner computes
+  nativeSessionPath from the same env var).
+
+## Smoke findings
+
+- `/api/status` is served before the auth gate (open by design) — bearer-gate
+  assertions must target registered routes (`/api/contexts/...`).

--- a/scripts/smoke-coding-agent.sh
+++ b/scripts/smoke-coding-agent.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Smoke check for the coding-agent image (#123). Not part of the unit suite —
+# needs Docker and ~5 minutes on a cold build.
+#
+#   scripts/smoke-coding-agent.sh            # build base + coding image, boot, assert
+#   SKIP_BUILD=1 scripts/smoke-coding-agent.sh   # reuse existing images
+#
+# Asserts:
+#   1. image builds from the habitat base
+#   2. container boots the container server; /health is OK; bearer auth gates /api/*
+#   3. gh, pi, claude, mise, git, rg available inside
+#   4. standards corpus present at /opt/standards (entry doc + prompts)
+#   5. server process runs as the node user (non-root)
+#   6. persona + routing + workspace agent seeded into the volume, node-owned
+#   7. volume contents survive a stop/start (sessions intact)
+
+IMAGE_BASE="${IMAGE_BASE:-habitat}"
+IMAGE="${IMAGE:-habitat-coding}"
+NAME="smoke-coding-agent"
+VOLUME="smoke-coding-agent-data"
+PORT="${PORT:-7439}"
+API_KEY="smoke-key-123"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1" >&2; cleanup; exit 1; }
+
+cleanup() {
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+  docker volume rm "$VOLUME" >/dev/null 2>&1 || true
+}
+
+cexec() { docker exec "$NAME" "$@"; }
+
+echo "── 1. build"
+if [ -z "${SKIP_BUILD:-}" ]; then
+  docker image inspect "$IMAGE_BASE" >/dev/null 2>&1 \
+    || docker build -t "$IMAGE_BASE" -f packages/habitat/Dockerfile .
+  # The standards repo is private — pass a token as a BuildKit secret.
+  GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+  export GITHUB_TOKEN
+  SECRET_ARGS=()
+  [ -n "$GITHUB_TOKEN" ] && SECRET_ARGS=(--secret "id=gh_token,env=GITHUB_TOKEN")
+  docker build -t "$IMAGE" -f packages/habitat/Dockerfile.coding-agent \
+    --build-arg "BASE_IMAGE=$IMAGE_BASE" "${SECRET_ARGS[@]}" .
+fi
+pass "image $IMAGE built (base: $IMAGE_BASE)"
+
+cleanup
+docker volume create "$VOLUME" >/dev/null
+docker run -d --name "$NAME" -v "$VOLUME:/data" \
+  -e "HABITAT_API_KEY=$API_KEY" -p "127.0.0.1:$PORT:8080" "$IMAGE" >/dev/null
+
+echo "── 2. boot + auth"
+for i in $(seq 1 60); do
+  if curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then break; fi
+  if [ "$i" = 60 ]; then docker logs "$NAME" | tail -20; fail "server did not become healthy in 60s"; fi
+  sleep 1
+done
+curl -sf "http://127.0.0.1:$PORT/health" | grep -q '"status":"ok"' || fail "/health not ok"
+pass "/health ok"
+# /api/status is open by design; the registered routes (e.g. /api/contexts)
+# are the bearer-gated surface.
+[ "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/api/contexts/smoke")" = "401" ] \
+  || fail "unauthenticated gated /api/* not rejected"
+[ "$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $API_KEY" "http://127.0.0.1:$PORT/api/contexts/smoke")" = "404" ] \
+  || fail "bearer-authenticated gated /api/* not served"
+curl -sf -H "Authorization: Bearer $API_KEY" "http://127.0.0.1:$PORT/.well-known/agent-card.json" >/dev/null \
+  || fail "A2A agent card not served"
+pass "bearer auth gates registered /api/* routes; A2A agent card served"
+
+echo "── 3. toolchain"
+for tool in gh pi claude mise git rg; do
+  cexec sh -c "command -v $tool >/dev/null" || fail "$tool missing"
+done
+pass "gh, pi, claude, mise, git, rg present"
+
+echo "── 4. standards corpus"
+cexec test -f /opt/standards/AGENTS.md || fail "standards entry doc missing"
+cexec test -f /opt/standards/prompts/setup-project.md || fail "setup prompt missing"
+cexec test -f /opt/standards/prompts/standardize-project.md || fail "standardize prompt missing"
+pass "/opt/standards corpus present"
+
+echo "── 5. non-root"
+[ "$(cexec stat -c %u /proc/1)" = "1000" ] || fail "server (pid 1) not running as node (uid 1000)"
+pass "server runs as node (uid 1000)"
+
+echo "── 6. volume seeding"
+cexec test -f /data/STIMULUS.md || fail "STIMULUS.md not seeded"
+cexec grep -q "/opt/standards" /data/STIMULUS.md || fail "persona does not reference the standards corpus"
+cexec grep -q '"runtime": "claude-sdk"' /data/routing.json || fail "routing not bound to an agentic runtime"
+cexec node -e 'const c=JSON.parse(require("fs").readFileSync("/data/config.json","utf8")); if(!c.agents.some(a=>a.id==="workspace")) process.exit(1)' \
+  || fail "workspace agent not in config.json"
+[ "$(cexec stat -c %u /data/STIMULUS.md)" = "1000" ] || fail "/data not owned by node"
+pass "persona + routing + workspace agent seeded, node-owned"
+
+echo "── 7. stop/start persistence"
+cexec sh -c 'echo smoke-marker > /data/sessions/smoke-marker.txt'
+docker restart "$NAME" >/dev/null
+for i in $(seq 1 60); do
+  if curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then break; fi
+  if [ "$i" = 60 ]; then fail "server did not come back after restart"; fi
+  sleep 1
+done
+[ "$(cexec cat /data/sessions/smoke-marker.txt)" = "smoke-marker" ] || fail "volume contents lost across restart"
+cexec grep -q "/opt/standards" /data/STIMULUS.md || fail "persona overwritten on reboot"
+pass "volume survives restart; seeds not re-stamped"
+
+cleanup
+echo ""
+echo "PASS — coding-agent image smoke check complete."


### PR DESCRIPTION
Closes #123. Parent PRD: #113 — the packaged self-healing coding agent, composing #115 (per-entry image), #127 (runtime seam), #128 (context routes), and #130 (pi runner).

## What this builds

**`packages/habitat/Dockerfile.coding-agent`** — layers onto the habitat serve image:

- **Standards corpus at `/opt/standards`** (fixed path, shallow clone). The repo is private, so the clone uses a BuildKit secret (`--secret id=gh_token,env=GITHUB_TOKEN`) that never lands in a layer; the remote URL is reset after cloning.
- **Toolchain**: gh CLI (arch-matched static release), `@earendil-works/pi-coding-agent`, `@anthropic-ai/claude-code` (all version-pinned ARGs); mise/git/rg come from the base.
- **Non-root execution**: the wrapper entrypoint runs as root only to seed the volume and `chown` it (required every boot — Gaia re-seeds config/secrets as root), then `exec gosu node` into the base entrypoint. mise is re-homed out of `/root` so the node user can run it.
- **Session co-location**: `CLAUDE_CONFIG_DIR` comes from the base; this image adds `PI_CODING_AGENT_DIR=/data/pi-agent` so pi's settings *and* session traces live on the volume (#130's `nativeSessionPath` resolves against the same env).
- **Seed persona + binding** (`packages/habitat/coding-agent/`): a STIMULUS.md pointing the agent at `/opt/standards/AGENTS.md` and the `setup-project.md` / `standardize-project.md` prompts; a routing.json binding `a2a`/`web` platform defaults to the `workspace` agent on the **claude-sdk** runtime; an idempotent config seeder adding `workspace` (write, `/data/workspace`) and `standards-corpus` (read, `/opt/standards` — which also whitelists the corpus for file tools). All seeds are copy-if-absent: operator and Gaia content always wins, reboots never re-stamp.
- CMD unchanged — the container server (A2A + MCP + chat + bearer auth).

**Base Dockerfile fix (drive-by, necessary)**: `packages/habitat/Dockerfile` still COPYed the deleted `packages/server/package.json` and missed `protocols`/`sessions` — **the habitat image has been unbuildable since the package split** (my local `habitat` tag predated the entire runtime seam). Fixed to the current workspace layout.

**Smoke check**: `scripts/smoke-coding-agent.sh` (also `mise coding-agent-smoke`) — 7 sections: build, boot+auth+agent-card, toolchain presence, corpus presence, non-root (pid 1 uid==1000), volume seeding, stop/start persistence.

## Acceptance criteria from #123, with validation steps

**1. Image builds from the habitat base and boots the container server with A2A + bearer auth working.**
```bash
GITHUB_TOKEN=$(gh auth token) scripts/smoke-coding-agent.sh
```
Sections 1–2 (note: `/api/status` is open by design; the gated assertion targets `/api/contexts/...`).

**2. Standards repo, mise, gh, pi, and Claude Code available inside; agent runs as non-root.**
Smoke sections 3–5. Verified: all six tools on PATH, corpus + both prompts present, pid 1 runs as uid 1000.

**3. Seed persona references the standards corpus; coding channel bound to an agentic runtime out of the box.**
Smoke section 6 asserts the STIMULUS references `/opt/standards`, routing binds `claude-sdk`, and the `workspace` agent is in config.json.

**4. Runtime logs land under the data volume and are linked via nativeSessionRef.**
Live (below): `meta.json` → `nativeSessionRef.runtime: "pi"`, path `/data/pi-agent/sessions/--data-workspace--/…jsonl`, file present in the volume (45 KB native trace).

**5. A Gaia entry with this image starts, chats, and survives stop/rebuild with sessions intact.**
Live (below): entry `{"image":"habitat-coding"}` started via Gaia (#115 path), chatted over the Gaia A2A proxy, and after stop/start (and even a delete/recreate of the registry entry) the workspace, sessions, and routing were intact.

**6. Build/boot smoke check documented or scripted.** — `scripts/smoke-coding-agent.sh`, wired as `mise coding-agent-smoke`. Full output in my run: PASS on all 7 sections.

## Verified live (the demo from the issue)

Registered `coding-demo` with `"image": "habitat-coding"` on a fresh Gaia, bound secrets from the vault, started it, and over A2A asked it to scaffold `hello-standards`. The agent **read `/opt/standards` and produced a compliant project**: mise.toml with mise-managed tools, fnox-injected env, and the mandatory task set (`setup/install/dev/lint/test/deploy/secrets:*`); README with `mise trust → install → run setup` instructions. Then:

- `/data/workspace/hello-standards/{README.md,mise.toml}` exist
- `meta.json` carries the pi `nativeSessionRef`; the 31-event native trace is in the volume
- `GET /api/habitats/coding-demo/contexts/ctx-scaffold-1` (Gaia proxy → #128 route) returns `messageCount: 2` + the ref
- stop/start via Gaia: workspace + sessions + routing intact (new port assigned, volume untouched)

## Worth knowing / further work

- **The demo ran on the pi runtime, not claude-sdk**: the `ANTHROPIC_API_KEY` in the local `.env` is invalid (verified directly against `api.anthropic.com` — `authentication_error`). The claude-sdk chain was proven to the last hop (vault → secrets.json → process.env → Claude Code subprocess → Anthropic rejected the key). With a valid key, the seeded claude-sdk binding should work unchanged. **Recommend rotating the key in `.env`.**
- The runtime switch was done by editing `/data/routing.json` in the volume — which doubles as proof that operator overrides survive the seed logic.
- **Port-allocation gap bit again** (documented in #129): `findAvailablePort` ignores ports held by containers outside the registry; the demo seeded a placeholder entry to skirt the user's `gaia-a2a-probe` on 7440. Still worth its own small issue.
- **pi first-run in a fresh container** worked fine here (settings under `/data/pi-agent` persist), with `GEMINI_API_KEY` bound from the vault for pi's google provider.
- The standards corpus is baked at build time; refreshing it = rebuild the image (out of band, per the PRD). `STANDARDS_REPO_URL`/`BRANCH` are build ARGs.
- fly.io deployment needs only: this image, a volume at `/data`, `HABITAT_API_KEY` + provider keys as secrets — same artifact, second orchestrator (not exercised here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)