### PR TITLE
feat(habitat): wire per-agent MCP mount to mcp-serve (un-501) (#121)

### DIFF
--- a/packages/habitat/src/agent-mcp-mount.test.ts
+++ b/packages/habitat/src/agent-mcp-mount.test.ts
@@ -1,0 +1,246 @@
+/**
+ * resolveAgentMcpMount — manifest → mcp-serve handler wiring.
+ *
+ * The framework store and module loading are stubbed via deps, so these
+ * tests exercise exactly the resolution logic: export shapes, store
+ * driver selection, and the structured errors the container server turns
+ * into JSON responses.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { MemoryStore } from "@umwelten/protocols";
+import { resolveAgentMcpMount } from "./agent-mcp-mount.js";
+import type { AgentManifest } from "./identity/agent-manifest.js";
+
+const PROJECT = "/data/agents/demo/repo";
+
+function manifest(overrides: Partial<AgentManifest> = {}): AgentManifest {
+	return {
+		name: "demo-agent",
+		publicMcp: true,
+		publicRoutes: [],
+		publicAuth: {
+			kind: "oauth-server",
+			upstreamProvider: "dist/upstream.js",
+			registerTools: "dist/tools.js",
+		},
+		...overrides,
+	} as AgentManifest;
+}
+
+const validProvider = {
+	name: "stub",
+	buildAuthorizeUrl: () => "https://upstream.example/authorize",
+	exchangeCode: async () => ({
+		tokens: { access_token: "a", refresh_token: "r", expires_at: null },
+		userId: "u1",
+	}),
+	refreshToken: async () => ({
+		access_token: "a",
+		refresh_token: "r",
+		expires_at: null,
+	}),
+};
+
+function stubModules(modules: Record<string, Record<string, unknown>>) {
+	return vi.fn(async (absPath: string) => {
+		for (const [suffix, mod] of Object.entries(modules)) {
+			if (absPath.endsWith(suffix)) return mod;
+		}
+		throw new Error(`no stub module for ${absPath}`);
+	});
+}
+
+const silentWarn = () => {};
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe("resolveAgentMcpMount", () => {
+	it("wires manifest modules into a working mount (default export + in-memory store)", async () => {
+		const importModule = stubModules({
+			"dist/upstream.js": { default: validProvider },
+			"dist/tools.js": { default: async () => {} },
+		});
+		const warn = vi.fn();
+
+		const result = await resolveAgentMcpMount("demo", PROJECT, manifest(), {
+			importModule,
+			warn,
+		});
+
+		expect(result.ok).toBe(true);
+		// Modules resolve against the agent repo root.
+		expect(importModule).toHaveBeenCalledWith(`${PROJECT}/dist/upstream.js`);
+		expect(importModule).toHaveBeenCalledWith(`${PROJECT}/dist/tools.js`);
+		// No store configured → in-memory fallback is announced, not silent.
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining("in-memory"));
+
+		// The mount actually serves: AS metadata under the prefix.
+		if (!result.ok) throw new Error("unreachable");
+		let body = "";
+		const res = {
+			writeHead: vi.fn(),
+			end: (c?: string) => {
+				if (c) body += c;
+			},
+		} as unknown as ServerResponse;
+		const handled = await result.mount.handle(
+			{ method: "GET", url: "/x", headers: {} } as unknown as IncomingMessage,
+			res,
+			".well-known/oauth-authorization-server",
+			"http://h/agents/demo",
+		);
+		expect(handled).toBe(true);
+		expect(JSON.parse(body).authorization_endpoint).toBe(
+			"http://h/agents/demo/oauth/authorize",
+		);
+	});
+
+	it("accepts named exports (provider / registerTools)", async () => {
+		const result = await resolveAgentMcpMount("demo", PROJECT, manifest(), {
+			importModule: stubModules({
+				"dist/upstream.js": { provider: validProvider },
+				"dist/tools.js": { registerTools: async () => {} },
+			}),
+			warn: silentWarn,
+		});
+		expect(result.ok).toBe(true);
+	});
+
+	it("rejects an agent whose manifest has publicMcp false", async () => {
+		const result = await resolveAgentMcpMount(
+			"demo",
+			PROJECT,
+			manifest({ publicMcp: false }),
+			{ importModule: stubModules({}), warn: silentWarn },
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("unreachable");
+		expect(result.error.error).toBe("MCP_NOT_ENABLED");
+		expect(result.error.status).toBe(404);
+	});
+
+	it("reports a clear error when the provider module fails to load", async () => {
+		const result = await resolveAgentMcpMount("demo", PROJECT, manifest(), {
+			importModule: vi.fn(async () => {
+				throw new Error("Cannot find module");
+			}),
+			warn: silentWarn,
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("unreachable");
+		expect(result.error.error).toBe("UPSTREAM_PROVIDER_LOAD_FAILED");
+		expect(result.error.message).toContain("dist/upstream.js");
+		expect(result.error.message).toContain("Cannot find module");
+	});
+
+	it("rejects a provider module with the wrong export shape", async () => {
+		const result = await resolveAgentMcpMount("demo", PROJECT, manifest(), {
+			importModule: stubModules({
+				"dist/upstream.js": { default: { notAProvider: true } },
+				"dist/tools.js": { default: async () => {} },
+			}),
+			warn: silentWarn,
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("unreachable");
+		expect(result.error.error).toBe("UPSTREAM_PROVIDER_INVALID");
+	});
+
+	it("rejects a registrar module without a function export", async () => {
+		const result = await resolveAgentMcpMount("demo", PROJECT, manifest(), {
+			importModule: stubModules({
+				"dist/upstream.js": { default: validProvider },
+				"dist/tools.js": { default: "not a function" },
+			}),
+			warn: silentWarn,
+		});
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("unreachable");
+		expect(result.error.error).toBe("REGISTER_TOOLS_INVALID");
+	});
+
+	it("builds the neon store from the envRef connection string", async () => {
+		vi.stubEnv("DEMO_DATABASE_URL", "postgres://example");
+		const createNeonStore = vi.fn(() => new MemoryStore());
+
+		const result = await resolveAgentMcpMount(
+			"demo",
+			PROJECT,
+			manifest({
+				publicAuth: {
+					kind: "oauth-server",
+					upstreamProvider: "dist/upstream.js",
+					registerTools: "dist/tools.js",
+					store: { driver: "neon", envRef: "DEMO_DATABASE_URL" },
+				},
+			} as Partial<AgentManifest>),
+			{
+				importModule: stubModules({
+					"dist/upstream.js": { default: validProvider },
+					"dist/tools.js": { default: async () => {} },
+				}),
+				createNeonStore,
+				warn: silentWarn,
+			},
+		);
+
+		expect(result.ok).toBe(true);
+		expect(createNeonStore).toHaveBeenCalledWith("postgres://example");
+	});
+
+	it("errors clearly when the neon envRef is unset", async () => {
+		const result = await resolveAgentMcpMount(
+			"demo",
+			PROJECT,
+			manifest({
+				publicAuth: {
+					kind: "oauth-server",
+					upstreamProvider: "dist/upstream.js",
+					registerTools: "dist/tools.js",
+					store: { driver: "neon", envRef: "DEFINITELY_NOT_SET_12345" },
+				},
+			} as Partial<AgentManifest>),
+			{
+				importModule: stubModules({
+					"dist/upstream.js": { default: validProvider },
+					"dist/tools.js": { default: async () => {} },
+				}),
+				warn: silentWarn,
+			},
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("unreachable");
+		expect(result.error.error).toBe("STORE_ENV_MISSING");
+		expect(result.error.message).toContain("DEFINITELY_NOT_SET_12345");
+	});
+
+	it("errors clearly on the not-yet-implemented sqlite driver", async () => {
+		const result = await resolveAgentMcpMount(
+			"demo",
+			PROJECT,
+			manifest({
+				publicAuth: {
+					kind: "oauth-server",
+					upstreamProvider: "dist/upstream.js",
+					registerTools: "dist/tools.js",
+					store: { driver: "sqlite", path: "./oauth.db" },
+				},
+			} as Partial<AgentManifest>),
+			{
+				importModule: stubModules({
+					"dist/upstream.js": { default: validProvider },
+					"dist/tools.js": { default: async () => {} },
+				}),
+				warn: silentWarn,
+			},
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) throw new Error("unreachable");
+		expect(result.error.error).toBe("STORE_DRIVER_UNSUPPORTED");
+		expect(result.error.message).toContain("sqlite");
+	});
+});

--- a/packages/habitat/src/agent-mcp-mount.ts
+++ b/packages/habitat/src/agent-mcp-mount.ts
@@ -1,0 +1,191 @@
+/**
+ * agent-mcp-mount — resolve an mcp-agent's manifest into a live mcp-serve mount.
+ *
+ * The manifest (identity/agent-manifest.ts) declares the mcp-serve
+ * configuration declaratively:
+ *   publicAuth.upstreamProvider — JS module exporting an UpstreamOAuthProvider
+ *                                 (`default` or `provider`)
+ *   publicAuth.registerTools    — JS module exporting an McpToolRegistrar
+ *                                 (`default` or `registerTools`)
+ *   publicAuth.store            — neon | sqlite | omitted (in-memory)
+ *
+ * This module turns that into a McpServeMount the container server can
+ * dispatch requests to. Failures are returned as structured errors (never
+ * thrown) so the host can answer with a clear JSON response instead of
+ * crashing the request loop.
+ *
+ * Deps (module import, Neon store construction) are injectable so unit
+ * tests can stub the framework store and avoid touching the filesystem.
+ */
+
+import { pathToFileURL } from "node:url";
+import {
+	createMcpServeMount,
+	MemoryStore,
+	NeonStore,
+	type McpServeMount,
+	type McpServeStore,
+	type McpToolRegistrar,
+	type UpstreamOAuthProvider,
+} from "@umwelten/protocols";
+import {
+	resolveManifestPath,
+	type AgentManifest,
+} from "./identity/agent-manifest.js";
+
+export interface AgentMcpMountError {
+	/** Stable machine-readable code, e.g. "MCP_NOT_ENABLED". */
+	error: string;
+	/** Human-readable explanation with enough detail to fix the manifest. */
+	message: string;
+	/** Suggested HTTP status for the host to respond with. */
+	status: number;
+}
+
+export type AgentMcpMountResult =
+	| { ok: true; mount: McpServeMount }
+	| { ok: false; error: AgentMcpMountError };
+
+export interface AgentMcpMountDeps {
+	/** Import a JS module by absolute path. Default: dynamic import(). */
+	importModule?: (absPath: string) => Promise<Record<string, unknown>>;
+	/** Construct the Neon-backed store. Default: new NeonStore(conn). */
+	createNeonStore?: (connectionString: string) => McpServeStore;
+	/** Construct the fallback in-memory store. Default: new MemoryStore(). */
+	createMemoryStore?: () => McpServeStore;
+	/** Warning sink. Default: console.warn. */
+	warn?: (message: string) => void;
+}
+
+function err(error: string, message: string, status: number): AgentMcpMountResult {
+	return { ok: false, error: { error, message, status } };
+}
+
+async function defaultImportModule(absPath: string): Promise<Record<string, unknown>> {
+	return (await import(pathToFileURL(absPath).href)) as Record<string, unknown>;
+}
+
+function looksLikeUpstreamProvider(value: unknown): value is UpstreamOAuthProvider {
+	if (!value || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	return (
+		typeof v.name === "string" &&
+		typeof v.buildAuthorizeUrl === "function" &&
+		typeof v.exchangeCode === "function" &&
+		typeof v.refreshToken === "function"
+	);
+}
+
+/**
+ * Resolve a manifest into a ready-to-serve McpServeMount.
+ *
+ * @param agentId     - the agent's id (used in error messages / server name)
+ * @param projectPath - the agent's repo root; manifest paths resolve against it
+ * @param manifest    - the already-validated agent manifest
+ */
+export async function resolveAgentMcpMount(
+	agentId: string,
+	projectPath: string,
+	manifest: AgentManifest,
+	deps: AgentMcpMountDeps = {},
+): Promise<AgentMcpMountResult> {
+	const importModule = deps.importModule ?? defaultImportModule;
+	const warn = deps.warn ?? ((m: string) => console.warn(m));
+
+	if (!manifest.publicMcp) {
+		return err(
+			"MCP_NOT_ENABLED",
+			`agent "${agentId}" does not expose an MCP endpoint — its manifest has publicMcp: false (or unset).`,
+			404,
+		);
+	}
+
+	const auth = manifest.publicAuth;
+	if (!auth) {
+		// parseAgentManifest enforces this; guard anyway for manifests built in code.
+		return err(
+			"MCP_AUTH_MISSING",
+			`agent "${agentId}" has publicMcp: true but no publicAuth oauth-server configuration.`,
+			422,
+		);
+	}
+
+	// ── Upstream OAuth provider module ────────────────────────────
+	const providerPath = resolveManifestPath(projectPath, auth.upstreamProvider);
+	let providerModule: Record<string, unknown>;
+	try {
+		providerModule = await importModule(providerPath);
+	} catch (e) {
+		return err(
+			"UPSTREAM_PROVIDER_LOAD_FAILED",
+			`agent "${agentId}": failed to load upstreamProvider module ${auth.upstreamProvider} (${providerPath}): ${e instanceof Error ? e.message : String(e)}`,
+			422,
+		);
+	}
+	const upstream = providerModule.default ?? providerModule.provider;
+	if (!looksLikeUpstreamProvider(upstream)) {
+		return err(
+			"UPSTREAM_PROVIDER_INVALID",
+			`agent "${agentId}": ${auth.upstreamProvider} must export an UpstreamOAuthProvider (name, buildAuthorizeUrl, exchangeCode, refreshToken) as \`default\` or \`provider\`.`,
+			422,
+		);
+	}
+
+	// ── Tool registrar module ─────────────────────────────────────
+	const registrarPath = resolveManifestPath(projectPath, auth.registerTools);
+	let registrarModule: Record<string, unknown>;
+	try {
+		registrarModule = await importModule(registrarPath);
+	} catch (e) {
+		return err(
+			"REGISTER_TOOLS_LOAD_FAILED",
+			`agent "${agentId}": failed to load registerTools module ${auth.registerTools} (${registrarPath}): ${e instanceof Error ? e.message : String(e)}`,
+			422,
+		);
+	}
+	const registerTools = registrarModule.default ?? registrarModule.registerTools;
+	if (typeof registerTools !== "function") {
+		return err(
+			"REGISTER_TOOLS_INVALID",
+			`agent "${agentId}": ${auth.registerTools} must export an McpToolRegistrar function as \`default\` or \`registerTools\`.`,
+			422,
+		);
+	}
+
+	// ── Store ─────────────────────────────────────────────────────
+	let store: McpServeStore;
+	if (!auth.store) {
+		store = deps.createMemoryStore ? deps.createMemoryStore() : new MemoryStore();
+		warn(
+			`[agent-mcp-mount] agent "${agentId}": no store configured — using in-memory OAuth state (lost on restart). Configure publicAuth.store for persistence.`,
+		);
+	} else if (auth.store.driver === "neon") {
+		const conn = process.env[auth.store.envRef];
+		if (!conn) {
+			return err(
+				"STORE_ENV_MISSING",
+				`agent "${agentId}": store driver "neon" reads the connection string from env var ${auth.store.envRef}, which is not set.`,
+				422,
+			);
+		}
+		store = deps.createNeonStore
+			? deps.createNeonStore(conn)
+			: new NeonStore(conn);
+	} else {
+		return err(
+			"STORE_DRIVER_UNSUPPORTED",
+			`agent "${agentId}": store driver "${auth.store.driver}" is not implemented yet — use driver "neon" or omit store for in-memory state.`,
+			422,
+		);
+	}
+
+	const mount = createMcpServeMount({
+		name: manifest.name,
+		version: manifest.version,
+		upstream,
+		registerTools: registerTools as McpToolRegistrar,
+		store,
+	});
+
+	return { ok: true, mount };
+}

--- a/packages/habitat/src/agent-surface.test.ts
+++ b/packages/habitat/src/agent-surface.test.ts
@@ -1,0 +1,344 @@
+/**
+ * createAgentSurface — the /agents/<id>/... routing of the container server.
+ *
+ * Covers the issue-#121 acceptance criteria:
+ *  - the per-agent MCP path serves a real mcp-serve handler (no more 501)
+ *  - manifest.json and static UI serving keep working as before
+ *  - an agent without MCP configuration yields a clear error, not a crash
+ *  - the RFC 8414 path-inserted discovery URLs route into the right mount
+ *
+ * Uses a minimal host stub (getAgent/getMcpAgents) and stubbed manifest
+ * modules — no container server, no network, no real OAuth provider.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createAgentSurface, type AgentSurfaceHost } from "./agent-surface.js";
+import type { AgentManifest } from "./identity/agent-manifest.js";
+import type { AgentEntry } from "./types.js";
+
+function fakeReq(method: string, url: string): IncomingMessage {
+	// x-forwarded-proto pins getPublicBaseUrl to the host header — the test
+	// runner's ambient BASE_URL (vite injects "/") must not leak into URLs.
+	return {
+		method,
+		url,
+		headers: { host: "localhost:7430", "x-forwarded-proto": "http" },
+	} as unknown as IncomingMessage;
+}
+
+function fakeRes() {
+	let statusCode = 0;
+	const headers: Record<string, string> = {};
+	let body = "";
+	let headersSent = false;
+	const res = {
+		get headersSent() {
+			return headersSent;
+		},
+		writeHead(code: number, h?: Record<string, string | number>) {
+			statusCode = code;
+			if (h) for (const [k, v] of Object.entries(h)) headers[k] = String(v);
+			headersSent = true;
+			return res;
+		},
+		setHeader(k: string, v: string) {
+			headers[k] = v;
+		},
+		end(chunk?: string | Buffer) {
+			if (chunk) body += chunk.toString();
+		},
+	};
+	return {
+		res: res as unknown as ServerResponse,
+		status: () => statusCode,
+		header: (k: string) => headers[k],
+		body: () => body,
+		json: () => JSON.parse(body),
+	};
+}
+
+const validProvider = {
+	name: "stub",
+	buildAuthorizeUrl: () => "https://upstream.example/authorize",
+	exchangeCode: async () => ({
+		tokens: { access_token: "a", refresh_token: "r", expires_at: null },
+		userId: "u1",
+	}),
+	refreshToken: async () => ({
+		access_token: "a",
+		refresh_token: "r",
+		expires_at: null,
+	}),
+};
+
+const stubImportModule = vi.fn(async (absPath: string) => {
+	if (absPath.endsWith("dist/upstream.js")) return { default: validProvider };
+	if (absPath.endsWith("dist/tools.js")) return { default: async () => {} };
+	throw new Error(`no stub module for ${absPath}`);
+});
+
+let uiDir: string;
+let projectDir: string;
+
+beforeAll(async () => {
+	projectDir = await mkdtemp(join(tmpdir(), "agent-surface-test-"));
+	uiDir = join(projectDir, "public");
+	await mkdir(uiDir, { recursive: true });
+	await writeFile(join(uiDir, "index.html"), "<h1>demo ui</h1>");
+	await writeFile(join(uiDir, "app.css"), "body{}");
+});
+
+afterAll(async () => {
+	await rm(projectDir, { recursive: true, force: true });
+});
+
+function makeHost(): AgentSurfaceHost {
+	const mcpAgent: AgentEntry = {
+		id: "demo",
+		name: "Demo",
+		projectPath: projectDir,
+		kind: "mcp-agent",
+	} as AgentEntry;
+	const uiOnlyAgent: AgentEntry = {
+		id: "ui-only",
+		name: "UI Only",
+		projectPath: projectDir,
+		kind: "mcp-agent",
+	} as AgentEntry;
+	const brokenAgent: AgentEntry = {
+		id: "broken",
+		name: "Broken",
+		projectPath: projectDir,
+		kind: "mcp-agent",
+	} as AgentEntry;
+	const bareAgent: AgentEntry = {
+		id: "bare",
+		name: "Bare",
+		projectPath: projectDir,
+		kind: "mcp-agent",
+	} as AgentEntry;
+	const normalAgent: AgentEntry = {
+		id: "normal",
+		name: "Normal",
+		projectPath: projectDir,
+	} as AgentEntry;
+
+	const demoManifest = {
+		name: "demo-agent",
+		publicMcp: true,
+		publicRoutes: [],
+		publicUiDir: "public",
+		publicAuth: {
+			kind: "oauth-server",
+			upstreamProvider: "dist/upstream.js",
+			registerTools: "dist/tools.js",
+		},
+	} as AgentManifest;
+
+	const uiOnlyManifest = {
+		name: "ui-only-agent",
+		publicMcp: false,
+		publicRoutes: [],
+		publicUiDir: "public",
+	} as AgentManifest;
+
+	const agents: Record<string, AgentEntry> = {
+		demo: mcpAgent,
+		"ui-only": uiOnlyAgent,
+		broken: brokenAgent,
+		bare: bareAgent,
+		normal: normalAgent,
+	};
+
+	return {
+		getAgent: (id) => agents[id],
+		getMcpAgents: async () => ({
+			mcpAgents: [
+				{ agent: mcpAgent, manifest: demoManifest, path: join(projectDir, "agent-manifest.json") },
+				{ agent: uiOnlyAgent, manifest: uiOnlyManifest, path: join(projectDir, "agent-manifest.json") },
+			],
+			unmanifested: [bareAgent],
+			errors: [{ agent: brokenAgent, error: "publicMcp is true but publicAuth is missing" }],
+		}),
+	};
+}
+
+function makeSurface() {
+	return createAgentSurface(makeHost(), {
+		importModule: stubImportModule,
+		warn: () => {},
+	});
+}
+
+describe("createAgentSurface — MCP mount (un-501)", () => {
+	it("serves a real mcp-serve handler on /agents/<id>/mcp (401 challenge, not 501)", async () => {
+		const surface = makeSurface();
+		const { res, status, header } = fakeRes();
+
+		const handled = await surface.handle(fakeReq("GET", "/agents/demo/mcp"), res, "/agents/demo/mcp");
+
+		expect(handled).toBe(true);
+		expect(status()).toBe(401);
+		expect(header("WWW-Authenticate")).toContain(
+			"http://localhost:7430/agents/demo/.well-known/oauth-protected-resource",
+		);
+	});
+
+	it("serves suffix-style AS metadata under the agent prefix", async () => {
+		const surface = makeSurface();
+		const { res, status, json } = fakeRes();
+
+		await surface.handle(
+			fakeReq("GET", "/agents/demo/.well-known/oauth-authorization-server"),
+			res,
+			"/agents/demo/.well-known/oauth-authorization-server",
+		);
+
+		expect(status()).toBe(200);
+		expect(json().authorization_endpoint).toBe(
+			"http://localhost:7430/agents/demo/oauth/authorize",
+		);
+	});
+
+	it("routes RFC 8414 path-inserted discovery URLs into the agent's mount", async () => {
+		const surface = makeSurface();
+
+		const asMeta = fakeRes();
+		await surface.handle(
+			fakeReq("GET", "/.well-known/oauth-authorization-server/agents/demo"),
+			asMeta.res,
+			"/.well-known/oauth-authorization-server/agents/demo",
+		);
+		expect(asMeta.status()).toBe(200);
+		expect(asMeta.json().issuer).toBe("http://localhost:7430/agents/demo");
+
+		const prMeta = fakeRes();
+		await surface.handle(
+			fakeReq("GET", "/.well-known/oauth-protected-resource/agents/demo/mcp"),
+			prMeta.res,
+			"/.well-known/oauth-protected-resource/agents/demo/mcp",
+		);
+		expect(prMeta.status()).toBe(200);
+		expect(prMeta.json().authorization_servers).toEqual([
+			"http://localhost:7430/agents/demo",
+		]);
+	});
+
+	it("returns 404 for path-inserted discovery of an unknown agent", async () => {
+		const surface = makeSurface();
+		const { res, status, json } = fakeRes();
+
+		const handled = await surface.handle(
+			fakeReq("GET", "/.well-known/oauth-authorization-server/agents/nope"),
+			res,
+			"/.well-known/oauth-authorization-server/agents/nope",
+		);
+
+		expect(handled).toBe(true);
+		expect(status()).toBe(404);
+		expect(json().error).toBe("UNKNOWN_AGENT");
+	});
+
+	it("caches the resolved mount per agent (modules import once)", async () => {
+		stubImportModule.mockClear();
+		const surface = makeSurface();
+
+		const r1 = fakeRes();
+		await surface.handle(fakeReq("GET", "/agents/demo/mcp"), r1.res, "/agents/demo/mcp");
+		const r2 = fakeRes();
+		await surface.handle(fakeReq("GET", "/agents/demo/mcp"), r2.res, "/agents/demo/mcp");
+
+		const upstreamLoads = stubImportModule.mock.calls.filter(([p]) =>
+			p.endsWith("dist/upstream.js"),
+		);
+		expect(upstreamLoads).toHaveLength(1);
+	});
+});
+
+describe("createAgentSurface — agents without MCP configuration", () => {
+	it("answers /mcp with a clear MCP_NOT_ENABLED error when publicMcp is false", async () => {
+		const surface = makeSurface();
+		const { res, status, json } = fakeRes();
+
+		const handled = await surface.handle(
+			fakeReq("GET", "/agents/ui-only/mcp"),
+			res,
+			"/agents/ui-only/mcp",
+		);
+
+		expect(handled).toBe(true);
+		expect(status()).toBe(404);
+		expect(json().error).toBe("MCP_NOT_ENABLED");
+		expect(json().message).toContain("publicMcp");
+	});
+
+	it("keeps the existing manifest errors: invalid manifest → 422, missing → 503", async () => {
+		const surface = makeSurface();
+
+		const invalid = fakeRes();
+		await surface.handle(fakeReq("GET", "/agents/broken/mcp"), invalid.res, "/agents/broken/mcp");
+		expect(invalid.status()).toBe(422);
+		expect(invalid.json().error).toBe("MANIFEST_INVALID");
+
+		const missing = fakeRes();
+		await surface.handle(fakeReq("GET", "/agents/bare/mcp"), missing.res, "/agents/bare/mcp");
+		expect(missing.status()).toBe(503);
+		expect(missing.json().error).toBe("MANIFEST_NOT_FOUND");
+	});
+});
+
+describe("createAgentSurface — manifest + static UI (unchanged behavior)", () => {
+	it("serves manifest.json", async () => {
+		const surface = makeSurface();
+		const { res, status, json } = fakeRes();
+
+		await surface.handle(fakeReq("GET", "/agents/demo/manifest.json"), res, "/agents/demo/manifest.json");
+
+		expect(status()).toBe(200);
+		expect(json().name).toBe("demo-agent");
+	});
+
+	it("serves index.html at the agent root and assets by path", async () => {
+		const surface = makeSurface();
+
+		const root = fakeRes();
+		await surface.handle(fakeReq("GET", "/agents/demo"), root.res, "/agents/demo");
+		expect(root.status()).toBe(200);
+		expect(root.header("Content-Type")).toContain("text/html");
+		expect(root.body()).toContain("demo ui");
+
+		const css = fakeRes();
+		await surface.handle(fakeReq("GET", "/agents/demo/app.css"), css.res, "/agents/demo/app.css");
+		expect(css.status()).toBe(200);
+		expect(css.header("Content-Type")).toContain("text/css");
+	});
+
+	it("still rejects path traversal and missing files", async () => {
+		const surface = makeSurface();
+
+		const traversal = fakeRes();
+		await surface.handle(
+			fakeReq("GET", "/agents/demo/..%2Fsecret"),
+			traversal.res,
+			"/agents/demo/../secret",
+		);
+		expect(traversal.status()).toBe(400);
+
+		const missing = fakeRes();
+		await surface.handle(fakeReq("GET", "/agents/demo/nope.png"), missing.res, "/agents/demo/nope.png");
+		expect(missing.status()).toBe(404);
+	});
+
+	it("falls through (returns false) for non-mcp agents and non-agent paths", async () => {
+		const surface = makeSurface();
+		const { res } = fakeRes();
+
+		expect(await surface.handle(fakeReq("GET", "/agents/normal/mcp"), res, "/agents/normal/mcp")).toBe(false);
+		expect(await surface.handle(fakeReq("GET", "/agents/missing"), res, "/agents/missing")).toBe(false);
+		expect(await surface.handle(fakeReq("GET", "/api/health"), res, "/api/health")).toBe(false);
+	});
+});

--- a/packages/habitat/src/agent-surface.ts
+++ b/packages/habitat/src/agent-surface.ts
@@ -1,0 +1,243 @@
+/**
+ * agent-surface — the /agents/<id>/... public surface of the container server.
+ *
+ * Serves, per mcp-agent:
+ *   /agents/<id>/manifest.json   → the validated agent-manifest.json
+ *   /agents/<id>/mcp             → mcp-serve OAuth 2.1 MCP endpoint (when publicMcp)
+ *   /agents/<id>/oauth/*         → the mount's OAuth endpoints
+ *   /agents/<id>/.well-known/*   → suffix-style OAuth metadata
+ *   /agents/<id>/<file>          → static files under manifest.publicUiDir
+ *
+ * Plus the RFC 8414 path-inserted discovery URLs at the host root, which
+ * MCP SDK clients require for a path-bearing issuer (they never try the
+ * suffix form for authorization-server metadata):
+ *   /.well-known/oauth-authorization-server/agents/<id>
+ *   /.well-known/oauth-protected-resource/agents/<id>[/mcp]
+ *
+ * This surface is intentionally NOT gated by HABITAT_API_KEY: the mount's
+ * own OAuth layer authenticates /mcp, and the UI, manifest, and OAuth
+ * endpoints must be publicly reachable for the connector flow to work.
+ * The habitat's own bearer-only /mcp endpoint is unaffected.
+ *
+ * Extracted from startContainerServer so the routing is unit-testable
+ * against a minimal host stub.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { readFile, stat } from "node:fs/promises";
+import { resolve, extname } from "node:path";
+import {
+	getPublicBaseUrl,
+	isMcpServeMountPath,
+	type McpServeMount,
+} from "@umwelten/protocols";
+import type { AgentManifest } from "./identity/agent-manifest.js";
+import type { AgentEntry } from "./types.js";
+import {
+	resolveAgentMcpMount,
+	type AgentMcpMountDeps,
+} from "./agent-mcp-mount.js";
+
+/** The slice of Habitat the agent surface needs. */
+export interface AgentSurfaceHost {
+	getAgent(idOrName: string): AgentEntry | undefined;
+	getMcpAgents(): Promise<{
+		mcpAgents: { agent: AgentEntry; manifest: AgentManifest; path: string }[];
+		unmanifested: AgentEntry[];
+		errors: { agent: AgentEntry; error: string }[];
+	}>;
+}
+
+export interface AgentSurface {
+	/**
+	 * Handle a request if it belongs to the agent surface.
+	 * @param path - URL pathname (query already stripped)
+	 * @returns true if the request was handled (response sent)
+	 */
+	handle(
+		req: IncomingMessage,
+		res: ServerResponse,
+		path: string,
+	): Promise<boolean>;
+}
+
+function sendJson(res: ServerResponse, data: unknown, status = 200): void {
+	res.writeHead(status, {
+		"Content-Type": "application/json",
+		"Cache-Control": "no-cache",
+	});
+	res.end(JSON.stringify(data));
+}
+
+const PATH_INSERTED_WELL_KNOWN =
+	/^\/\.well-known\/(oauth-protected-resource|oauth-authorization-server)\/agents\/([^/]+)(\/mcp)?$/;
+const AGENT_PATH = /^\/agents\/([^/]+)(?:\/(.*))?$/;
+
+export function createAgentSurface(
+	host: AgentSurfaceHost,
+	mountDeps: AgentMcpMountDeps = {},
+): AgentSurface {
+	// Resolved mounts are cached per agent id (module import + store
+	// construction happen once). Resolution errors are NOT cached so a
+	// fixed manifest or env var heals on the next request.
+	const mounts = new Map<string, McpServeMount>();
+
+	async function dispatchToMount(
+		req: IncomingMessage,
+		res: ServerResponse,
+		agentId: string,
+		agent: AgentEntry,
+		manifest: AgentManifest,
+		subPath: string,
+	): Promise<void> {
+		let mount = mounts.get(agentId);
+		if (!mount) {
+			const result = await resolveAgentMcpMount(
+				agentId,
+				agent.projectPath,
+				manifest,
+				mountDeps,
+			);
+			if (!result.ok) {
+				sendJson(
+					res,
+					{ error: result.error.error, agentId, message: result.error.message },
+					result.error.status,
+				);
+				return;
+			}
+			mount = result.mount;
+			mounts.set(agentId, mount);
+		}
+
+		const baseUrl = `${getPublicBaseUrl(req)}/agents/${agentId}`;
+		const handled = await mount.handle(req, res, subPath, baseUrl);
+		if (!handled) {
+			sendJson(res, { error: "NOT_FOUND", agentId, subPath }, 404);
+		}
+	}
+
+	return {
+		async handle(req, res, path) {
+			// RFC 8414 path-inserted discovery at the host root.
+			let agentId: string;
+			let subPath: string;
+			const wellKnown = path.match(PATH_INSERTED_WELL_KNOWN);
+			if (wellKnown) {
+				agentId = wellKnown[2];
+				subPath = `.well-known/${wellKnown[1]}`;
+			} else {
+				const m = path.match(AGENT_PATH);
+				if (!m) return false;
+				agentId = m[1];
+				subPath = m[2] ?? "";
+			}
+
+			const agent = host.getAgent(agentId);
+			if (!agent || agent.kind !== "mcp-agent") {
+				// Path-inserted well-known URLs belong to this surface even when
+				// the agent is unknown; /agents/<id> falls through as before.
+				if (wellKnown) {
+					sendJson(res, { error: "UNKNOWN_AGENT", agentId }, 404);
+					return true;
+				}
+				return false;
+			}
+
+			const all = await host.getMcpAgents();
+			const found = all.mcpAgents.find((x) => x.agent.id === agentId);
+			const manifestErr = all.errors.find((e) => e.agent.id === agentId);
+
+			if (!found) {
+				sendJson(
+					res,
+					{
+						error: manifestErr ? "MANIFEST_INVALID" : "MANIFEST_NOT_FOUND",
+						agentId,
+						message:
+							manifestErr?.error ??
+							"agent has no agent-manifest.json (cannot mount)",
+					},
+					manifestErr ? 422 : 503,
+				);
+				return true;
+			}
+
+			// MCP / OAuth surface — reserved subpaths go to the mcp-serve mount.
+			if (isMcpServeMountPath(subPath)) {
+				if (!found.manifest.publicMcp) {
+					if (subPath === "mcp") {
+						sendJson(
+							res,
+							{
+								error: "MCP_NOT_ENABLED",
+								agentId,
+								message: `agent "${agentId}" does not expose an MCP endpoint — its manifest has publicMcp: false (or unset).`,
+							},
+							404,
+						);
+						return true;
+					}
+					// Not an MCP agent surface — let oauth/.well-known names fall
+					// through to the static UI below.
+				} else {
+					await dispatchToMount(req, res, agentId, agent, found.manifest, subPath);
+					return true;
+				}
+			}
+
+			if (subPath === "manifest.json") {
+				sendJson(res, found.manifest);
+				return true;
+			}
+
+			// Static UI passthrough — serve files under publicUiDir.
+			if (req.method === "GET" && found.manifest.publicUiDir) {
+				const uiRoot = resolve(agent.projectPath, found.manifest.publicUiDir);
+				const fileName = subPath === "" ? "index.html" : subPath;
+				if (fileName.includes("..")) {
+					sendJson(res, { error: "Invalid path" }, 400);
+					return true;
+				}
+				const absPath = resolve(uiRoot, fileName);
+				if (!absPath.startsWith(uiRoot + "/") && absPath !== uiRoot) {
+					sendJson(res, { error: "Path outside ui root" }, 403);
+					return true;
+				}
+				try {
+					const fileStat = await stat(absPath);
+					if (fileStat.isDirectory()) {
+						sendJson(res, { error: "Cannot serve directories" }, 400);
+						return true;
+					}
+					const ext = extname(absPath).toLowerCase();
+					const types: Record<string, string> = {
+						".html": "text/html; charset=utf-8",
+						".css": "text/css; charset=utf-8",
+						".js": "application/javascript; charset=utf-8",
+						".json": "application/json; charset=utf-8",
+						".png": "image/png",
+						".jpg": "image/jpeg",
+						".svg": "image/svg+xml",
+					};
+					const body = await readFile(absPath);
+					res.writeHead(200, {
+						"Content-Type": types[ext] ?? "application/octet-stream",
+						"Content-Length": body.length,
+						"Cache-Control": "no-cache",
+					});
+					res.end(body);
+				} catch (err) {
+					const e = err as NodeJS.ErrnoException;
+					if (e.code === "ENOENT")
+						sendJson(res, { error: "File not found" }, 404);
+					else sendJson(res, { error: e.message }, 500);
+				}
+				return true;
+			}
+
+			sendJson(res, { error: "NOT_FOUND", agentId, subPath }, 404);
+			return true;
+		},
+	};
+}

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -30,6 +30,7 @@ import type { AgentHost } from "./types.js";
 import { resolveProjectDir, saveConfig, fileExists } from "./config.js";
 import { listArtifacts } from "./tools/artifact-tools.js";
 import { createA2AHandler, type A2AHandler } from "./a2a-handler.js";
+import { createAgentSurface } from "./agent-surface.js";
 import { buildAgentStimulus } from "./habitat-agent.js";
 import { createClaudeSdkRuntimeRunner } from "./claude-sdk-runner.js";
 import { createPiRuntimeRunner } from "./pi-runner.js";
@@ -227,6 +228,9 @@ export async function startContainerServer(
 
 	const webAdapter = new WebAdapter(bridge);
 
+	// Per-agent public surface (/agents/<id>/... + path-inserted well-known).
+	const agentSurface = createAgentSurface(habitat);
+
 	// A2A handler — initialized lazily on first request (needs port for baseUrl)
 	let a2aHandler: A2AHandler | null = null;
 	async function getA2AHandler(actualPort: number): Promise<A2AHandler> {
@@ -279,6 +283,7 @@ export async function startContainerServer(
 			// Log non-static requests
 			const shouldLog =
 				path.startsWith("/api/") ||
+				path.startsWith("/agents/") ||
 				path === "/mcp" ||
 				path === "/a2a" ||
 				path === "/health";
@@ -462,112 +467,11 @@ export async function startContainerServer(
 				}
 
 				// ── mcp-agent public surface (/agents/<id>/...) ───────
-				// Scaffold for Phase 4 of the Habitat Runtime spec: serve a
-				// mcp-agent's static UI dir, return its manifest, and stub the
-				// MCP endpoint with a 501 + diagnostic until mcp-serve is wired up.
-				{
-					const m = path.match(/^\/agents\/([^/]+)(?:\/(.*))?$/);
-					if (m) {
-						const agentId = m[1];
-						const subPath = m[2] ?? "";
-						const agent = habitat.getAgent(agentId);
-						if (agent && agent.kind === "mcp-agent") {
-							const all = await habitat.getMcpAgents();
-							const found = all.mcpAgents.find((x) => x.agent.id === agentId);
-							const manifestErr = all.errors.find(
-								(e) => e.agent.id === agentId,
-							);
-
-							if (!found) {
-								sendJson(
-									res,
-									{
-										error: manifestErr
-											? "MANIFEST_INVALID"
-											: "MANIFEST_NOT_FOUND",
-										agentId,
-										message:
-											manifestErr?.error ??
-											"agent has no agent-manifest.json (cannot mount)",
-									},
-									manifestErr ? 422 : 503,
-								);
-								return;
-							}
-
-							if (subPath === "mcp") {
-								sendJson(
-									res,
-									{
-										error: "NOT_IMPLEMENTED",
-										agentId,
-										message:
-											"mcp-agent MCP endpoint mount is scaffolded but not yet wired to @umwelten/protocols/mcp-serve. Manifest detected at " +
-											found.path,
-										manifest: found.manifest,
-									},
-									501,
-								);
-								return;
-							}
-
-							if (subPath === "manifest.json") {
-								sendJson(res, found.manifest);
-								return;
-							}
-
-							// Static UI passthrough — serve files under publicUiDir.
-							if (req.method === "GET" && found.manifest.publicUiDir) {
-								const uiRoot = resolve(
-									agent.projectPath,
-									found.manifest.publicUiDir,
-								);
-								const fileName = subPath === "" ? "index.html" : subPath;
-								if (fileName.includes("..")) {
-									sendJson(res, { error: "Invalid path" }, 400);
-									return;
-								}
-								const absPath = resolve(uiRoot, fileName);
-								if (!absPath.startsWith(uiRoot + "/") && absPath !== uiRoot) {
-									sendJson(res, { error: "Path outside ui root" }, 403);
-									return;
-								}
-								try {
-									const fileStat = await stat(absPath);
-									if (fileStat.isDirectory()) {
-										sendJson(res, { error: "Cannot serve directories" }, 400);
-										return;
-									}
-									const ext = extname(absPath).toLowerCase();
-									const types: Record<string, string> = {
-										".html": "text/html; charset=utf-8",
-										".css": "text/css; charset=utf-8",
-										".js": "application/javascript; charset=utf-8",
-										".json": "application/json; charset=utf-8",
-										".png": "image/png",
-										".jpg": "image/jpeg",
-										".svg": "image/svg+xml",
-									};
-									const body = await readFile(absPath);
-									res.writeHead(200, {
-										"Content-Type": types[ext] ?? "application/octet-stream",
-										"Content-Length": body.length,
-										"Cache-Control": "no-cache",
-									});
-									res.end(body);
-								} catch (err: any) {
-									if (err.code === "ENOENT")
-										sendJson(res, { error: "File not found" }, 404);
-									else sendJson(res, { error: err.message }, 500);
-								}
-								return;
-							}
-
-							sendJson(res, { error: "NOT_FOUND", agentId, subPath }, 404);
-							return;
-						}
-					}
-				}
+				// Static UI, manifest, and the mcp-serve OAuth MCP mount,
+				// plus the root-level path-inserted OAuth discovery URLs.
+				// See agent-surface.ts. Not gated by HABITAT_API_KEY — the
+				// mount's own OAuth layer authenticates /mcp.
+				if (await agentSurface.handle(req, res, path)) return;
 
 				// ── File serving (sandboxed to work dir) ───────────────
 				if (path.startsWith("/files/") && req.method === "GET") {

--- a/packages/protocols/src/index.ts
+++ b/packages/protocols/src/index.ts
@@ -33,7 +33,10 @@ export type {
 // ── MCP Serve (OAuth MCP server framework) ──────────────────────────────
 export { createMcpServer } from "./mcp-serve/server.js";
 export type { McpHttpServer } from "./mcp-serve/server.js";
+export { createMcpServeMount, isMcpServeMountPath } from "./mcp-serve/mount.js";
+export type { McpServeMount, McpServeMountConfig } from "./mcp-serve/mount.js";
 export { NeonStore } from "./mcp-serve/neon-store.js";
+export { MemoryStore } from "./mcp-serve/memory-store.js";
 export type {
   UpstreamOAuthProvider,
   UpstreamTokens,

--- a/packages/protocols/src/mcp-serve/index.ts
+++ b/packages/protocols/src/mcp-serve/index.ts
@@ -16,7 +16,11 @@
 export { createMcpServer } from './server.js';
 export type { McpHttpServer } from './server.js';
 
+export { createMcpServeMount, isMcpServeMountPath } from './mount.js';
+export type { McpServeMount, McpServeMountConfig } from './mount.js';
+
 export { NeonStore } from './neon-store.js';
+export { MemoryStore } from './memory-store.js';
 
 export type {
   UpstreamOAuthProvider,

--- a/packages/protocols/src/mcp-serve/memory-store.test.ts
+++ b/packages/protocols/src/mcp-serve/memory-store.test.ts
@@ -1,0 +1,86 @@
+/**
+ * MemoryStore — behavior parity with NeonStore for the McpServeStore
+ * contract the OAuth flow depends on (session lookup by state/code,
+ * token expiry, upstream token upsert).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { MemoryStore } from './memory-store.js';
+import type { AuthSession } from './types.js';
+
+function session(overrides: Partial<AuthSession> = {}): AuthSession {
+  const now = new Date();
+  return {
+    id: 'sess-1',
+    client_id: 'client-1',
+    redirect_uri: 'https://client.example/cb',
+    code_challenge: 'abc',
+    code_challenge_method: 'S256',
+    state: 'client-state',
+    resource: null,
+    upstream_state: 'up-state',
+    mcp_auth_code: null,
+    user_id: null,
+    created_at: now,
+    expires_at: new Date(now.getTime() + 10 * 60 * 1000),
+    ...overrides,
+  };
+}
+
+describe('MemoryStore', () => {
+  it('round-trips OAuth clients', async () => {
+    const store = new MemoryStore();
+    await store.createClient('c1', 'My Client', ['https://a/cb']);
+    const client = await store.getClient('c1');
+    expect(client?.client_name).toBe('My Client');
+    expect(client?.redirect_uris).toEqual(['https://a/cb']);
+    expect(await store.getClient('missing')).toBeNull();
+  });
+
+  it('finds sessions by id, upstream state, and mcp code', async () => {
+    const store = new MemoryStore();
+    await store.createSession(session());
+    expect((await store.getSession('sess-1'))?.client_id).toBe('client-1');
+    expect((await store.getSessionByUpstreamState('up-state'))?.id).toBe('sess-1');
+    expect(await store.getSessionByMcpCode('nope')).toBeNull();
+
+    await store.updateSession('sess-1', { mcp_auth_code: 'code-9', user_id: 'u1' });
+    const found = await store.getSessionByMcpCode('code-9');
+    expect(found?.user_id).toBe('u1');
+
+    await store.deleteSession('sess-1');
+    expect(await store.getSession('sess-1')).toBeNull();
+  });
+
+  it('maps token hashes to users and honors expiry', async () => {
+    const store = new MemoryStore();
+    const future = new Date(Date.now() + 60_000);
+    const past = new Date(Date.now() - 60_000);
+
+    await store.createToken('hash-live', 'u1', 'c1', 'access', future);
+    await store.createToken('hash-dead', 'u1', 'c1', 'access', past);
+
+    expect(await store.getUserByTokenHash('hash-live')).toBe('u1');
+    expect(await store.getUserByTokenHash('hash-dead')).toBeNull();
+    expect((await store.getTokenByHash('hash-dead'))?.user_id).toBe('u1');
+
+    await store.deleteToken('hash-live');
+    expect(await store.getUserByTokenHash('hash-live')).toBeNull();
+  });
+
+  it('upserts upstream tokens', async () => {
+    const store = new MemoryStore();
+    await store.upsertUpstreamTokens('u1', {
+      access_token: 'a1',
+      refresh_token: 'r1',
+      expires_at: null,
+    });
+    await store.upsertUpstreamTokens('u1', {
+      access_token: 'a2',
+      refresh_token: 'r2',
+      expires_at: null,
+    });
+    expect((await store.getUpstreamTokens('u1'))?.access_token).toBe('a2');
+    expect(await store.getUpstreamTokens('u2')).toBeNull();
+  });
+});

--- a/packages/protocols/src/mcp-serve/memory-store.ts
+++ b/packages/protocols/src/mcp-serve/memory-store.ts
@@ -1,0 +1,110 @@
+/**
+ * In-memory implementation of McpServeStore.
+ *
+ * For tests and dev/demo mounts: all OAuth state (registered clients,
+ * pending auth sessions, issued tokens, upstream tokens) is lost when the
+ * process exits, so every client must re-authenticate after a restart.
+ * Use NeonStore for anything that needs to survive a deploy.
+ */
+
+import type {
+  McpServeStore,
+  OAuthClient,
+  AuthSession,
+  McpTokenRow,
+  UpstreamTokens,
+} from './types.js';
+
+export class MemoryStore implements McpServeStore {
+  private clients = new Map<string, OAuthClient>();
+  private sessions = new Map<string, AuthSession>();
+  private tokens = new Map<string, McpTokenRow>();
+  private upstreamTokens = new Map<string, UpstreamTokens>();
+
+  // ── OAuth Clients (DCR) ─────────────────────────────────────────
+
+  async createClient(clientId: string, clientName: string | null, redirectUris: string[]): Promise<void> {
+    this.clients.set(clientId, {
+      client_id: clientId,
+      client_name: clientName,
+      redirect_uris: [...redirectUris],
+      created_at: new Date(),
+    });
+  }
+
+  async getClient(clientId: string): Promise<OAuthClient | null> {
+    return this.clients.get(clientId) ?? null;
+  }
+
+  // ── Auth Sessions ───────────────────────────────────────────────
+
+  async createSession(session: AuthSession): Promise<void> {
+    this.sessions.set(session.id, { ...session });
+  }
+
+  async getSession(id: string): Promise<AuthSession | null> {
+    return this.sessions.get(id) ?? null;
+  }
+
+  async getSessionByUpstreamState(state: string): Promise<AuthSession | null> {
+    for (const session of this.sessions.values()) {
+      if (session.upstream_state === state) return session;
+    }
+    return null;
+  }
+
+  async getSessionByMcpCode(code: string): Promise<AuthSession | null> {
+    for (const session of this.sessions.values()) {
+      if (session.mcp_auth_code === code) return session;
+    }
+    return null;
+  }
+
+  async updateSession(id: string, updates: Partial<AuthSession>): Promise<void> {
+    const session = this.sessions.get(id);
+    if (!session) return;
+    Object.assign(session, updates);
+  }
+
+  async deleteSession(id: string): Promise<void> {
+    this.sessions.delete(id);
+  }
+
+  // ── MCP Tokens ──────────────────────────────────────────────────
+
+  async createToken(tokenHash: string, userId: string, clientId: string, tokenType: string, expiresAt: Date): Promise<void> {
+    this.tokens.set(tokenHash, {
+      token_hash: tokenHash,
+      user_id: userId,
+      client_id: clientId,
+      token_type: tokenType as McpTokenRow['token_type'],
+      expires_at: expiresAt,
+      created_at: new Date(),
+    });
+  }
+
+  async getUserByTokenHash(tokenHash: string): Promise<string | null> {
+    const row = this.tokens.get(tokenHash);
+    if (!row) return null;
+    if (row.expires_at <= new Date()) return null;
+    return row.user_id;
+  }
+
+  async getTokenByHash(tokenHash: string): Promise<McpTokenRow | null> {
+    return this.tokens.get(tokenHash) ?? null;
+  }
+
+  async deleteToken(tokenHash: string): Promise<void> {
+    this.tokens.delete(tokenHash);
+  }
+
+  // ── Upstream Tokens ─────────────────────────────────────────────
+
+  async upsertUpstreamTokens(userId: string, tokens: UpstreamTokens): Promise<void> {
+    this.upstreamTokens.set(userId, { ...tokens });
+  }
+
+  async getUpstreamTokens(userId: string): Promise<UpstreamTokens | null> {
+    return this.upstreamTokens.get(userId) ?? null;
+  }
+}

--- a/packages/protocols/src/mcp-serve/mount.test.ts
+++ b/packages/protocols/src/mcp-serve/mount.test.ts
@@ -1,0 +1,198 @@
+/**
+ * createMcpServeMount — prefix-relative dispatch of the mcp-serve surface.
+ *
+ * Proves that a mount served under a base URL like http://host/agents/x
+ * emits every OAuth/MCP URL under that prefix, and that non-mount paths
+ * fall through (return false) so the host can serve static files.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { createMcpServeMount, isMcpServeMountPath } from './mount.js';
+import { MemoryStore } from './memory-store.js';
+import type { UpstreamOAuthProvider } from './types.js';
+
+const BASE = 'http://localhost:7430/agents/demo';
+
+function fakeReq(method: string, url: string, headers: Record<string, string> = {}): IncomingMessage {
+  return {
+    method,
+    url,
+    headers: { host: 'localhost:7430', ...headers },
+  } as unknown as IncomingMessage;
+}
+
+function fakeRes() {
+  let statusCode = 0;
+  const headers: Record<string, string> = {};
+  let body = '';
+  let headersSent = false;
+  const res = {
+    get headersSent() {
+      return headersSent;
+    },
+    writeHead(code: number, h?: Record<string, string | number>) {
+      statusCode = code;
+      if (h) for (const [k, v] of Object.entries(h)) headers[k] = String(v);
+      headersSent = true;
+      return res;
+    },
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    end(chunk?: string | Buffer) {
+      if (chunk) body += chunk.toString();
+    },
+  };
+  return {
+    res: res as unknown as ServerResponse,
+    status: () => statusCode,
+    header: (k: string) => headers[k],
+    json: () => JSON.parse(body),
+  };
+}
+
+function stubUpstream(): UpstreamOAuthProvider {
+  return {
+    name: 'stub',
+    buildAuthorizeUrl: vi.fn(
+      (callbackUrl: string, state: string) =>
+        `https://upstream.example/authorize?cb=${encodeURIComponent(callbackUrl)}&state=${state}`,
+    ),
+    exchangeCode: vi.fn(async () => ({
+      tokens: { access_token: 'a', refresh_token: 'r', expires_at: null },
+      userId: 'user-1',
+    })),
+    refreshToken: vi.fn(async () => ({
+      access_token: 'a2',
+      refresh_token: 'r2',
+      expires_at: null,
+    })),
+  };
+}
+
+function makeMount(store = new MemoryStore()) {
+  return createMcpServeMount({
+    name: 'demo-agent',
+    upstream: stubUpstream(),
+    registerTools: async () => {},
+    store,
+  });
+}
+
+describe('isMcpServeMountPath', () => {
+  it('reserves mcp, oauth/*, and the oauth well-known endpoints', () => {
+    expect(isMcpServeMountPath('mcp')).toBe(true);
+    expect(isMcpServeMountPath('oauth/token')).toBe(true);
+    expect(isMcpServeMountPath('oauth/authorize')).toBe(true);
+    expect(isMcpServeMountPath('.well-known/oauth-protected-resource')).toBe(true);
+    expect(isMcpServeMountPath('.well-known/oauth-authorization-server')).toBe(true);
+  });
+
+  it('does not reserve static-ui style paths', () => {
+    expect(isMcpServeMountPath('')).toBe(false);
+    expect(isMcpServeMountPath('index.html')).toBe(false);
+    expect(isMcpServeMountPath('manifest.json')).toBe(false);
+    expect(isMcpServeMountPath('mcp/extra')).toBe(false);
+  });
+});
+
+describe('createMcpServeMount', () => {
+  it('serves authorization-server metadata with every endpoint under the prefix', async () => {
+    const mount = makeMount();
+    const { res, status, json } = fakeRes();
+
+    const handled = await mount.handle(
+      fakeReq('GET', '/agents/demo/.well-known/oauth-authorization-server'),
+      res,
+      '.well-known/oauth-authorization-server',
+      BASE,
+    );
+
+    expect(handled).toBe(true);
+    expect(status()).toBe(200);
+    const meta = json();
+    expect(meta.issuer).toBe(BASE);
+    expect(meta.authorization_endpoint).toBe(`${BASE}/oauth/authorize`);
+    expect(meta.token_endpoint).toBe(`${BASE}/oauth/token`);
+    expect(meta.registration_endpoint).toBe(`${BASE}/oauth/register`);
+  });
+
+  it('serves protected-resource metadata pointing at the prefixed auth server', async () => {
+    const mount = makeMount();
+    const { res, status, json } = fakeRes();
+
+    const handled = await mount.handle(
+      fakeReq('GET', '/agents/demo/.well-known/oauth-protected-resource'),
+      res,
+      '.well-known/oauth-protected-resource',
+      BASE,
+    );
+
+    expect(handled).toBe(true);
+    expect(status()).toBe(200);
+    const meta = json();
+    expect(meta.resource).toBe(BASE);
+    expect(meta.authorization_servers).toEqual([BASE]);
+  });
+
+  it('answers unauthenticated /mcp with 401 + prefixed resource_metadata hint', async () => {
+    const mount = makeMount();
+    const { res, status, header } = fakeRes();
+
+    const handled = await mount.handle(
+      fakeReq('GET', '/agents/demo/mcp'),
+      res,
+      'mcp',
+      BASE,
+    );
+
+    expect(handled).toBe(true);
+    expect(status()).toBe(401);
+    expect(header('WWW-Authenticate')).toContain(
+      `${BASE}/.well-known/oauth-protected-resource`,
+    );
+  });
+
+  it('redirects oauth/authorize upstream with the prefixed callback URL', async () => {
+    const store = new MemoryStore();
+    await store.createClient('client-1', 'Test Client', ['https://client.example/cb']);
+    const upstream = stubUpstream();
+    const mount = createMcpServeMount({
+      name: 'demo-agent',
+      upstream,
+      registerTools: async () => {},
+      store,
+    });
+    const { res, status, header } = fakeRes();
+
+    const query =
+      'client_id=client-1&redirect_uri=' +
+      encodeURIComponent('https://client.example/cb') +
+      '&response_type=code&code_challenge=abc&code_challenge_method=S256';
+    const handled = await mount.handle(
+      fakeReq('GET', `/agents/demo/oauth/authorize?${query}`),
+      res,
+      'oauth/authorize',
+      BASE,
+    );
+
+    expect(handled).toBe(true);
+    expect(status()).toBe(302);
+    expect(upstream.buildAuthorizeUrl).toHaveBeenCalledWith(
+      `${BASE}/oauth/upstream-callback`,
+      expect.any(String),
+    );
+    expect(header('Location')).toContain('https://upstream.example/authorize');
+  });
+
+  it('returns false for paths it does not own', async () => {
+    const mount = makeMount();
+    const { res } = fakeRes();
+
+    expect(await mount.handle(fakeReq('GET', '/agents/demo/logo.png'), res, 'logo.png', BASE)).toBe(false);
+    expect(await mount.handle(fakeReq('GET', '/agents/demo/'), res, '', BASE)).toBe(false);
+    // Wrong method on an owned path falls through too.
+    expect(await mount.handle(fakeReq('GET', '/agents/demo/oauth/register'), res, 'oauth/register', BASE)).toBe(false);
+  });
+});

--- a/packages/protocols/src/mcp-serve/mount.ts
+++ b/packages/protocols/src/mcp-serve/mount.ts
@@ -1,0 +1,112 @@
+/**
+ * Path-prefix mount for mcp-serve.
+ *
+ * createMcpServer() owns a whole http server with routes at the root
+ * (/mcp, /oauth/*, /.well-known/*). A mount is the embeddable form: the
+ * same handlers, dispatched relative to a base path that a host server
+ * (e.g. the habitat container server's /agents/<id>) controls.
+ *
+ * Every URL the OAuth surface emits derives from the baseUrl passed to
+ * handle(), so a mount served at https://host/agents/foo advertises
+ * authorization_endpoint https://host/agents/foo/oauth/authorize, returns
+ * WWW-Authenticate resource_metadata under that prefix, and so on.
+ *
+ * Discovery caveat (verified against @modelcontextprotocol/sdk 1.29.0):
+ * for an issuer with a path component, clients build the RFC 8414
+ * path-inserted form /.well-known/oauth-authorization-server/<prefix> at
+ * the ORIGIN — they never try <prefix>/.well-known/... for AS metadata.
+ * The host must therefore also route those root-level path-inserted URLs
+ * into this mount (see isMcpServeMountPath consumers).
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { McpServeConfig } from './types.js';
+import { handleMcpRequest, type McpHandlerConfig } from './mcp-handler.js';
+import { handleProtectedResource, handleAuthServerMetadata } from './oauth/metadata.js';
+import { handleRegister } from './oauth/register.js';
+import { handleAuthorize, handleUpstreamCallback } from './oauth/authorize.js';
+import { handleToken } from './oauth/token.js';
+
+/** Everything createMcpServer takes except the http-server concerns. */
+export type McpServeMountConfig = Omit<McpServeConfig, 'port' | 'staticRoot'>;
+
+export interface McpServeMount {
+  /**
+   * Handle a request whose path falls under the mount.
+   *
+   * @param subPath - path relative to the mount root, no leading slash
+   *                  (e.g. "mcp", "oauth/token", ".well-known/oauth-protected-resource")
+   * @param baseUrl - public URL of the mount root (origin + prefix, no trailing slash)
+   * @returns true if the request was handled (response sent)
+   */
+  handle(
+    req: IncomingMessage,
+    res: ServerResponse,
+    subPath: string,
+    baseUrl: string,
+  ): Promise<boolean>;
+}
+
+/**
+ * Subpaths reserved by a mount. Hosts use this to decide which requests
+ * under a prefix belong to the MCP/OAuth surface (vs. e.g. static files).
+ */
+export function isMcpServeMountPath(subPath: string): boolean {
+  const p = subPath.replace(/^\//, '');
+  return (
+    p === 'mcp' ||
+    p.startsWith('oauth/') ||
+    p === '.well-known/oauth-protected-resource' ||
+    p === '.well-known/oauth-authorization-server'
+  );
+}
+
+export function createMcpServeMount(config: McpServeMountConfig): McpServeMount {
+  const { name, version = '0.1.0', upstream, registerTools, store } = config;
+
+  const mcpHandlerConfig: McpHandlerConfig = {
+    serverName: name,
+    serverVersion: version,
+    upstream,
+    store,
+    registerTools,
+  };
+
+  return {
+    async handle(req, res, subPath, baseUrl) {
+      const path = subPath.replace(/^\//, '');
+      const base = baseUrl.replace(/\/$/, '');
+
+      if (path === '.well-known/oauth-protected-resource') {
+        handleProtectedResource(base, req, res);
+        return true;
+      }
+      if (path === '.well-known/oauth-authorization-server') {
+        handleAuthServerMetadata(base, req, res);
+        return true;
+      }
+      if (path === 'oauth/register' && req.method === 'POST') {
+        await handleRegister(store, req, res);
+        return true;
+      }
+      if (path === 'oauth/authorize' && req.method === 'GET') {
+        await handleAuthorize(upstream, store, base, req, res);
+        return true;
+      }
+      if (path === 'oauth/upstream-callback' && req.method === 'GET') {
+        await handleUpstreamCallback(upstream, store, base, req, res);
+        return true;
+      }
+      if (path === 'oauth/token' && req.method === 'POST') {
+        await handleToken(store, req, res);
+        return true;
+      }
+      if (path === 'mcp') {
+        await handleMcpRequest(mcpHandlerConfig, req, res, base);
+        return true;
+      }
+
+      return false;
+    },
+  };
+}

--- a/reports/2026-06-11-mcp-serve-prefix-mount.md
+++ b/reports/2026-06-11-mcp-serve-prefix-mount.md
@@ -1,0 +1,101 @@
+# Mounting mcp-serve under a path prefix (per-agent MCP mount)
+
+**Date:** 2026-06-11 · **Issue:** #121 · **Scope:** wiring `/agents/<id>/mcp` in the
+habitat container server to `@umwelten/protocols/mcp-serve`.
+
+Complements `2026-05-04-a2a-mcp-skills-implementation.md` (A2A-outside / MCP-inside
+composition, OAuth task lifecycle) and `2026-05-07-acp-a2a-mcp-agent-protocols.md`
+(protocol comparison). Neither covers serving an OAuth-backed MCP endpoint **under a
+path prefix on a shared host**, which is the whole game here. This report records the
+findings that drove the implementation.
+
+## 1. mcp-serve is prefix-ready except for its router
+
+Every handler in `packages/protocols/src/mcp-serve/` (`handleMcpRequest`,
+`handleProtectedResource`, `handleAuthServerMetadata`, `handleRegister`,
+`handleAuthorize`, `handleUpstreamCallback`, `handleToken`) takes a `baseUrl`/
+`publicBaseUrl` string and derives every emitted URL from it:
+
+- 401 `WWW-Authenticate: Bearer resource_metadata="<base>/.well-known/oauth-protected-resource"`
+- AS metadata: `authorization_endpoint: <base>/oauth/authorize`, `token_endpoint`,
+  `registration_endpoint`
+- upstream callback: `<base>/oauth/upstream-callback`
+
+Only `createMcpServer()`'s internal router hardcodes root paths (`/mcp`, `/oauth/*`,
+`/.well-known/*`). So a prefix mount needs **no changes to any handler** — just a
+prefix-relative dispatcher that passes `baseUrl = <origin>/agents/<id>`. That is what
+`mcp-serve/mount.ts` (`createMcpServeMount`) now provides; `createMcpServer` is the
+single-tenant wrapper, the mount is the embeddable multi-tenant form.
+
+## 2. OAuth discovery URL forms — the load-bearing detail
+
+Verified against `@modelcontextprotocol/sdk` **1.29.0** (`dist/esm/client/auth.js`,
+`buildDiscoveryUrls`): for an authorization-server issuer **with a path component**
+(`https://host/agents/foo`), the client tries, in order:
+
+1. `https://host/.well-known/oauth-authorization-server/agents/foo`  ← RFC 8414 path-inserted
+2. `https://host/.well-known/openid-configuration/agents/foo`
+3. `https://host/agents/foo/.well-known/openid-configuration`
+
+It **never** tries suffix-style `https://host/agents/foo/.well-known/oauth-authorization-server`.
+Consequences for the container server:
+
+- The **root-level path-inserted** route `/.well-known/oauth-authorization-server/agents/<id>`
+  is mandatory, or every SDK-based client (including `umwelten mcp chat` and claude.ai
+  connectors) fails discovery after the 401.
+- Protected-resource metadata is found via the explicit `resource_metadata` URL in the
+  401 header (RFC 9728), so the suffix route `/agents/<id>/.well-known/oauth-protected-resource`
+  works for that step — but clients that probe without a 401 hint build the
+  path-inserted form `/.well-known/oauth-protected-resource/agents/<id>/mcp`, so serve
+  both (and the `/agents/<id>` variant without `/mcp`).
+- Serving suffix-style AS metadata under the prefix as well is harmless extra compat.
+
+## 3. Manifest → handler wiring
+
+`agent-manifest.json` (parsed by `packages/habitat/src/identity/agent-manifest.ts`)
+already declares the full mcp-serve configuration; validation already enforces
+`publicAuth` when `publicMcp: true`:
+
+- `publicAuth.upstreamProvider` — repo-relative JS module, `default` or `provider`
+  export → `UpstreamOAuthProvider`
+- `publicAuth.registerTools` — repo-relative JS module, `default` or `registerTools`
+  export → `McpToolRegistrar`
+- `publicAuth.store` — `{driver:"neon", envRef}` | `{driver:"sqlite", path}` | omitted
+
+Modules are loaded with `import(pathToFileURL(abs).href)` — agent repos ship built JS
+(the manifest doc says "JS module"); TS sources will not load under plain node.
+
+Store resolution (implemented in `packages/habitat/src/agent-mcp-mount.ts`):
+
+- `neon` → `NeonStore(process.env[envRef])`; missing env var is a configuration error
+  surfaced as JSON, not a crash.
+- `sqlite` → declared in the manifest schema but **no implementation exists** in
+  mcp-serve yet; surfaced as a clear "not yet supported" error rather than a silent
+  fallback.
+- omitted → `MemoryStore` (new, in `mcp-serve/memory-store.ts`) with a logged warning:
+  OAuth clients/tokens are lost on restart, fine for dev/demo, not for production.
+
+## 4. Container-server integration notes
+
+- The `/agents/<id>/...` surface is intentionally **not** gated by `HABITAT_API_KEY` —
+  the mount's own OAuth 2.1 layer authenticates `/mcp`, and the UI/manifest/OAuth
+  endpoints must be publicly reachable for the connector flow. The habitat's own
+  bearer-only `/mcp` endpoint is untouched.
+- Resolved mounts are cached per agent id (module import + store construction happen
+  once); resolution **errors are not cached**, so fixing a manifest/env on disk heals
+  on the next request without a restart.
+- `getPublicBaseUrl()` (already exported by mcp-serve) honors
+  `X-Forwarded-Proto`/`X-Forwarded-Host`, so prefix base URLs are correct behind the
+  Gaia proxy / Fly edge.
+
+## 5. Test seams
+
+- `createMcpServeMount` is pure dispatch — testable with stub req/res
+  (`node-mocks-http` not needed; plain objects with `writeHead`/`end` capture, same
+  idiom as `packages/habitat/src/web/WebAdapter.test.ts`).
+- `resolveAgentMcpMount` takes injectable `importModule` / `createNeonStore` deps so
+  unit tests stub the framework store and module loading (no Neon, no real files).
+- The per-agent routing block is extracted from `startContainerServer`'s closure into
+  `handleAgentSurface()` so manifest/static-UI/501-replacement behavior is unit-testable
+  against a minimal `{ getAgent, getMcpAgents }` habitat stub, without booting the full
+  container server (ChannelBridge, A2A, web routes).


### PR DESCRIPTION
Closes #121 (parent PRD: #113).

## What this builds

`/agents/<id>/mcp` on the container server now serves a **working OAuth 2.1 mcp-serve handler configured from the agent's manifest**, replacing the 501 scaffold. This is the piece that lets a tool server (oura-mcp, twitter-mcp, …) be repackaged as a habitat agent: one container serving authenticated A2A chat **and** an OAuth MCP connector compatible with claude.ai / `umwelten mcp chat`.

### New in `@umwelten/protocols` (mcp-serve)

- **`mount.ts` — `createMcpServeMount()`**: the embeddable, path-prefix form of `createMcpServer()`. Same handlers, dispatched relative to a base path; every emitted URL (authorization/token/registration endpoints, `WWW-Authenticate` hint, upstream callback) derives from the mount's baseUrl. `isMcpServeMountPath()` tells hosts which subpaths the mount owns.
- **`memory-store.ts` — `MemoryStore`**: in-memory `McpServeStore` for unit tests and dev mounts (state lost on restart, announced with a warning).

### New in `@umwelten/habitat`

- **`agent-mcp-mount.ts` — `resolveAgentMcpMount()`**: manifest → handler wiring. Loads `publicAuth.upstreamProvider` / `registerTools` JS modules from the agent repo (`default` or named exports), picks the store (`neon` via `envRef`, in-memory fallback when omitted, clear error for the unimplemented `sqlite` driver), and returns **structured errors instead of throwing** so misconfiguration becomes a JSON response, never a crash.
- **`agent-surface.ts`**: the `/agents/<id>/...` routing extracted from `startContainerServer` (now unit-testable against a host stub). Preserves manifest.json + static UI behavior byte-for-byte, dispatches reserved subpaths to the mount, caches resolved mounts per agent (errors are not cached, so fixing a manifest heals without restart).
- **Discovery routing**: serves both suffix-style well-known endpoints under the agent prefix *and* the RFC 8414 **path-inserted** forms at the host root (`/.well-known/oauth-authorization-server/agents/<id>`). Verified against `@modelcontextprotocol/sdk` 1.29.0: for a path-bearing issuer, SDK clients *only* try the path-inserted form — without those root routes every client fails discovery after the 401. Details in `reports/2026-06-11-mcp-serve-prefix-mount.md`.

The `/agents/<id>/...` surface is intentionally not gated by `HABITAT_API_KEY` (matches the previous scaffold): the mount's own OAuth layer authenticates `/mcp`, and the discovery/OAuth/UI endpoints must be publicly reachable for the connector flow.

## Acceptance criteria → how to verify

Each criterion from #121, with copy-pasteable steps. For the live steps, first create a throwaway agent fixture:

```bash
mkdir -p /tmp/mcp-agent-demo/repo/dist /tmp/mcp-agent-demo/repo/public /tmp/habitat-demo-121
cat > /tmp/mcp-agent-demo/repo/agent-manifest.json <<'JSON'
{ "name": "demo-oauth-agent", "publicUiDir": "public", "publicMcp": true,
  "publicAuth": { "kind": "oauth-server", "upstreamProvider": "dist/upstream.js", "registerTools": "dist/tools.js" } }
JSON
cat > /tmp/mcp-agent-demo/repo/dist/upstream.js <<'JS'
export default {
  name: "demo-upstream",
  buildAuthorizeUrl: (cb, state) => `${cb}?code=demo-code&state=${encodeURIComponent(state)}`,
  exchangeCode: async () => ({ tokens: { access_token: "a", refresh_token: "r", expires_at: null }, userId: "demo-user" }),
  refreshToken: async () => ({ access_token: "a2", refresh_token: "r2", expires_at: null }),
};
JS
cat > /tmp/mcp-agent-demo/repo/dist/tools.js <<'JS'
export default async function registerTools(server, userId) {
  server.tool("whoami", "Return the authenticated user id", {}, async () => ({
    content: [{ type: "text", text: `you are ${userId}` }],
  }));
}
JS
echo '<h1>demo agent ui</h1>' > /tmp/mcp-agent-demo/repo/public/index.html
cat > /tmp/habitat-demo-121/config.json <<'JSON'
{ "name": "smoke-habitat", "agents": [
  { "id": "demo", "name": "Demo", "projectPath": "/tmp/mcp-agent-demo/repo", "kind": "mcp-agent" } ] }
JSON
dotenvx run -- pnpm run cli habitat serve --work-dir /tmp/habitat-demo-121 --port 7461 --host 127.0.0.1
```

### ✅ Per-agent MCP path serves a working mcp-serve handler instead of 501

```bash
curl -i -X POST http://127.0.0.1:7461/agents/demo/mcp -H 'Content-Type: application/json' -d '{}'
# → HTTP/1.1 401 (not 501) with
#   WWW-Authenticate: Bearer resource_metadata="http://127.0.0.1:7461/agents/demo/.well-known/oauth-protected-resource"
```

Or run the full connector flow the issue's demo describes — `umwelten mcp chat --url http://127.0.0.1:7461/agents/demo/mcp` opens a browser, completes OAuth (the fixture upstream auto-approves), and `tools/list` shows `whoami`. I verified the same flow non-interactively with curl: DCR → authorize → upstream callback → PKCE token exchange → authenticated `tools/call whoami` returned `you are demo-user`.

### ✅ Manifest and static UI serving keep working as today

```bash
curl http://127.0.0.1:7461/agents/demo/manifest.json   # → the manifest JSON
curl http://127.0.0.1:7461/agents/demo/                # → <h1>demo agent ui</h1>
```

Path-traversal rejection, MIME mapping, directory rejection, 422/503 manifest errors are covered by `agent-surface.test.ts` (the logic moved verbatim from container-server.ts).

### ✅ Agent without MCP configuration yields a clear error, not a crash

Set `"publicMcp": false` in the fixture manifest, restart, then:

```bash
curl -i http://127.0.0.1:7461/agents/demo/mcp
# → 404 {"error":"MCP_NOT_ENABLED","agentId":"demo","message":"agent \"demo\" does not expose an MCP endpoint — its manifest has publicMcp: false (or unset)."}
```

Bad module paths, wrong export shapes, missing `envRef`, and the sqlite driver all return structured 422 JSON (`UPSTREAM_PROVIDER_LOAD_FAILED`, `REGISTER_TOOLS_INVALID`, `STORE_ENV_MISSING`, `STORE_DRIVER_UNSUPPORTED`) — each unit-tested.

### ✅ Unit tests for mount configuration resolution, store stubbed

```bash
npx vitest run packages/habitat/src/agent-mcp-mount.test.ts packages/habitat/src/agent-surface.test.ts \
  packages/protocols/src/mcp-serve/mount.test.ts packages/protocols/src/mcp-serve/memory-store.test.ts
# → 31 tests, all passing
```

`resolveAgentMcpMount` takes injectable `importModule` / `createNeonStore` deps; tests stub both (no Neon, no real module files).

### ✅ `pnpm test:run` passes

108 files, 1409 tests green (includes the untouched `request-options` regression tests — no token caps anywhere near this change). `pnpm lint`: 0 errors, no new warnings.

## Worth knowing / further work

- **No `umwelten mcp chat` UX change needed**: the existing client works against the mount as-is (verified the SDK discovery order; see the report).
- **`sqlite` store driver** is declared in the manifest schema but has no implementation in mcp-serve; it now errors clearly instead of 501-ing. Implementing a sqlite/file store would make single-container deployments persistent without Neon — natural follow-up.
- **Omitted store → MemoryStore**: deliberate, so the demo works with zero config, but tokens die on restart (warned in logs). Production agents should set `store: { driver: "neon", envRef: ... }`.
- **`getPublicBaseUrl` quirk**: `BASE_URL="/"` in the environment yields an empty origin (pre-existing; Vite injects that value in vitest, which is why the surface tests pin `x-forwarded-proto`). Harmless at runtime, but worth a guard in mcp-serve someday.
- Repackaging oura-mcp / twitter-mcp as agent manifests happens in their own repos, per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)