### PR TITLE
feat(gaia): session egress — bind-mount container sessions to the host (#119)

### DIFF
--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -13,6 +13,8 @@
  */
 
 import { execFile as execFileCb, spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import type { ContainerStatus, GaiaHabitatEntry } from "./types.js";
 
@@ -104,9 +106,20 @@ export class DockerManager {
   }
 
   /**
+   * Host path where a container's sessions are bind-mounted (#119) — one
+   * subdirectory per habitat entry under the Gaia data dir, so host-side
+   * introspection (`umwelten browse --sessions-dir`, the digester) sees
+   * in-container sessions with configuration only.
+   */
+  hostSessionsDir(id: string): string {
+    return join(this.dataDir, "sessions", id);
+  }
+
+  /**
    * Start a container for a habitat entry.
-   * Uses a named Docker volume and assigns a port from the 7440+ range.
-   * Returns the assigned host port.
+   * Uses a named Docker volume and assigns a port from the 7440+ range;
+   * the sessions subdirectory is additionally bind-mounted to the host
+   * (session egress, #119). Returns the assigned host port.
    */
   async startContainer(
     entry: GaiaHabitatEntry,
@@ -132,11 +145,18 @@ export class DockerManager {
     // Pick a port
     const hostPort = await this.findAvailablePort(allEntries ?? []);
 
+    // Session egress (#119): the sessions subdir lives on the host so it
+    // survives volume lifecycle and is readable by host-side introspection.
+    // Never cleared here — stop/rebuild preserves session files.
+    const sessionsHostDir = this.hostSessionsDir(entry.id);
+    await mkdir(sessionsHostDir, { recursive: true });
+
     const args = [
       "run", "-d",
       "--name", name,
       "--network", NETWORK_NAME,
       "-v", `${volume}:/data`,
+      "-v", `${sessionsHostDir}:/data/sessions`,
       "--env", `HABITAT_API_KEY=${entry.apiKey}`,
       "-p", `127.0.0.1:${hostPort}:8080`,
       image,

--- a/packages/habitat/src/tools/gaia/session-egress.test.ts
+++ b/packages/habitat/src/tools/gaia/session-egress.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Session egress tests (#119) — Gaia bind-mounts each container's sessions
+ * directory to a host path under the data dir so host-side introspection
+ * (umwelten browse, the digester) sees in-container sessions. Exec layer
+ * mocked; the host directory creation is real (tmp data dir).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, stat, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+type CallbackFn = (
+  error: Error | null,
+  result: { stdout: string; stderr: string },
+) => void;
+
+interface RecordedCall {
+  cmd: string;
+  args: string[];
+}
+
+let recordedCalls: RecordedCall[] = [];
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual('node:child_process');
+  return {
+    ...actual,
+    execFile: vi
+      .fn()
+      .mockImplementation(
+        (
+          cmd: string,
+          args?: string[] | CallbackFn,
+          options?: Record<string, unknown> | CallbackFn,
+          cb?: CallbackFn,
+        ) => {
+          let callback: CallbackFn | undefined;
+          if (typeof args === 'function') {
+            callback = args;
+          } else if (typeof options === 'function') {
+            callback = options;
+          } else {
+            callback = cb;
+          }
+          recordedCalls.push({ cmd, args: Array.isArray(args) ? args : [] });
+          if (callback) callback(null, { stdout: '', stderr: '' });
+          return {} as never;
+        },
+      ),
+  };
+});
+
+import { DockerManager } from './docker.js';
+import type { GaiaHabitatEntry } from './types.js';
+
+function makeEntry(id = 'egress-hab'): GaiaHabitatEntry {
+  return {
+    id,
+    name: 'Egress Hab',
+    config: { name: 'Egress Hab', agents: [] },
+    secretBindings: [],
+    apiKey: 'gaia_testkey',
+    createdAt: '2026-06-11T00:00:00.000Z',
+  };
+}
+
+function runArgs(): string[] {
+  const run = recordedCalls.find(
+    (c) => c.cmd === 'docker' && c.args[0] === 'run',
+  );
+  return run?.args ?? [];
+}
+
+describe('Gaia session egress (#119)', () => {
+  let dataDir: string;
+  let docker: DockerManager;
+
+  beforeEach(async () => {
+    recordedCalls = [];
+    dataDir = await mkdtemp(join(tmpdir(), 'umwl-gaia-egress-'));
+    docker = new DockerManager(dataDir, '/tmp/project');
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it('exposes the per-entry host sessions path', () => {
+    expect(docker.hostSessionsDir('egress-hab')).toBe(
+      join(dataDir, 'sessions', 'egress-hab'),
+    );
+  });
+
+  it('bind-mounts the sessions dir over the named volume in docker run', async () => {
+    await docker.startContainer(makeEntry(), '', []);
+    const args = runArgs();
+    const volumes = args.filter((_, i) => args[i - 1] === '-v');
+    // Named volume first, then the more specific sessions bind that shadows it.
+    expect(volumes).toEqual([
+      'gaia-egress-hab-data:/data',
+      `${join(dataDir, 'sessions', 'egress-hab')}:/data/sessions`,
+    ]);
+  });
+
+  it('creates the host sessions directory before docker run', async () => {
+    await docker.startContainer(makeEntry(), '', []);
+    const st = await stat(join(dataDir, 'sessions', 'egress-hab'));
+    expect(st.isDirectory()).toBe(true);
+  });
+
+  it('keeps existing host session files across restarts (no clearing)', async () => {
+    const hostDir = join(dataDir, 'sessions', 'egress-hab');
+    await mkdir(join(hostDir, 'ctx-1'), { recursive: true });
+    await writeFile(join(hostDir, 'ctx-1', 'transcript.jsonl'), '{}\n');
+
+    await docker.startContainer(makeEntry(), '', []);
+
+    const st = await stat(join(hostDir, 'ctx-1', 'transcript.jsonl'));
+    expect(st.isFile()).toBe(true);
+  });
+
+  it('keeps image, port, network, and api-key wiring unchanged', async () => {
+    await docker.startContainer(makeEntry(), '', []);
+    const args = runArgs();
+    expect(args[args.length - 1]).toBe('habitat');
+    expect(args).toContain('HABITAT_API_KEY=gaia_testkey');
+    expect(args.join(' ')).toMatch(/-p 127\.0\.0\.1:\d+:8080/);
+    expect(args).toContain('gaia-net');
+  });
+});

--- a/reports/2026-06-11-gaia-session-egress.md
+++ b/reports/2026-06-11-gaia-session-egress.md
@@ -1,0 +1,40 @@
+# Gaia session egress (bind-mount) — research (issue #119)
+
+Date: 2026-06-11. Scope: make in-container sessions visible to host-side
+introspection. Small slice; the relevant facts:
+
+## Mechanics
+
+- Sessions live at `/data/sessions/<sessionId>/` inside containers
+  (`HABITAT_WORK_DIR=/data`, session manager). The rest of `/data` stays a
+  named volume (`gaia-<id>-data`).
+- Docker supports nested mounts: a bind at `/data/sessions` shadows the named
+  volume's `sessions/` subdir regardless of `-v` flag order; listing the
+  named volume first, then the more specific bind, keeps intent readable.
+- Host path convention: `<gaiaDataDir>/sessions/<entryId>` — one subdir per
+  habitat entry, exposed as `DockerManager.hostSessionsDir(id)`.
+  `startContainer` mkdirs it (recursive, never clears) before `docker run`,
+  so stop/rebuild/recreate preserve session files on the host.
+- The host-side habitat session machinery reads any sessions dir via
+  `--sessions-dir` (`umwelten browse --sessions-dir`, `umwelten sessions
+  habitat list/show --sessions-dir`) — no new adapter code needed, exactly as
+  the issue intended.
+
+## Permissions
+
+- Base habitat image runs as root → writes to the bind fine. The
+  coding-agent image (#123) chowns `/data` recursively as root each boot
+  before dropping to node — which now also covers the bind mount. On macOS
+  Docker Desktop, uid mapping makes host reads trivially fine; on Linux the
+  files appear as the container's uid (root or 1000) — readable for
+  introspection run as the same user or via group/ACL setup (noted in PR).
+
+## Verified live
+
+- Fresh Gaia → entry → start → A2A chat → host has
+  `sessions/egress-demo/ctx-egress-1/{transcript.jsonl,meta.json}`;
+  `sessions habitat show` reads 2 messages from the host copy; stop +
+  rebuild (volume reseed) leaves host files intact.
+- Quirk noticed: `sessions habitat list` shows `0 msg` for the session while
+  `show` correctly reports 2 — pre-existing list-stats display issue,
+  unrelated to egress.


### PR DESCRIPTION
Closes #119. Parent PRD: #113 — the local half of the container/host observability gap (the remote half is #120).

## What this builds

`DockerManager.startContainer` additionally bind-mounts each container's sessions directory to a predictable host path:

- **`<gaiaDataDir>/sessions/<entryId>` ↔ `/data/sessions`** — exposed as `DockerManager.hostSessionsDir(id)`. The named volume still covers the rest of `/data`; the more specific bind shadows its `sessions/` subdir (nested-mount semantics, verified live).
- The host dir is created (`mkdir -p`) before `docker run` and **never cleared** — stop, rebuild (volume reseed), and even entry delete/recreate preserve session files on the host.
- No new adapter code: the existing habitat session machinery reads it via `--sessions-dir`, exactly as the issue intended.

## Tests

5 new unit tests (exec layer mocked, real tmp data dir); full suite **1383 passed**, lint 0 errors.

- `session-egress.test.ts` — `hostSessionsDir` mapping; docker run carries both mounts in order (named volume, then sessions bind); host dir created before run; pre-existing host session files untouched by a restart; image/port/network/api-key wiring unchanged.

## Acceptance criteria from #119, with validation steps

**1. Containers started by Gaia expose their sessions directory at a predictable host path under the data dir.**
```bash
npx vitest run packages/habitat/src/tools/gaia/session-egress.test.ts
```
Live: after one A2A message, the host had `/tmp/gaia-egress-demo/sessions/egress-demo/ctx-egress-1/{transcript.jsonl,meta.json}`.

**2. Existing containers/registries keep working; stop/rebuild preserves session files on the host.**
Registry schema untouched. Live: `POST .../stop` then `POST .../rebuild` (which stops, reseeds the volume, and restarts) left the host session files intact.

**3. `umwelten browse` pointed at the Gaia data dir lists in-container sessions.**
```bash
dotenvx run -- pnpm run cli browse --sessions-dir <gaiaDataDir>/sessions/<entryId>
```
Scripted equivalent (same data layer), verified live:
```bash
dotenvx run -- pnpm run cli sessions habitat show ctx-egress --sessions-dir /tmp/gaia-egress-demo/sessions/egress-demo
# → Messages: 2 (user: 1, assistant: 1) · First prompt: "Reply with exactly: egress works"
```
The TUI itself is worth one human smoke test (browse is interactive).

**4. Unit tests: docker run argument construction includes the bind mount with the right host path (exec layer mocked).** — see above.

**5. `pnpm test:run` passes.** — 1383 passed.

## Verified live (the demo from the issue)

Fresh Gaia → created `egress-demo` → started it → chatted over A2A (`"egress works"`) → the conversation appeared on the host filesystem as a Source Session and was readable by the host-side sessions CLI → stop/rebuild preserved it.

## Worth knowing / further work

- **Linux uid note**: files in the bind appear as the container's uid (root for the base image; node/1000 for the coding-agent image, whose entrypoint chown covers the bind too). On macOS Docker Desktop the uid mapping makes host reads transparent. Remote hosts are #120's territory.
- **Pre-existing display quirk noticed**: `sessions habitat list` shows `0 msg` for the session while `show` correctly counts 2 — the list's quick-stats path, unrelated to this change.
- **One Gaia per data dir** remains the assumption: per-entry subdirs avoid session-id collisions between habitats.
- The first A2A call immediately after `start` can hit "socket hang up" while the container boots (~5s) — pre-existing behavior of the proxy, retry succeeds once `/health` is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)