### PR TITLE
feat(core): proxy-backed Gaia session adapter for remote hosts (#120)

### DIFF
--- a/packages/core/src/interaction/adapters/gaia-session-adapter.test.ts
+++ b/packages/core/src/interaction/adapters/gaia-session-adapter.test.ts
@@ -1,0 +1,267 @@
+/**
+ * GaiaSessionAdapter (issue #120) — proxy-backed remote habitat sessions.
+ *
+ * All HTTP is mocked via the injectable fetchImpl: listing across
+ * habitats, loading full messages, habitat attribution, and the error
+ * paths (unreachable host, bad token, one habitat down).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { GaiaSessionAdapter } from "./gaia-session-adapter.js";
+import { AdapterRegistry } from "./adapter.js";
+import { projectSessions } from "../projection/projector.js";
+
+const HOST = "http://gaia.example:7420";
+
+type RouteMap = Record<string, unknown | (() => unknown)>;
+
+/** fetch stub: path → JSON body, or a thrower for network errors. */
+function fetchFor(routes: RouteMap, status = 200) {
+	return vi.fn(async (url: RequestInfo | URL) => {
+		const path = String(url).replace(HOST, "");
+		const hit = routes[path];
+		if (hit === undefined) {
+			return { ok: false, status: 404, json: async () => ({}) } as Response;
+		}
+		const body = typeof hit === "function" ? (hit as () => unknown)() : hit;
+		return {
+			ok: status >= 200 && status < 300,
+			status,
+			json: async () => body,
+		} as Response;
+	});
+}
+
+const HABITATS = [
+	{ id: "jeeves", name: "Jeeves Bot", status: "running" },
+	{ id: "scout", name: "Scout", status: "running" },
+];
+
+const JEEVES_SESSIONS = {
+	sessions: [
+		{
+			sessionId: "s-100",
+			type: "chat",
+			created: "2026-06-01T10:00:00.000Z",
+			lastUsed: "2026-06-02T10:00:00.000Z",
+			firstPrompt: "deploy the newsletter",
+			messageCount: 8,
+		},
+	],
+	total: 1,
+};
+
+const SCOUT_SESSIONS = {
+	sessions: [
+		{
+			sessionId: "s-200",
+			type: "chat",
+			created: "2026-06-03T10:00:00.000Z",
+			lastUsed: "2026-06-03T11:00:00.000Z",
+			firstPrompt: "scan the feeds",
+			messageCount: 3,
+		},
+	],
+	total: 1,
+};
+
+const MESSAGES = {
+	sessionId: "s-100",
+	messages: [
+		{ index: 0, role: "user", content: "deploy the newsletter", timestamp: "2026-06-01T10:00:00.000Z" },
+		{
+			index: 1,
+			role: "assistant",
+			content: "On it.",
+			model: "gemini-3-flash-preview",
+			toolCalls: [{ id: "t1", name: "deploy", input: { target: "prod" } }],
+			toolResults: [{ tool_use_id: "t1", content: "deployed ok", is_error: false }],
+		},
+	],
+};
+
+function adapter(routes: RouteMap, opts: { token?: string; warn?: (m: string) => void } = {}) {
+	return new GaiaSessionAdapter({
+		host: HOST,
+		token: opts.token ?? "secret-token",
+		fetchImpl: fetchFor(routes) as unknown as typeof fetch,
+		warn: opts.warn ?? (() => {}),
+	});
+}
+
+describe("GaiaSessionAdapter — listing", () => {
+	it("lists sessions across all registered habitats with bearer auth", async () => {
+		const fetchImpl = fetchFor({
+			"/api/habitats": HABITATS,
+			"/api/habitats/jeeves/sessions": JEEVES_SESSIONS,
+			"/api/habitats/scout/sessions": SCOUT_SESSIONS,
+		});
+		const a = new GaiaSessionAdapter({
+			host: HOST,
+			token: "secret-token",
+			fetchImpl: fetchImpl as unknown as typeof fetch,
+			warn: () => {},
+		});
+
+		const result = await a.discoverSessions();
+
+		expect(result.source).toBe("gaia");
+		expect(result.totalCount).toBe(2);
+		expect(result.sessions.map((s) => s.id).sort()).toEqual([
+			"gaia:jeeves:s-100",
+			"gaia:scout:s-200",
+		]);
+		// Bearer auth on every request
+		for (const call of fetchImpl.mock.calls) {
+			expect((call[1] as RequestInit).headers).toMatchObject({
+				authorization: "Bearer secret-token",
+			});
+		}
+	});
+
+	it("attributes each session to its habitat entry", async () => {
+		const a = adapter({
+			"/api/habitats": HABITATS,
+			"/api/habitats/jeeves/sessions": JEEVES_SESSIONS,
+			"/api/habitats/scout/sessions": SCOUT_SESSIONS,
+		});
+
+		const { sessions } = await a.discoverSessions();
+		const jeeves = sessions.find((s) => s.id === "gaia:jeeves:s-100")!;
+
+		expect(jeeves.sourceData).toMatchObject({
+			habitatId: "jeeves",
+			habitatName: "Jeeves Bot",
+			gaiaHost: HOST,
+		});
+		expect(jeeves.firstPrompt).toBe("deploy the newsletter");
+		expect(jeeves.messageCount).toBe(8);
+	});
+
+	it("is inert (empty, no warnings) when no host is configured", async () => {
+		const warn = vi.fn();
+		const a = new GaiaSessionAdapter({
+			host: undefined,
+			fetchImpl: fetchFor({}) as unknown as typeof fetch,
+			warn,
+		});
+		// Belt and braces: GAIA_HOST may leak from the environment.
+		if (!process.env.GAIA_HOST) {
+			const result = await a.discoverSessions();
+			expect(result.sessions).toEqual([]);
+			expect(warn).not.toHaveBeenCalled();
+		}
+	});
+});
+
+describe("GaiaSessionAdapter — loading", () => {
+	it("loads a full session with normalized messages and tool activity", async () => {
+		const a = adapter({
+			"/api/habitats/jeeves/sessions": JEEVES_SESSIONS,
+			"/api/habitats/jeeves/sessions/s-100/messages": MESSAGES,
+		});
+
+		const session = await a.getSession("gaia:jeeves:s-100");
+
+		expect(session).not.toBeNull();
+		expect(session!.source).toBe("gaia");
+		expect(session!.sourceData).toMatchObject({ habitatId: "jeeves" });
+		const roles = session!.messages.map((m) => m.role);
+		expect(roles).toEqual(["user", "assistant", "tool"]);
+		const tool = session!.messages[2];
+		expect(tool.tool).toMatchObject({
+			name: "deploy",
+			output: "deployed ok",
+			isError: false,
+		});
+		expect(session!.messages[1].model).toBe("gemini-3-flash-preview");
+	});
+
+	it("accepts unprefixed habitat:session ids too", async () => {
+		const a = adapter({
+			"/api/habitats/jeeves/sessions": JEEVES_SESSIONS,
+			"/api/habitats/jeeves/sessions/s-100/messages": MESSAGES,
+		});
+		expect(await a.getMessages("jeeves:s-100")).toHaveLength(3);
+	});
+});
+
+describe("GaiaSessionAdapter — degradation", () => {
+	it("warns and returns an empty result when the host is unreachable", async () => {
+		const warn = vi.fn();
+		const a = new GaiaSessionAdapter({
+			host: HOST,
+			fetchImpl: vi.fn(async () => {
+				throw new Error("ECONNREFUSED");
+			}) as unknown as typeof fetch,
+			warn,
+		});
+
+		const result = await a.discoverSessions();
+
+		expect(result.sessions).toEqual([]);
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining("unreachable"));
+	});
+
+	it("warns and returns an empty result on a bad token (401)", async () => {
+		const warn = vi.fn();
+		const a = new GaiaSessionAdapter({
+			host: HOST,
+			token: "wrong",
+			fetchImpl: vi.fn(async () => ({
+				ok: false,
+				status: 401,
+				json: async () => ({ error: "Unauthorized" }),
+			})) as unknown as typeof fetch,
+			warn,
+		});
+
+		const result = await a.discoverSessions();
+
+		expect(result.sessions).toEqual([]);
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining("401"));
+	});
+
+	it("skips a failing habitat but keeps listing the others", async () => {
+		const warn = vi.fn();
+		const a = adapter(
+			{
+				"/api/habitats": HABITATS,
+				// jeeves missing → 404 from the stub
+				"/api/habitats/scout/sessions": SCOUT_SESSIONS,
+			},
+			{ warn },
+		);
+
+		const { sessions } = await a.discoverSessions();
+
+		expect(sessions.map((s) => s.id)).toEqual(["gaia:scout:s-200"]);
+		expect(warn).toHaveBeenCalledWith(expect.stringContaining('habitat "jeeves"'));
+	});
+});
+
+describe("GaiaSessionAdapter — projection integration", () => {
+	it("projects remote sessions into Explorations like any other adapter", async () => {
+		const registry = new AdapterRegistry();
+		registry.register(
+			adapter({
+				"/api/habitats": HABITATS,
+				"/api/habitats/jeeves/sessions": JEEVES_SESSIONS,
+				"/api/habitats/scout/sessions": SCOUT_SESSIONS,
+			}),
+		);
+
+		const projection = await projectSessions("/some/project", { registry });
+
+		expect(projection.sourceSessions).toHaveLength(2);
+		const jeeves = projection.sourceSessions.find(
+			(s) => s.id === "gaia:jeeves:s-100",
+		)!;
+		expect(jeeves.source).toBe("gaia");
+		expect(jeeves.sourceData).toMatchObject({
+			habitatId: "jeeves",
+			habitatName: "Jeeves Bot",
+		});
+		expect(projection.explorations).toHaveLength(2);
+	});
+});

