### PR TITLE
feat(habitat): A2A surface completion — securitySchemes, tasks/cancel, usage metadata (#117)

### DIFF
--- a/packages/habitat/src/a2a-handler.test.ts
+++ b/packages/habitat/src/a2a-handler.test.ts
@@ -1,0 +1,300 @@
+/**
+ * A2A surface completion (issue #117):
+ *  1. the agent card declares bearer auth iff the API key is enforced
+ *  2. tasks/cancel aborts an in-flight run; canceling an unknown task
+ *     returns a proper JSON-RPC error (via the real SDK transport)
+ *  3. the final A2A message carries token usage + model identity metadata
+ *
+ * The bridge is stubbed — no models, no network.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { BridgeResponseMetadata } from "./bridge/types.js";
+import type {
+	RequestContext,
+	ExecutionEventBus,
+} from "@umwelten/protocols";
+import {
+	buildAgentCard,
+	createA2AHandler,
+	HabitatAgentExecutor,
+} from "./a2a-handler.js";
+import type { AgentHost } from "./types.js";
+import type { ChannelBridge } from "./bridge/channel-bridge.js";
+import type { BridgeEventHandlers, ChannelMessage } from "./bridge/types.js";
+
+async function makeHost(): Promise<AgentHost> {
+	const workDir = await mkdtemp(join(tmpdir(), "a2a-handler-test-"));
+	return {
+		getConfig: () => ({ name: "Test Agent", agents: [] }),
+		getStimulus: async () => ({ options: { role: "test assistant" } }),
+		getWorkDir: () => workDir,
+	} as unknown as AgentHost;
+}
+
+function fakeEventBus() {
+	const events: unknown[] = [];
+	const bus = {
+		publish: vi.fn((e: unknown) => {
+			events.push(e);
+		}),
+		finished: vi.fn(),
+	} as unknown as ExecutionEventBus;
+	return { bus, events: events as Array<Record<string, any>> };
+}
+
+function requestContext(taskId = "task-1", contextId = "ctx-1", text = "hello"): RequestContext {
+	return {
+		taskId,
+		contextId,
+		userMessage: {
+			kind: "message",
+			messageId: "msg-user-1",
+			role: "user",
+			parts: [{ kind: "text", text }],
+		},
+	} as unknown as RequestContext;
+}
+
+const SAMPLE_METADATA = {
+	startTime: new Date(),
+	endTime: new Date(),
+	tokenUsage: { promptTokens: 42, completionTokens: 7, total: 49 },
+	provider: "google",
+	model: "gemini-3-flash-preview",
+	cost: { promptCost: 0, completionCost: 0, totalCost: 0 },
+} as unknown as BridgeResponseMetadata;
+
+/** A bridge whose handleMessage resolves immediately with a canned result. */
+function instantBridge(content = "hi there"): ChannelBridge {
+	return {
+		handleMessage: async (
+			msg: ChannelMessage,
+			events: BridgeEventHandlers,
+			_signal?: AbortSignal,
+		) => {
+			events.onText?.(content);
+			await events.onDone({
+				content,
+				sessionId: "sess-1",
+				channelKey: msg.channelKey,
+				metadata: SAMPLE_METADATA,
+			});
+		},
+	} as unknown as ChannelBridge;
+}
+
+// ── 1. securitySchemes ───────────────────────────────────────────
+
+describe("buildAgentCard — securitySchemes", () => {
+	it("omits security declarations when no API key is enforced", async () => {
+		const card = await buildAgentCard({
+			baseUrl: "http://localhost:7430",
+			habitat: await makeHost(),
+		});
+		expect(card.securitySchemes).toBeUndefined();
+		expect(card.security).toBeUndefined();
+	});
+
+	it("declares HTTP bearer auth iff the API key is set", async () => {
+		const card = await buildAgentCard({
+			baseUrl: "http://localhost:7430",
+			habitat: await makeHost(),
+			requiresApiKey: true,
+		});
+		expect(card.securitySchemes).toEqual({
+			bearer: expect.objectContaining({ type: "http", scheme: "bearer" }),
+		});
+		expect(card.security).toEqual([{ bearer: [] }]);
+	});
+});
+
+// ── 2 + 3. executor: task tracking, usage metadata, cancel ──────
+
+describe("HabitatAgentExecutor — execute", () => {
+	it("publishes an initial Task so the store can track (and cancel) the run", async () => {
+		const executor = new HabitatAgentExecutor(await makeHost(), instantBridge());
+		const { bus, events } = fakeEventBus();
+
+		await executor.execute(requestContext(), bus);
+
+		const task = events.find((e) => e.kind === "task");
+		expect(task).toBeDefined();
+		expect(task!.id).toBe("task-1");
+		expect(task!.contextId).toBe("ctx-1");
+		expect(task!.status.state).toBe("submitted");
+		expect(task!.history?.[0]?.messageId).toBe("msg-user-1");
+	});
+
+	it("attaches token usage and model identity to the final message metadata", async () => {
+		const executor = new HabitatAgentExecutor(await makeHost(), instantBridge());
+		const { bus, events } = fakeEventBus();
+
+		await executor.execute(requestContext(), bus);
+
+		const final = events.find((e) => e.kind === "message");
+		expect(final).toBeDefined();
+		expect(final!.metadata).toEqual({
+			usage: { promptTokens: 42, completionTokens: 7, totalTokens: 49 },
+			provider: "google",
+			model: "gemini-3-flash-preview",
+		});
+	});
+
+	it("omits metadata when the bridge result has none (non-default runtimes)", async () => {
+		const bridge = {
+			handleMessage: async (msg: ChannelMessage, events: BridgeEventHandlers) => {
+				await events.onDone({
+					content: "done",
+					sessionId: "s",
+					channelKey: msg.channelKey,
+				});
+			},
+		} as unknown as ChannelBridge;
+		const executor = new HabitatAgentExecutor(await makeHost(), bridge);
+		const { bus, events } = fakeEventBus();
+
+		await executor.execute(requestContext(), bus);
+
+		const final = events.find((e) => e.kind === "message");
+		expect(final!.metadata).toBeUndefined();
+	});
+});
+
+describe("HabitatAgentExecutor — cancelTask", () => {
+	it("aborts the in-flight run and emits a final canceled status", async () => {
+		// A bridge that only settles when the abort signal fires.
+		let sawAbort = false;
+		const bridge = {
+			handleMessage: (
+				_msg: ChannelMessage,
+				events: BridgeEventHandlers,
+				signal?: AbortSignal,
+			) =>
+				new Promise<void>((resolvePromise) => {
+					signal?.addEventListener("abort", () => {
+						sawAbort = true;
+						events.onError?.("aborted");
+						resolvePromise();
+					});
+				}),
+		} as unknown as ChannelBridge;
+
+		const executor = new HabitatAgentExecutor(await makeHost(), bridge);
+		const { bus, events } = fakeEventBus();
+
+		const running = executor.execute(requestContext("task-9", "ctx-9"), bus);
+		// Let execute() register the active task before canceling.
+		await new Promise((r) => setTimeout(r, 0));
+
+		await executor.cancelTask("task-9", bus);
+		await running;
+
+		expect(sawAbort).toBe(true);
+		const canceled = events.find(
+			(e) => e.kind === "status-update" && e.status?.state === "canceled",
+		);
+		expect(canceled).toBeDefined();
+		expect(canceled!.final).toBe(true);
+		expect(canceled!.contextId).toBe("ctx-9");
+		// The abort-driven onError must not publish an error message on top
+		// of the canceled status.
+		const errorMsg = events.find(
+			(e) =>
+				e.kind === "message" &&
+				e.parts?.[0]?.text?.startsWith("Error:"),
+		);
+		expect(errorMsg).toBeUndefined();
+	});
+
+	it("still emits a canceled status when no run is active", async () => {
+		const executor = new HabitatAgentExecutor(await makeHost(), instantBridge());
+		const { bus, events } = fakeEventBus();
+
+		await executor.cancelTask("ghost-task", bus);
+
+		const canceled = events.find((e) => e.kind === "status-update");
+		expect(canceled!.status.state).toBe("canceled");
+	});
+});
+
+// ── Protocol-level: tasks/cancel routed through the real SDK ────
+
+describe("tasks/cancel via the JSON-RPC transport", () => {
+	it("returns a proper JSON-RPC error for an unknown task", async () => {
+		const handler = await createA2AHandler({
+			habitat: await makeHost(),
+			bridge: instantBridge(),
+			baseUrl: "http://localhost:7430",
+		});
+
+		const response = (await handler.transportHandler.handle({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "tasks/cancel",
+			params: { id: "no-such-task" },
+		})) as Record<string, any>;
+
+		expect(response.jsonrpc).toBe("2.0");
+		expect(response.error).toBeDefined();
+		expect(response.error.code).toBe(-32001); // TaskNotFound
+		expect(response.result).toBeUndefined();
+	});
+
+	it("cancels a task created by message/send", async () => {
+		// Bridge that stays in-flight until aborted, so the task is active
+		// in the store when the cancel RPC arrives.
+		const bridge = {
+			handleMessage: (
+				_msg: ChannelMessage,
+				events: BridgeEventHandlers,
+				signal?: AbortSignal,
+			) =>
+				new Promise<void>((resolvePromise) => {
+					signal?.addEventListener("abort", () => {
+						events.onError?.("aborted");
+						resolvePromise();
+					});
+				}),
+		} as unknown as ChannelBridge;
+
+		const handler = await createA2AHandler({
+			habitat: await makeHost(),
+			bridge,
+			baseUrl: "http://localhost:7430",
+		});
+
+		// Fire a streaming send (don't await — it stays in-flight).
+		const stream = (await handler.transportHandler.handle({
+			jsonrpc: "2.0",
+			id: 2,
+			method: "message/stream",
+			params: {
+				message: {
+					kind: "message",
+					messageId: "m-1",
+					role: "user",
+					parts: [{ kind: "text", text: "long running job" }],
+				},
+			},
+		})) as AsyncGenerator<Record<string, any>>;
+
+		// Read events until the Task record exists (first event carries it).
+		const first = await stream.next();
+		const taskId = first.value?.result?.id;
+		expect(taskId).toBeDefined();
+
+		const cancelResponse = (await handler.transportHandler.handle({
+			jsonrpc: "2.0",
+			id: 3,
+			method: "tasks/cancel",
+			params: { id: taskId },
+		})) as Record<string, any>;
+
+		expect(cancelResponse.error).toBeUndefined();
+		expect(cancelResponse.result?.status?.state).toBe("canceled");
+	});
+});

--- a/packages/habitat/src/a2a-handler.ts
+++ b/packages/habitat/src/a2a-handler.ts
@@ -17,6 +17,7 @@ import type {
   AgentCard,
   AgentSkill,
   Message as A2AMessage,
+  Task as A2ATask,
   TextPart,
   FilePart,
   Artifact as A2AArtifact,
@@ -44,6 +45,12 @@ export interface AgentCardOptions {
   name?: string;
   /** Override description. */
   description?: string;
+  /**
+   * When true, the card declares HTTP bearer auth (securitySchemes +
+   * security) so clients discover the requirement instead of failing
+   * on 401. Set iff the host enforces an API key on /a2a.
+   */
+  requiresApiKey?: boolean;
 }
 
 export async function buildAgentCard(
@@ -81,14 +88,38 @@ export async function buildAgentCard(
     defaultInputModes: ["text/plain"],
     defaultOutputModes: ["text/plain"],
     skills,
+    ...(options.requiresApiKey
+      ? {
+          securitySchemes: {
+            bearer: {
+              type: "http" as const,
+              scheme: "bearer",
+              description:
+                "API key as a bearer token (Authorization: Bearer <HABITAT_API_KEY>).",
+            },
+          },
+          security: [{ bearer: [] }],
+        }
+      : {}),
   };
 }
 
 // ── Agent executor (bridges A2A → ChannelBridge) ──────────────────
 
+interface ActiveTask {
+  controller: AbortController;
+  contextId: string;
+}
+
 export class HabitatAgentExecutor implements AgentExecutor {
   private bridge: ChannelBridge;
   private habitat: AgentHost;
+  /**
+   * Active runs by taskId — the minimal in-memory store that lets
+   * tasks/cancel abort an in-flight Interaction. Entries are removed
+   * when the run settles (done, error, or canceled).
+   */
+  private activeTasks = new Map<string, ActiveTask>();
 
   constructor(habitat: AgentHost, bridge: ChannelBridge) {
     this.habitat = habitat;
@@ -119,89 +150,136 @@ export class HabitatAgentExecutor implements AgentExecutor {
       return;
     }
 
+    // Publish the initial Task so the request handler's task store tracks
+    // this run — without a Task record, tasks/cancel returns taskNotFound
+    // and the working status-updates below are dropped as "unknown task".
+    if (!requestContext.task) {
+      eventBus.publish({
+        kind: "task",
+        id: taskId,
+        contextId,
+        status: {
+          state: "submitted" as TaskState,
+          timestamp: new Date().toISOString(),
+        },
+        history: [userMessage],
+      } satisfies A2ATask);
+    }
+
     // Use contextId as channel key for session continuity
     const channelKey = `a2a:${contextId}`;
 
     let fullText = "";
 
-    await this.bridge.handleMessage(
-      { channelKey, text, userId: `a2a:${contextId}` },
-      {
-        onText: (delta) => {
-          // Emit working status with incremental text
-          eventBus.publish({
-            kind: "status-update",
-            taskId,
-            contextId,
-            final: false,
-            status: {
-              state: "working" as TaskState,
-              timestamp: new Date().toISOString(),
-              message: {
-                kind: "message",
-                messageId: randomUUID(),
-                role: "agent",
-                parts: [{ kind: "text", text: delta }],
-              },
-            },
-          });
-        },
-        onToolCall: (_name, _input) => {
-          // Optionally emit status updates for tool calls
-        },
-        onToolResult: (_name, _output, _isError) => {
-          // Optionally emit status updates for tool results
-        },
-        onDone: async (result) => {
-          fullText = result.content;
+    const controller = new AbortController();
+    this.activeTasks.set(taskId, { controller, contextId });
 
-          // Check for published artifacts
-          const artifacts = await this.buildA2AArtifacts();
-
-          const responseParts: (TextPart | FilePart)[] = [
-            { kind: "text", text: fullText },
-          ];
-
-          eventBus.publish({
-            kind: "message",
-            messageId: randomUUID(),
-            role: "agent",
-            parts: responseParts,
-            contextId,
-            taskId,
-          } satisfies A2AMessage);
-
-          for (const artifact of artifacts) {
+    try {
+      await this.bridge.handleMessage(
+        { channelKey, text, userId: `a2a:${contextId}` },
+        {
+          onText: (delta) => {
+            // Emit working status with incremental text
             eventBus.publish({
-              kind: "artifact-update",
+              kind: "status-update",
               taskId,
               contextId,
-              artifact,
+              final: false,
+              status: {
+                state: "working" as TaskState,
+                timestamp: new Date().toISOString(),
+                message: {
+                  kind: "message",
+                  messageId: randomUUID(),
+                  role: "agent",
+                  parts: [{ kind: "text", text: delta }],
+                },
+              },
             });
-          }
+          },
+          onToolCall: (_name, _input) => {
+            // Optionally emit status updates for tool calls
+          },
+          onToolResult: (_name, _output, _isError) => {
+            // Optionally emit status updates for tool results
+          },
+          onDone: async (result) => {
+            fullText = result.content;
 
-          eventBus.finished();
+            // Check for published artifacts
+            const artifacts = await this.buildA2AArtifacts();
+
+            const responseParts: (TextPart | FilePart)[] = [
+              { kind: "text", text: fullText },
+            ];
+
+            // Per-run usage so downstream consumers can record cost
+            // without a side channel (issue #117).
+            const usageMetadata = result.metadata
+              ? {
+                  usage: {
+                    promptTokens: result.metadata.tokenUsage.promptTokens,
+                    completionTokens: result.metadata.tokenUsage.completionTokens,
+                    totalTokens: result.metadata.tokenUsage.total,
+                  },
+                  provider: result.metadata.provider,
+                  model: result.metadata.model,
+                }
+              : undefined;
+
+            eventBus.publish({
+              kind: "message",
+              messageId: randomUUID(),
+              role: "agent",
+              parts: responseParts,
+              contextId,
+              taskId,
+              ...(usageMetadata ? { metadata: usageMetadata } : {}),
+            } satisfies A2AMessage);
+
+            for (const artifact of artifacts) {
+              eventBus.publish({
+                kind: "artifact-update",
+                taskId,
+                contextId,
+                artifact,
+              });
+            }
+
+            eventBus.finished();
+          },
+          onError: (error) => {
+            // A canceled run surfaces as an abort error — cancelTask already
+            // emitted the canceled status, so don't follow it with an error.
+            if (controller.signal.aborted) return;
+            eventBus.publish({
+              kind: "message",
+              messageId: randomUUID(),
+              role: "agent",
+              parts: [{ kind: "text", text: `Error: ${error}` }],
+              contextId,
+              taskId,
+            } satisfies A2AMessage);
+            eventBus.finished();
+          },
         },
-        onError: (error) => {
-          eventBus.publish({
-            kind: "message",
-            messageId: randomUUID(),
-            role: "agent",
-            parts: [{ kind: "text", text: `Error: ${error}` }],
-            contextId,
-            taskId,
-          } satisfies A2AMessage);
-          eventBus.finished();
-        },
-      },
-    );
+        controller.signal,
+      );
+    } finally {
+      this.activeTasks.delete(taskId);
+    }
   }
 
   async cancelTask(taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+    const active = this.activeTasks.get(taskId);
+    if (active) {
+      active.controller.abort();
+      this.activeTasks.delete(taskId);
+    }
     eventBus.publish({
       kind: "status-update",
       taskId,
-      contextId: "",
+      contextId: active?.contextId ?? "",
       final: true,
       status: {
         state: "canceled" as TaskState,
@@ -250,6 +328,8 @@ export interface A2AHandlerOptions {
   baseUrl: string;
   name?: string;
   description?: string;
+  /** Declare bearer auth in the agent card (set iff /a2a enforces an API key). */
+  requiresApiKey?: boolean;
 }
 
 /**
@@ -267,6 +347,7 @@ export async function createA2AHandler(
     habitat: options.habitat,
     name: options.name,
     description: options.description,
+    requiresApiKey: options.requiresApiKey,
   });
 
   const executor = new HabitatAgentExecutor(options.habitat, options.bridge);

--- a/packages/habitat/src/bridge/channel-bridge.ts
+++ b/packages/habitat/src/bridge/channel-bridge.ts
@@ -126,6 +126,7 @@ export class ChannelBridge {
   async handleMessage(
     msg: ChannelMessage,
     events: BridgeEventHandlers,
+    signal?: AbortSignal,
   ): Promise<void> {
     try {
       // Non-default runtimes dispatch through the RuntimeRunner seam (#118)
@@ -170,10 +171,11 @@ export class ChannelBridge {
       // Stream the response
       let response;
       try {
-        response = await interaction.streamText(undefined, observer);
+        response = await interaction.streamText(signal, observer);
       } finally {
         interaction.onTranscriptUpdate = originalCallback ?? undefined;
       }
+      let finalResponse = response;
 
       let content = typeof response.content === 'string' ? response.content : '';
       const reasoning = typeof response.reasoning === 'string'
@@ -187,10 +189,11 @@ export class ChannelBridge {
         const meta = response.metadata as { toolCalls?: unknown[] };
         if (Array.isArray(meta.toolCalls) && meta.toolCalls.length > 0) {
           try {
-            const followUp = await interaction.streamText(undefined, observer);
+            const followUp = await interaction.streamText(signal, observer);
             const followText = typeof followUp.content === 'string' ? followUp.content : '';
             if (followText.trim()) {
               content = followText;
+              finalResponse = followUp;
             }
           } catch {
             // fall through with empty content
@@ -207,6 +210,7 @@ export class ChannelBridge {
         sessionId,
         channelKey: msg.channelKey,
         reasoning,
+        metadata: finalResponse.metadata,
       };
       await events.onDone(result);
     } catch (err) {

--- a/packages/habitat/src/bridge/types.ts
+++ b/packages/habitat/src/bridge/types.ts
@@ -5,7 +5,11 @@
  */
 
 import type { CoreMessage } from 'ai';
+import type { ModelResponse } from '@umwelten/core/cognition/types.js';
 import type { AgentEntry, NativeSessionRef } from '../types.js';
+
+/** Model-run metadata (token usage, provider, model, cost) — core doesn't export the type directly. */
+export type BridgeResponseMetadata = ModelResponse['metadata'];
 
 // ── Inbound message ──────────────────────────────────────────────────
 
@@ -69,6 +73,14 @@ export interface BridgeResult {
   channelKey: string;
   /** Extended reasoning if the model emitted it. */
   reasoning?: string;
+  /**
+   * Response metadata from the model run (token usage, provider, model,
+   * cost) when the default Interaction runtime produced the response.
+   * Non-default runtimes (claude-sdk, pi) don't surface this yet.
+   * When the tool-call follow-up turn produced the final text, this is
+   * the follow-up turn's metadata (per-run, not cumulative).
+   */
+  metadata?: BridgeResponseMetadata;
 }
 
 // ── Runtime seam (#118) ──────────────────────────────────────────────

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -192,38 +192,42 @@ export async function startContainerServer(
 
 	// Wrap bridge.handleMessage to log chat activity and track session
 	const originalHandleMessage = bridge.handleMessage.bind(bridge);
-	bridge.handleMessage = async (msg, events) => {
+	bridge.handleMessage = async (msg, events, signal) => {
 		const ts = () => new Date().toISOString();
 		console.log(
 			`[${ts()}] 💬 chat: "${msg.text.slice(0, 80)}${msg.text.length > 80 ? "..." : ""}"`,
 		);
-		return originalHandleMessage(msg, {
-			...events,
-			onReasoning: (delta) => {
-				events.onReasoning?.(delta);
+		return originalHandleMessage(
+			msg,
+			{
+				...events,
+				onReasoning: (delta) => {
+					events.onReasoning?.(delta);
+				},
+				onToolCall: (name, input) => {
+					// Update session ID for artifact tools (session exists by the time tools run)
+					const sid = bridge.getChannelSessionId(msg.channelKey);
+					if (sid) (habitat as any)._currentSessionId = sid;
+					console.log(`[${ts()}] ⚡ ${name}`);
+					events.onToolCall?.(name, input);
+				},
+				onToolResult: (name, output, isError) => {
+					const marker = isError ? "✗" : "✓";
+					console.log(`[${ts()}] ${marker} ${name}`);
+					events.onToolResult?.(name, output, isError);
+				},
+				onDone: (result) => {
+					const len = result.content?.length ?? 0;
+					console.log(`[${ts()}] ✅ chat done (${len} chars)`);
+					return events.onDone(result);
+				},
+				onError: (err) => {
+					console.error(`[${ts()}] ❌ chat error: ${err}`);
+					events.onError?.(err);
+				},
 			},
-			onToolCall: (name, input) => {
-				// Update session ID for artifact tools (session exists by the time tools run)
-				const sid = bridge.getChannelSessionId(msg.channelKey);
-				if (sid) (habitat as any)._currentSessionId = sid;
-				console.log(`[${ts()}] ⚡ ${name}`);
-				events.onToolCall?.(name, input);
-			},
-			onToolResult: (name, output, isError) => {
-				const marker = isError ? "✗" : "✓";
-				console.log(`[${ts()}] ${marker} ${name}`);
-				events.onToolResult?.(name, output, isError);
-			},
-			onDone: (result) => {
-				const len = result.content?.length ?? 0;
-				console.log(`[${ts()}] ✅ chat done (${len} chars)`);
-				return events.onDone(result);
-			},
-			onError: (err) => {
-				console.error(`[${ts()}] ❌ chat error: ${err}`);
-				events.onError?.(err);
-			},
-		});
+			signal,
+		);
 	};
 
 	const webAdapter = new WebAdapter(bridge);
@@ -241,6 +245,7 @@ export async function startContainerServer(
 				bridge,
 				baseUrl,
 				name: serverName,
+				requiresApiKey: Boolean(apiKey),
 			});
 		}
 		return a2aHandler;


### PR DESCRIPTION
Closes #117 (parent PRD: #113).

## What this builds

Three gaps in the deployed-agent A2A surface, all in `packages/habitat`:

**1. securitySchemes in the agent card.** `buildAgentCard` takes `requiresApiKey`; the container server sets it iff `HABITAT_API_KEY` is enforced. The card then declares `securitySchemes: { bearer: { type: "http", scheme: "bearer" } }` plus a matching `security` requirement, so clients discover auth instead of failing on 401.

**2. tasks/cancel actually works.** Root cause found during scoping: the SDK's `JsonRpcTransportHandler` already routes `tasks/cancel` → `DefaultRequestHandler.cancelTask` → `executor.cancelTask`, **but** the SDK's `ResultManager` only tracks tasks the executor publishes as `kind: "task"` events — and `HabitatAgentExecutor` never did. So every run was invisible to the task store: `tasks/cancel` always returned `taskNotFound`, and the streaming `working` status-updates were silently dropped as "unknown task". Now:
- the executor publishes the initial Task event (state `submitted`, user message in history)
- it keeps the minimal in-memory store of active runs the issue asked for (`taskId → AbortController + contextId`)
- `cancelTask` aborts the in-flight Interaction — the AbortSignal flows `executor → bridge.handleMessage(msg, events, signal) → interaction.streamText(signal, …)` — and emits the final `canceled` status; the abort-driven `onError` is suppressed so no error message follows the cancel
- canceling an unknown task returns the SDK's proper JSON-RPC error (`-32001 TaskNotFound`)

**3. Usage metadata on the final message.** `BridgeResult` now carries the run's `ResponseMetadata` (exposed as `BridgeResponseMetadata` since core only exports the Zod schema); the executor attaches `{ usage: { promptTokens, completionTokens, totalTokens }, provider, model }` to the final A2A message's `metadata`, sourced from the Interaction's response metadata. When the tool-call follow-up turn produces the final text, it's that turn's metadata (per-run, not cumulative).

The container-server logging wrapper around `bridge.handleMessage` forwards the new signal parameter (it would have silently dropped it otherwise).

## Acceptance criteria → how to verify

Start a server (any provider whose AI-SDK adapter matches `ai@5` — see *Worth knowing* below; openrouter works):

```bash
mkdir -p /tmp/a2a-smoke && cat > /tmp/a2a-smoke/config.json <<'JSON'
{ "name": "smoke", "defaultProvider": "openrouter", "defaultModel": "openai/gpt-4o-mini", "agents": [] }
JSON
HABITAT_API_KEY=test-key-123 dotenvx run -- pnpm run cli habitat serve --work-dir /tmp/a2a-smoke --port 7463 --host 127.0.0.1
```

### ✅ Card contains a bearer securityScheme iff the API key is set

```bash
curl -s http://127.0.0.1:7463/.well-known/agent-card.json | jq '{securitySchemes, security}'
# → bearer http scheme + [{"bearer":[]}]   (restart without HABITAT_API_KEY → both fields absent)
```

### ✅ tasks/cancel stops an active run; unknown task → proper JSON-RPC error

```bash
curl -s -X POST http://127.0.0.1:7463/a2a -H 'Authorization: Bearer test-key-123' -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":2,"method":"tasks/cancel","params":{"id":"no-such-task"}}'
# → {"jsonrpc":"2.0","id":2,"error":{"code":-32001,"message":"Task not found: no-such-task"}}   (verified live)
```

In-flight cancellation is covered by two tests that drive the **real SDK transport**: `message/stream` → grab the Task from the first SSE event → `tasks/cancel` → response is the task with `status.state: "canceled"`, and the executor test asserts the AbortSignal actually fired and no error message follows the cancel.

### ✅ Final message metadata includes token usage and model identity

```bash
curl -s -X POST http://127.0.0.1:7463/a2a -H 'Authorization: Bearer test-key-123' -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"kind":"message","messageId":"m1","role":"user","parts":[{"kind":"text","text":"Reply with exactly: pong"}]},"configuration":{"blocking":true}}}' | jq '.result.metadata'
```

Verified live — returned `pong` with:
```json
{ "usage": { "promptTokens": 2709, "completionTokens": 2, "totalTokens": 2711 }, "provider": "openrouter", "model": "openai/gpt-4o-mini" }
```

### ✅ Unit tests / suites

```bash
npx vitest run packages/habitat/src/a2a-handler.test.ts   # 9 tests: card auth, task tracking, metadata, cancel (executor + real SDK transport)
pnpm test:run                                             # 110 files, 1423 tests green
pnpm lint                                                 # 0 errors
```

### ✅ request-options regression tests pass unmodified

Untouched, green in the full run. No token caps introduced anywhere.

## Worth knowing / further work

- **Pre-existing main breakage found while smoking this**: `packages/core` pins `@ai-sdk/google@^3.0.80`, which implements the AI-SDK v3 model spec and requires `ai@6` — but the repo uses `ai@5.0.115`. Any **fresh install** of main fails Google runs with `Unsupported model version v3` (existing checkouts with older node_modules still work, and CI never calls real models, so it's invisible there). Dependabot PR #104 (`ai` 5→6) is the likely fix path, or pin `@ai-sdk/google` back to `^2`. Unrelated to this PR.
- Cancellation aborts the **default Interaction runtime** only. The `claude-sdk` / `pi` RuntimeRunner seam doesn't accept a signal yet — canceling such a run emits the canceled status but the subprocess finishes in the background. Adding signal support to `RuntimeRunner.run` is a natural follow-up when those runtimes mature.
- Usage metadata is likewise default-runtime only (`BridgeResult.metadata` documents this); non-default runtimes don't surface token usage yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)