--- a/packages/core/src/interaction/adapters/gaia-session-adapter.ts
+++ b/packages/core/src/interaction/adapters/gaia-session-adapter.ts
@@ -1,0 +1,331 @@
+/**
+ * Gaia session adapter — reads habitat container sessions over HTTP.
+ *
+ * For remote Gaia hosts where bind mounts don't help: lists and fetches
+ * sessions through Gaia's authenticated proxy routes (the per-habitat
+ * sessions API), tagging each session with its habitat entry. Registers
+ * with the projection layer like any other adapter, so `umwelten browse`
+ * and the digester consume remote sessions the same way as local ones.
+ *
+ * Wire shapes consumed (Gaia orchestrator, bearer auth):
+ *   GET {host}/api/habitats                         → GaiaHabitatEntry[] (+status)
+ *   GET {host}/api/habitats/:id/sessions            → { sessions, total }
+ *   GET {host}/api/habitats/:id/sessions/:sid/messages → { sessionId, messages }
+ *
+ * Degradation contract: an unreachable host or bad token logs a warning
+ * and yields an empty discovery result (skipped source), never a throw
+ * that would take down the whole projection. A single failing habitat is
+ * skipped; the others still list.
+ *
+ * Configuration: GAIA_HOST (e.g. "http://gaia.example:7420") and
+ * GAIA_TOKEN env vars, or explicit options. With no host configured the
+ * adapter is inert (empty results, no warnings).
+ */
+
+import type {
+	NormalizedMessage,
+	NormalizedSession,
+	NormalizedSessionEntry,
+	SessionDiscoveryOptions,
+	SessionDiscoveryResult,
+	SessionSource,
+} from "../types/normalized-types.js";
+import type { SessionAdapter } from "./adapter.js";
+
+// ── Wire types (subset of the Gaia / container HTTP responses) ────
+
+interface WireHabitatEntry {
+	id: string;
+	name?: string;
+	status?: string;
+}
+
+interface WireSessionEntry {
+	sessionId: string;
+	type?: string;
+	created: string;
+	lastUsed?: string;
+	firstPrompt?: string;
+	messageCount?: number;
+	chatId?: string;
+}
+
+interface WireMessage {
+	index?: number;
+	role: string;
+	content?: string;
+	timestamp?: string;
+	model?: string;
+	toolCalls?: Array<{ id?: string; name: string; input?: unknown }>;
+	toolResults?: Array<{
+		tool_use_id?: string;
+		content?: string;
+		is_error?: boolean;
+	}>;
+}
+
+export interface GaiaSessionAdapterOptions {
+	/** Gaia host base URL, e.g. "http://gaia.example:7420". Default: GAIA_HOST. */
+	host?: string;
+	/** Bearer token for the Gaia API. Default: GAIA_TOKEN. */
+	token?: string;
+	/** Fetch implementation (injectable for tests). Default: global fetch. */
+	fetchImpl?: typeof fetch;
+	/** Warning sink. Default: console.warn. */
+	warn?: (message: string) => void;
+}
+
+export class GaiaSessionAdapter implements SessionAdapter {
+	readonly source: SessionSource = "gaia";
+	readonly displayName = "Gaia (remote habitats)";
+
+	private readonly host?: string;
+	private readonly token?: string;
+	private readonly fetchImpl: typeof fetch;
+	private readonly warn: (message: string) => void;
+
+	constructor(options: GaiaSessionAdapterOptions = {}) {
+		const host = options.host ?? process.env.GAIA_HOST;
+		this.host = host ? host.replace(/\/$/, "") : undefined;
+		this.token = options.token ?? process.env.GAIA_TOKEN;
+		this.fetchImpl = options.fetchImpl ?? fetch;
+		this.warn = options.warn ?? ((m) => console.warn(m));
+	}
+
+	getSourceLocation(): string {
+		return this.host ?? "(GAIA_HOST not set)";
+	}
+
+	/** Remote sessions are host-scoped, not project-scoped. */
+	async canHandle(_projectPath: string): Promise<boolean> {
+		return Boolean(this.host);
+	}
+
+	async discoverProjects(): Promise<string[]> {
+		return [];
+	}
+
+	async hasSessionsForProject(_projectPath: string): Promise<boolean> {
+		return false;
+	}
+
+	async discoverSessions(
+		options?: SessionDiscoveryOptions,
+	): Promise<SessionDiscoveryResult> {
+		const empty: SessionDiscoveryResult = {
+			sessions: [],
+			source: this.source,
+			totalCount: 0,
+			hasMore: false,
+		};
+		if (!this.host) return empty;
+
+		let habitats: WireHabitatEntry[];
+		try {
+			habitats = await this.getJson<WireHabitatEntry[]>("/api/habitats");
+		} catch (err) {
+			this.warn(
+				`[gaia-adapter] skipping Gaia source — ${this.host} unreachable or rejected the token: ${err instanceof Error ? err.message : String(err)}`,
+			);
+			return empty;
+		}
+
+		const entries: NormalizedSessionEntry[] = [];
+		for (const habitat of habitats) {
+			let result: { sessions?: WireSessionEntry[] };
+			try {
+				result = await this.getJson<{ sessions?: WireSessionEntry[] }>(
+					`/api/habitats/${encodeURIComponent(habitat.id)}/sessions`,
+				);
+			} catch (err) {
+				this.warn(
+					`[gaia-adapter] skipping habitat "${habitat.id}": ${err instanceof Error ? err.message : String(err)}`,
+				);
+				continue;
+			}
+			for (const session of result.sessions ?? []) {
+				entries.push(this.toNormalizedEntry(habitat, session));
+			}
+		}
+
+		// Date window + sort + limit (mirrors the other adapters).
+		let filtered = entries;
+		if (options?.since) {
+			const since = options.since.getTime();
+			filtered = filtered.filter(
+				(e) => new Date(e.modified).getTime() >= since,
+			);
+		}
+		if (options?.until) {
+			const until = options.until.getTime();
+			filtered = filtered.filter(
+				(e) => new Date(e.created).getTime() <= until,
+			);
+		}
+		const sortBy = options?.sortBy ?? "modified";
+		const dir = options?.sortOrder === "asc" ? 1 : -1;
+		filtered.sort((a, b) => {
+			const av =
+				sortBy === "messageCount"
+					? a.messageCount
+					: new Date(a[sortBy]).getTime();
+			const bv =
+				sortBy === "messageCount"
+					? b.messageCount
+					: new Date(b[sortBy]).getTime();
+			return (av - bv) * dir;
+		});
+		const totalCount = filtered.length;
+		if (options?.limit && filtered.length > options.limit) {
+			filtered = filtered.slice(0, options.limit);
+		}
+
+		return {
+			sessions: filtered,
+			source: this.source,
+			totalCount,
+			hasMore: filtered.length < totalCount,
+		};
+	}
+
+	async getSessionEntry(
+		sessionId: string,
+	): Promise<NormalizedSessionEntry | null> {
+		const parsed = this.parseId(sessionId);
+		if (!parsed || !this.host) return null;
+		try {
+			const result = await this.getJson<{ sessions?: WireSessionEntry[] }>(
+				`/api/habitats/${encodeURIComponent(parsed.habitatId)}/sessions`,
+			);
+			const session = (result.sessions ?? []).find(
+				(s) => s.sessionId === parsed.sessionId,
+			);
+			if (!session) return null;
+			return this.toNormalizedEntry({ id: parsed.habitatId }, session);
+		} catch {
+			return null;
+		}
+	}
+
+	async getSession(sessionId: string): Promise<NormalizedSession | null> {
+		const entry = await this.getSessionEntry(sessionId);
+		if (!entry) return null;
+		const messages = await this.getMessages(sessionId);
+		return {
+			...entry,
+			messages,
+			messageCount: messages.length || entry.messageCount,
+		};
+	}
+
+	async getMessages(sessionId: string): Promise<NormalizedMessage[]> {
+		const parsed = this.parseId(sessionId);
+		if (!parsed || !this.host) return [];
+		let result: { messages?: WireMessage[] };
+		try {
+			result = await this.getJson<{ messages?: WireMessage[] }>(
+				`/api/habitats/${encodeURIComponent(parsed.habitatId)}/sessions/${encodeURIComponent(parsed.sessionId)}/messages`,
+			);
+		} catch (err) {
+			this.warn(
+				`[gaia-adapter] failed to load messages for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+			);
+			return [];
+		}
+		return this.toNormalizedMessages(result.messages ?? []);
+	}
+
+	// ── Mapping ─────────────────────────────────────────────────────
+
+	private toNormalizedEntry(
+		habitat: WireHabitatEntry,
+		session: WireSessionEntry,
+	): NormalizedSessionEntry {
+		return {
+			id: `gaia:${habitat.id}:${session.sessionId}`,
+			source: this.source,
+			sourceId: `${habitat.id}:${session.sessionId}`,
+			created: session.created,
+			modified: session.lastUsed ?? session.created,
+			messageCount: session.messageCount ?? 0,
+			firstPrompt: session.firstPrompt ?? "",
+			sourceData: {
+				habitatId: habitat.id,
+				habitatName: habitat.name ?? habitat.id,
+				gaiaHost: this.host,
+				sessionType: session.type,
+				chatId: session.chatId,
+			},
+		};
+	}
+
+	private toNormalizedMessages(wire: WireMessage[]): NormalizedMessage[] {
+		const messages: NormalizedMessage[] = [];
+		for (const [i, raw] of wire.entries()) {
+			const role =
+				raw.role === "user" ||
+				raw.role === "assistant" ||
+				raw.role === "system" ||
+				raw.role === "tool"
+					? raw.role
+					: "assistant";
+			messages.push({
+				id: `msg-${raw.index ?? i}`,
+				role,
+				content: raw.content ?? "",
+				timestamp: raw.timestamp,
+				model: raw.model,
+			});
+			// Surface tool activity as tool messages, joining results by id.
+			for (const call of raw.toolCalls ?? []) {
+				const match = (raw.toolResults ?? []).find(
+					(r) => r.tool_use_id && r.tool_use_id === call.id,
+				);
+				messages.push({
+					id: `msg-${raw.index ?? i}-tool-${call.id ?? call.name}`,
+					role: "tool",
+					content: match?.content ?? "",
+					timestamp: raw.timestamp,
+					tool: {
+						name: call.name,
+						input: (call.input ?? undefined) as
+							| Record<string, unknown>
+							| undefined,
+						output: match?.content,
+						isError: match?.is_error,
+					},
+				});
+			}
+		}
+		return messages;
+	}
+
+	// ── HTTP ────────────────────────────────────────────────────────
+
+	/** Accepts "gaia:<habitatId>:<sessionId>" or "<habitatId>:<sessionId>". */
+	private parseId(
+		id: string,
+	): { habitatId: string; sessionId: string } | null {
+		const raw = id.startsWith("gaia:") ? id.slice(5) : id;
+		const sep = raw.indexOf(":");
+		if (sep <= 0 || sep === raw.length - 1) return null;
+		return { habitatId: raw.slice(0, sep), sessionId: raw.slice(sep + 1) };
+	}
+
+	private async getJson<T>(path: string): Promise<T> {
+		const response = await this.fetchImpl(`${this.host}${path}`, {
+			headers: {
+				accept: "application/json",
+				...(this.token ? { authorization: `Bearer ${this.token}` } : {}),
+			},
+		});
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status} from ${path}`);
+		}
+		return (await response.json()) as T;
+	}
+}
+
+export function createGaiaSessionAdapter(): GaiaSessionAdapter {
+	return new GaiaSessionAdapter();
+}

--- a/packages/core/src/interaction/adapters/index.ts
+++ b/packages/core/src/interaction/adapters/index.ts
@@ -8,6 +8,7 @@ export * from "./adapter.js";
 export * from "./antigravity-adapter.js";
 export * from "./claude-code-adapter.js";
 export * from "./cursor-adapter.js";
+export * from "./gaia-session-adapter.js";
 export * from "./pi-adapter.js";
 export * from "./load-interaction.js";
 
@@ -15,6 +16,7 @@ import { adapterRegistry } from "./adapter.js";
 import { createAntigravityAdapter } from "./antigravity-adapter.js";
 import { createClaudeCodeAdapter } from "./claude-code-adapter.js";
 import { createCursorAdapter } from "./cursor-adapter.js";
+import { createGaiaSessionAdapter } from "./gaia-session-adapter.js";
 import { PiSessionAdapter } from "./pi-adapter.js";
 
 /**
@@ -32,6 +34,9 @@ export function initializeAdapters(): void {
 
 	// Register Antigravity adapter
 	adapterRegistry.registerFactory("antigravity", createAntigravityAdapter);
+
+	// Register Gaia adapter (remote habitat sessions; inert without GAIA_HOST)
+	adapterRegistry.registerFactory("gaia", createGaiaSessionAdapter);
 }
 
 /**

--- a/packages/core/src/interaction/types/normalized-types.ts
+++ b/packages/core/src/interaction/types/normalized-types.ts
@@ -20,6 +20,7 @@ export type SessionSource =
 	| "native"
 	| "pi"
 	| "habitat"
+	| "gaia"
 	| "unknown";
 
 /**

--- a/packages/habitat/src/tools/gaia/proxy-target.test.ts
+++ b/packages/habitat/src/tools/gaia/proxy-target.test.ts
@@ -48,3 +48,19 @@ describe('resolveProxyTarget', () => {
     expect(resolveProxyTarget('/api/secrets')).toBeNull();
   });
 });
+
+describe('resolveProxyTarget — per-session routes (#120)', () => {
+  it('maps the sessions list route', () => {
+    expect(resolveProxyTarget('/api/habitats/h1/sessions')).toEqual({
+      id: 'h1',
+      targetPath: '/api/sessions',
+    });
+  });
+
+  it('maps per-session subpaths (messages) through the wildcard', () => {
+    expect(resolveProxyTarget('/api/habitats/h1/sessions/s-42/messages')).toEqual({
+      id: 'h1',
+      targetPath: '/api/sessions/s-42/messages',
+    });
+  });
+});

--- a/packages/habitat/src/tools/gaia/routes.ts
+++ b/packages/habitat/src/tools/gaia/routes.ts
@@ -115,6 +115,7 @@ const PROXY_ROUTES: Array<{ pattern: string; target: string }> = [
 	},
 	{ pattern: "/api/habitats/:id/status", target: "/api/status" },
 	{ pattern: "/api/habitats/:id/sessions", target: "/api/sessions" },
+	{ pattern: "/api/habitats/:id/sessions/*", target: "/api/sessions/" },
 	{ pattern: "/api/habitats/:id/artifacts", target: "/api/artifacts" },
 	{ pattern: "/api/habitats/:id/contexts/*", target: "/api/contexts/" },
 	{ pattern: "/api/habitats/:id/files/*", target: "/files/" },


### PR DESCRIPTION
Closes #120 (parent PRD: #113).

## What this builds

`GaiaSessionAdapter` (`packages/core/src/interaction/adapters/gaia-session-adapter.ts`) — a source-session adapter that reads habitat container sessions **over HTTP** through Gaia's authenticated proxy, for remote Gaia hosts where bind mounts don't help. It implements the same `SessionAdapter` interface as the other adapters and registers with the projection layer (`initializeAdapters()`), so `umwelten browse` and the digester consume remote sessions exactly like local ones.

- **Discovery**: `GET {GAIA_HOST}/api/habitats` (registry) → per-habitat `GET /api/habitats/:id/sessions` (proxied to each container's `/api/sessions`), all with `Authorization: Bearer {GAIA_TOKEN}`.
- **Attribution**: every Source Session carries its habitat entry — `sourceData: { habitatId, habitatName, gaiaHost, sessionType, chatId }`, ids shaped `gaia:<habitatId>:<sessionId>`. A new `"gaia"` member was added to the `SessionSource` union (additive; no exhaustive matches existed).
- **Loading**: per-session messages via the proxy; `toolCalls`/`toolResults` from the container API are surfaced as normalized `tool` messages joined by `tool_use_id`, with model identity preserved.
- **Config**: `GAIA_HOST` + `GAIA_TOKEN` env vars (or explicit constructor options with injectable `fetchImpl` for tests). Without a host the adapter is inert — empty results, zero noise in projects that don't use Gaia.
- **Gaia routes**: the proxy allowlist only had the exact `/api/habitats/:id/sessions` mapping, so per-session subpaths were unreachable; added the `/api/habitats/:id/sessions/*` wildcard (list route unchanged).

## Acceptance criteria → how to verify

### ✅ Adapter lists sessions across all registered habitats via the Gaia proxy with bearer auth

Unit-tested with mocked HTTP (`gaia-session-adapter.test.ts` — "lists sessions across all registered habitats with bearer auth" asserts the bearer header on every request). Live demo against a real Gaia host:

```bash
# with a Gaia orchestrator running containers somewhere:
GAIA_HOST=http://<gaia-host>:7420 GAIA_TOKEN=<key> dotenvx run -- pnpm run cli browse
# remote sessions appear alongside local ones, titled by first prompt
```

Verified end-to-end here against a stub Gaia host (three routes, bearer-enforced): `initializeAdapters()` + `projectSessions()` with only env vars set returned `gaia:jeeves:s-1` titled "hello from remote", attributed to "Jeeves Bot", and `getSession()` loaded both messages.

### ✅ Sessions load with full messages and are attributed to their habitat entry

- "loads a full session with normalized messages and tool activity" — user/assistant/tool roles, tool output joined by id, model preserved.
- "attributes each session to its habitat entry" + the projection-integration test assert `sourceData.habitatId/habitatName` survive all the way into `SourceSession`.

### ✅ Unreachable host or bad token degrades gracefully

- Unreachable host → `[gaia-adapter] skipping Gaia source — … unreachable …` warning + empty result (skipped source).
- 401 bad token → warning + empty result.
- One habitat down → that habitat skipped with a warning, the others still list.
- Nothing throws into `projectSessions` (and the registry's own catch is a second safety net).

### ✅ Unit tests with mocked HTTP: listing, loading, attribution, error paths

```bash
npx vitest run packages/core/src/interaction/adapters/gaia-session-adapter.test.ts packages/habitat/src/tools/gaia/proxy-target.test.ts
# 9 adapter tests + 2 new proxy-route mapping tests, all green
```

### ✅ `pnpm test:run` passes

110 files, 1425 tests green. `pnpm lint`: 0 errors, no new warnings.

## Worth knowing / further work

- The adapter intentionally ignores `projectPath` filtering — remote container sessions aren't project-scoped, and the issue's demo is "see sessions from that host" in any browse.
- Digesting a remote session re-fetches messages per run; fine at current volumes, a candidate for local caching if hosts get large.
- The Gaia dashboard's own API key is what `GAIA_TOKEN` should be set to (the per-container keys are injected by the proxy on the Gaia side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)