### PR TITLE
feat(twitter): bookmarks read tool + habitat work dir, chattable end-to-end (#151)

### DIFF
--- a/examples/twitter-habitat/.gitignore
+++ b/examples/twitter-habitat/.gitignore
@@ -1,0 +1,4 @@
+# Habitat runtime state (created when this dir is used as a habitat work dir)
+secrets.json
+sessions/
+dist/

--- a/examples/twitter-habitat/README.md
+++ b/examples/twitter-habitat/README.md
@@ -12,12 +12,44 @@ library packages.
 ```bash
 cd examples/twitter-habitat
 pnpm install        # standalone install (this dir is its own pnpm root)
-pnpm test:run       # runs the token-store + OAuth unit tests (vitest)
+pnpm test:run       # token-store + OAuth + X read-client unit tests (vitest)
 ```
 
-> Status: scaffolding in progress. This issue (#150) ships the **authentication
-> foundation** — the X OAuth token store + the one-shot bootstrap script. The
-> tools, persona, feed reader, and fly deploy land in #151–#155.
+> Status: scaffolding in progress. #150 shipped the **auth foundation** (X OAuth
+> token store + bootstrap). #151 adds the **habitat work dir** (config + persona +
+> `tools/`) and the first read tool — **bookmarks** — chattable end-to-end. The
+> X read client is introduced here (bookmarks call only). Mentions/timeline,
+> the Neon feed reader, the full persona, and the fly deploy land in #152–#155.
+
+## Run it as a habitat
+
+This directory doubles as the habitat work dir (`config.json` + `STIMULUS.md` +
+`tools/`). Boot it with the monorepo CLI and chat over A2A. (Run these from the
+**repo root**, which has the umwelten CLI + `.env`.)
+
+```bash
+# 1. Seed the X credentials as habitat secrets (one-time; see bootstrap below).
+dotenvx run -- pnpm run cli habitat secrets set TWITTER_CLIENT_ID     '...' --work-dir examples/twitter-habitat
+dotenvx run -- pnpm run cli habitat secrets set TWITTER_CLIENT_SECRET '...' --work-dir examples/twitter-habitat
+dotenvx run -- pnpm run cli habitat secrets set TWITTER_REFRESH_TOKEN '...' --work-dir examples/twitter-habitat
+
+# 2. Serve the habitat (A2A + chat). Uses openrouter by default (config.json);
+#    override with --provider/--model. Needs OPENROUTER_API_KEY in .env.
+dotenvx run -- pnpm run cli habitat serve --work-dir examples/twitter-habitat --port 7430
+
+# 3. In another terminal, chat with it:
+dotenvx run -- pnpm run cli habitat chat --url http://localhost:7430 --one-shot "show my bookmarks"
+```
+
+The `bookmarks` tool (`tools/bookmarks/`) is a factory-pattern Agent tool: it
+pulls the X credentials from Habitat secrets, drives the token store → X read
+client, and returns your real bookmarks (text, author, engagement, permalink),
+streamed back through the chat.
+
+> The handler in `tools/bookmarks/handler.ts` imports `ai`/`zod` and the `src/`
+> modules; it is loaded and run by the **monorepo** habitat runtime, so it is not
+> part of this example's standalone `tsc`/`vitest` build (which only covers
+> `src/`). The deep modules it calls (`token-store`, `x-read-client`) are unit-tested.
 
 ## Two data sources, split by privacy
 

--- a/examples/twitter-habitat/STIMULUS.md
+++ b/examples/twitter-habitat/STIMULUS.md
@@ -1,0 +1,26 @@
+You are **Twitter**, a conversational assistant for one person's X (Twitter) life.
+
+You answer questions about their Twitter world grounded in real data fetched
+through your tools — never guess or fabricate tweets, authors, or counts. If a
+tool returns an error (for example, authentication is not set up), say so plainly
+and tell the user what is needed; do not invent a result.
+
+## What you can do today
+
+- **Bookmarks** — show the tweets the user has saved. Use the `bookmarks` tool
+  when they ask things like "show my bookmarks", "what did I save", or "my recent
+  bookmarks". Pass a `limit` when they ask for a specific number.
+
+(More capabilities — mentions/replies, specific people, list digests, and a
+combined "what's new" briefing — are coming in later slices.)
+
+## How to answer
+
+- When you list tweets, lead with the author and a short version of the text,
+  then the engagement (likes/retweets/replies) when it's notable, and include the
+  permalink so the user can open it.
+- Order by what the tool returns (most recent first) unless the user asks for
+  something else.
+- Keep it skimmable: a tight list beats a wall of prose.
+- If the user asks for "the most popular" or "top" bookmarks, sort what the tool
+  returned by engagement before presenting.

--- a/examples/twitter-habitat/config.json
+++ b/examples/twitter-habitat/config.json
@@ -1,0 +1,8 @@
+{
+  "name": "Twitter",
+  "defaultProvider": "openrouter",
+  "defaultModel": "openai/gpt-4o-mini",
+  "toolsDir": "tools",
+  "stimulusFile": "STIMULUS.md",
+  "agents": []
+}

--- a/examples/twitter-habitat/src/x-read-client.test.ts
+++ b/examples/twitter-habitat/src/x-read-client.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { XReadClient, type TokenProvider } from './x-read-client.js';
+
+// ── Test doubles ─────────────────────────────────────────────────────
+
+/** Token provider that records how many times a forced refresh was requested. */
+function fakeTokens(): TokenProvider & { forceCount: number; calls: number } {
+  return {
+    forceCount: 0,
+    calls: 0,
+    async getValidToken(opts) {
+      this.calls++;
+      if (opts?.forceRefresh) this.forceCount++;
+      return this.forceCount > 0 ? 'token-refreshed' : 'token-1';
+    },
+  };
+}
+
+interface Queued {
+  status?: number;
+  json?: unknown;
+  body?: string;
+}
+function fakeFetch(responses: Queued[]) {
+  const calls: Array<{ url: string; authorization?: string }> = [];
+  let i = 0;
+  const fn = async (input: string | URL, init?: RequestInit): Promise<Response> => {
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    calls.push({ url: String(input), authorization: headers.Authorization });
+    const next = responses[i++];
+    if (!next) throw new Error('fakeFetch: no queued response');
+    const status = next.status ?? 200;
+    const payload = next.body ?? JSON.stringify(next.json ?? {});
+    return new Response(payload, { status });
+  };
+  return { fn, calls };
+}
+
+const ME = { json: { data: { id: 'u-me', username: 'me', name: 'Me' } } };
+
+function bookmarksPage() {
+  return {
+    json: {
+      data: [
+        {
+          id: 't1',
+          text: 'first bookmark',
+          created_at: '2026-06-01T00:00:00.000Z',
+          author_id: 'a1',
+          public_metrics: { like_count: 10, retweet_count: 2, reply_count: 1, quote_count: 0 },
+        },
+        {
+          id: 't2',
+          text: 'second bookmark',
+          author_id: 'a2',
+          public_metrics: { like_count: 5 },
+        },
+      ],
+      includes: {
+        users: [
+          { id: 'a1', username: 'alice', name: 'Alice' },
+          { id: 'a2', username: 'bob', name: 'Bob' },
+        ],
+      },
+    },
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('XReadClient.getBookmarks', () => {
+  it('returns shaped bookmarks with author, metrics, and permalink', async () => {
+    const tokens = fakeTokens();
+    const { fn, calls } = fakeFetch([ME, bookmarksPage()]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    const bookmarks = await client.getBookmarks({ maxResults: 20 });
+
+    expect(bookmarks).toHaveLength(2);
+    expect(bookmarks[0]).toMatchObject({
+      id: 't1',
+      text: 'first bookmark',
+      createdAt: '2026-06-01T00:00:00.000Z',
+      author: { id: 'a1', username: 'alice', name: 'Alice' },
+      metrics: { likes: 10, retweets: 2, replies: 1, quotes: 0 },
+      url: 'https://x.com/alice/status/t1',
+    });
+    // Missing metric fields default to 0.
+    expect(bookmarks[1].metrics).toEqual({ likes: 5, retweets: 0, replies: 0, quotes: 0 });
+    // Sends a bearer token on each request.
+    expect(calls[0].authorization).toBe('Bearer token-1');
+  });
+
+  it('requests the authenticated user id, then that user\'s bookmarks', async () => {
+    const tokens = fakeTokens();
+    const { fn, calls } = fakeFetch([ME, bookmarksPage()]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    await client.getBookmarks();
+
+    expect(calls[0].url).toContain('/users/me');
+    expect(calls[1].url).toContain('/users/u-me/bookmarks');
+    expect(calls[1].url).toContain('expansions=author_id');
+  });
+
+  it('caps max_results at 100 and floors it at 1', async () => {
+    const tokens = fakeTokens();
+    const { fn, calls } = fakeFetch([ME, bookmarksPage()]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    await client.getBookmarks({ maxResults: 9999 });
+    expect(calls[1].url).toContain('max_results=100');
+  });
+
+  it('force-refreshes the token and retries once on a 401', async () => {
+    const tokens = fakeTokens();
+    // me OK, then bookmarks 401, then bookmarks OK after refresh.
+    const { fn, calls } = fakeFetch([ME, { status: 401, body: 'unauthorized' }, bookmarksPage()]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    const bookmarks = await client.getBookmarks();
+
+    expect(bookmarks).toHaveLength(2);
+    expect(tokens.forceCount).toBe(1); // exactly one forced refresh
+    expect(calls).toHaveLength(3); // me, 401, retry
+    expect(calls[2].authorization).toBe('Bearer token-refreshed'); // retry uses the new token
+  });
+
+  it('throws when a non-401 error persists', async () => {
+    const tokens = fakeTokens();
+    const { fn } = fakeFetch([ME, { status: 503, body: 'upstream' }]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    await expect(client.getBookmarks()).rejects.toThrow(/503/);
+  });
+
+  it('caches the authenticated user across calls', async () => {
+    const tokens = fakeTokens();
+    const { fn, calls } = fakeFetch([ME, bookmarksPage(), bookmarksPage()]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    await client.getBookmarks();
+    await client.getBookmarks();
+
+    // /users/me fetched once; two bookmark fetches.
+    expect(calls.filter((c) => c.url.includes('/users/me'))).toHaveLength(1);
+  });
+});

--- a/examples/twitter-habitat/src/x-read-client.ts
+++ b/examples/twitter-habitat/src/x-read-client.ts
@@ -1,0 +1,156 @@
+/**
+ * X (Twitter) API v2 read client — the private-data path for the Twitter habitat.
+ *
+ * Thin, token-agnostic wrapper over the official X API v2 read endpoints. It takes
+ * a {@link TokenProvider} (the {@link XTokenStore} from token-store.ts) and returns
+ * shaped data; the Agent tools that consume it embed no HTTP or auth logic.
+ *
+ * This slice (#151) implements only the **bookmarks** call. Later slices (#152)
+ * extend the same client with mentions + my-timeline.
+ *
+ * Reactive 401 handling, per reports/2026-06-16-x-oauth2-token-refresh.md: a 401
+ * from a resource call means the access token went stale before its clock expiry,
+ * so we force a refresh and retry the request exactly once.
+ */
+
+/** Anything that can hand out a valid X access token — implemented by XTokenStore. */
+export interface TokenProvider {
+  getValidToken(opts?: { forceRefresh?: boolean }): Promise<string>;
+}
+
+/** Minimal `fetch` shape so callers can inject a fake in tests. */
+export type FetchLike = (
+  input: string | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/** The authenticated user, from GET /2/users/me. */
+export interface XUser {
+  id: string;
+  username?: string;
+  name?: string;
+}
+
+/** A bookmarked tweet, shaped for the agent. */
+export interface XBookmark {
+  id: string;
+  text: string;
+  createdAt?: string;
+  author?: XUser;
+  metrics: { likes: number; retweets: number; replies: number; quotes: number };
+  /** Permalink, when the author handle is known. */
+  url?: string;
+}
+
+export interface XReadClientOptions {
+  fetchFn?: FetchLike;
+  /** Override the API base (defaults to the canonical api.x.com host). */
+  baseUrl?: string;
+}
+
+const DEFAULT_BASE_URL = 'https://api.x.com/2';
+
+// X public_metrics → our flat shape.
+interface PublicMetrics {
+  like_count?: number;
+  retweet_count?: number;
+  reply_count?: number;
+  quote_count?: number;
+}
+interface RawTweet {
+  id: string;
+  text: string;
+  created_at?: string;
+  author_id?: string;
+  public_metrics?: PublicMetrics;
+}
+interface RawUser {
+  id: string;
+  username?: string;
+  name?: string;
+}
+
+export class XReadClient {
+  private readonly tokens: TokenProvider;
+  private readonly fetchFn: FetchLike;
+  private readonly baseUrl: string;
+  private me: XUser | undefined;
+
+  constructor(tokens: TokenProvider, opts: XReadClientOptions = {}) {
+    this.tokens = tokens;
+    this.fetchFn = opts.fetchFn ?? fetch;
+    this.baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
+  }
+
+  /** GET a JSON resource with a bearer token; on 401, force-refresh and retry once. */
+  private async authedGetJson(path: string): Promise<unknown> {
+    const url = `${this.baseUrl}${path}`;
+    let token = await this.tokens.getValidToken();
+    let res = await this.fetchFn(url, { headers: { Authorization: `Bearer ${token}` } });
+
+    if (res.status === 401) {
+      token = await this.tokens.getValidToken({ forceRefresh: true });
+      res = await this.fetchFn(url, { headers: { Authorization: `Bearer ${token}` } });
+    }
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`X read failed: ${res.status} ${body.slice(0, 200)}`);
+    }
+    return res.json();
+  }
+
+  /** The authenticated user (cached after the first call). */
+  async getMe(): Promise<XUser> {
+    if (this.me) return this.me;
+    const data = (await this.authedGetJson('/users/me?user.fields=username,name')) as {
+      data?: RawUser;
+    };
+    if (!data.data?.id) throw new Error('X /users/me returned no user');
+    this.me = { id: data.data.id, username: data.data.username, name: data.data.name };
+    return this.me;
+  }
+
+  /**
+   * The authenticated user's bookmarks, most-recent first, shaped for the agent.
+   * @param opts.maxResults 1–100 (X caps the page at 100); defaults to 20.
+   */
+  async getBookmarks(opts: { maxResults?: number } = {}): Promise<XBookmark[]> {
+    const max = Math.min(Math.max(opts.maxResults ?? 20, 1), 100);
+    const me = await this.getMe();
+    const params = new URLSearchParams({
+      max_results: String(max),
+      'tweet.fields': 'created_at,public_metrics,author_id',
+      expansions: 'author_id',
+      'user.fields': 'username,name',
+    });
+    const body = (await this.authedGetJson(
+      `/users/${me.id}/bookmarks?${params.toString()}`,
+    )) as { data?: RawTweet[]; includes?: { users?: RawUser[] } };
+
+    const usersById = new Map<string, RawUser>();
+    for (const u of body.includes?.users ?? []) usersById.set(u.id, u);
+
+    return (body.data ?? []).map((t) => {
+      const author = t.author_id ? usersById.get(t.author_id) : undefined;
+      const m = t.public_metrics ?? {};
+      return {
+        id: t.id,
+        text: t.text,
+        createdAt: t.created_at,
+        author: author
+          ? { id: author.id, username: author.username, name: author.name }
+          : t.author_id
+            ? { id: t.author_id }
+            : undefined,
+        metrics: {
+          likes: m.like_count ?? 0,
+          retweets: m.retweet_count ?? 0,
+          replies: m.reply_count ?? 0,
+          quotes: m.quote_count ?? 0,
+        },
+        url: author?.username ? `https://x.com/${author.username}/status/${t.id}` : undefined,
+      };
+    });
+  }
+}

--- a/examples/twitter-habitat/tools/bookmarks/TOOL.md
+++ b/examples/twitter-habitat/tools/bookmarks/TOOL.md
@@ -1,0 +1,10 @@
+---
+name: bookmarks
+description: "Show the authenticated user's most recent X (Twitter) bookmarks (the tweets they have saved). Use this whenever the user asks about their bookmarks or saved tweets. Returns each bookmark's text, author, engagement metrics, and a permalink. Reads the user's own X OAuth token from Habitat secrets — no argument needed beyond an optional limit."
+---
+
+Show the authenticated user's most recent X (Twitter) bookmarks.
+
+Private data, read through the user's own official X OAuth token (managed by the
+X token store, which refreshes and rotates it automatically). Optional `limit`
+controls how many bookmarks to return (default 20, max 100).

--- a/examples/twitter-habitat/tools/bookmarks/handler.ts
+++ b/examples/twitter-habitat/tools/bookmarks/handler.ts
@@ -1,0 +1,59 @@
+/**
+ * `bookmarks` Agent tool — factory pattern.
+ *
+ * Loaded from this habitat work directory's tools/ folder by Habitat.create(),
+ * which passes the Habitat in as the factory context. The tool pulls the X OAuth
+ * credentials from Habitat secrets (never env-baked globals) via the token store,
+ * then calls the X read client. It stays thin: no HTTP, no auth, no SQL.
+ *
+ * The factory builds one XTokenStore for the tool's lifetime so the access-token
+ * cache + single-flight refresh are shared across calls.
+ */
+
+import { tool } from 'ai';
+import { z } from 'zod';
+import { XTokenStore, habitatSecretStore } from '../../src/token-store.js';
+import { XReadClient } from '../../src/x-read-client.js';
+import { XAuthError } from '../../src/x-oauth.js';
+
+interface HabitatLike {
+  getSecret(name: string): string | undefined;
+  setSecret(name: string, value: string): Promise<void>;
+}
+
+export default (habitat: unknown) => {
+  const secrets = habitatSecretStore(habitat as HabitatLike);
+  const tokens = new XTokenStore({ secrets });
+  const client = new XReadClient(tokens);
+
+  return tool({
+    description:
+      "Show the authenticated user's most recent X (Twitter) bookmarks (saved tweets). " +
+      'Use when the user asks about their bookmarks or saved tweets.',
+    inputSchema: z.object({
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('How many bookmarks to return (default 20, max 100).'),
+    }),
+    async execute({ limit }) {
+      try {
+        const bookmarks = await client.getBookmarks({ maxResults: limit ?? 20 });
+        return { count: bookmarks.length, bookmarks };
+      } catch (err) {
+        if (err instanceof XAuthError && err.kind === 'needs_reauth') {
+          return {
+            error:
+              'Twitter is not authenticated yet. Run the OAuth bootstrap and store the ' +
+              'TWITTER_REFRESH_TOKEN secret on this habitat.',
+            kind: err.kind,
+          };
+        }
+        return { error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  });
+};


### PR DESCRIPTION
Closes #151. Parent PRD: #149. Builds on #150 (X OAuth token store).

## What this builds

The tracer bullet through the whole private-data path: a Twitter Habitat **work directory** (config + persona + `tools/`) with one working read tool — **bookmarks** — wired `Habitat secrets → token store (#150) → X read client → factory-pattern Agent tool`, chattable over A2A.

### New code (all in `examples/twitter-habitat/`, the standalone example project)
- **`src/x-read-client.ts`** — `XReadClient` (`getMe` + `getBookmarks`) over X API v2. Takes the token store as a `TokenProvider`; on a `401` it force-refreshes and retries once (the reactive path from the OAuth research). Returns shaped bookmarks (text, author resolved from `includes`, engagement metrics, permalink). The tool embeds no HTTP/auth/SQL.
- **`tools/bookmarks/{TOOL.md,handler.ts}`** — the factory-pattern Agent tool. `(habitat) => tool(...)`: reads X creds from **Habitat secrets** (not env-baked globals), builds one `XTokenStore` (shared access-token cache + single-flight) and `XReadClient`, returns bookmarks. Graceful `needs_reauth` message when unauthenticated.
- **`config.json`** (agent card name `Twitter`, openrouter default, `toolsDir`) + **`STIMULUS.md`** persona.
- **`.gitignore`** for habitat runtime state (`secrets.json`, `sessions/`, `dist/`).

## Acceptance criteria — how to verify

**Automated (no token needed):**
```bash
# X read-client unit tests (mocked fetch + fake token provider) — 6 tests
cd examples/twitter-habitat && pnpm install && pnpm test:run   # 24 pass (incl. #150's 18)

# Work dir boots + bookmarks tool loads + graceful error path (run from repo root):
cat > verify.mjs <<'JS'
import { Habitat } from '@umwelten/habitat/index.js';
const h = await Habitat.create({ workDir: 'examples/twitter-habitat', skipOnboard: true });
const t = h.getTools()['bookmarks'];
console.log('loaded:', !!t);
console.log(await t.execute({ limit: 5 }, { toolCallId: 't', messages: [] }));
JS
dotenvx run -- npx tsx verify.mjs && rm verify.mjs
# → loaded: true
# → { error: 'Twitter is not authenticated yet. Run the OAuth bootstrap ...', kind: 'needs_reauth' }
```

- [x] **A Twitter Habitat work dir exists (config + persona + `tools/`) and boots with `habitat serve`** — `Habitat.create({ workDir: 'examples/twitter-habitat' })` boots; `habitat serve --work-dir examples/twitter-habitat` serves it.
- [x] **A `bookmarks` Agent tool reads the X token via the token store and returns the user's bookmarks** — `tools/bookmarks/handler.ts` → `XTokenStore` → `XReadClient.getBookmarks()` (`GET /2/users/:id/bookmarks`).
- [x] **The tool reads credentials from Habitat secrets (factory pattern), not env-baked globals** — handler is `(habitat) => tool(...)`, uses `habitatSecretStore(habitat)` → `getSecret`/`setSecret`. Verified the factory runs and the tool loads at boot.
- [ ] **`habitat chat` "show my bookmarks" returns real bookmark data, streamed** — **needs a bootstrapped token (operator step).** Once `TWITTER_*` secrets are set (see README "Run it as a habitat"):
  ```bash
  dotenvx run -- pnpm run cli habitat serve --work-dir examples/twitter-habitat --port 7430
  dotenvx run -- pnpm run cli habitat chat --url http://localhost:7430 --one-shot "show my bookmarks"
  ```
- [x] **`pnpm test:run` passes** — example suite 24/24; monorepo suite untouched (no `packages/` changes).

The only criterion I can't run here is the live fetch (no real X token in this environment); everything up to the X API boundary is verified, and the error path proves the full token-store→client→tool wiring.

## Notes
- The handler imports `ai`/`zod` + the `src/` modules and is loaded/run by the **monorepo** habitat runtime, so it's intentionally outside this example's standalone `tsc`/`vitest` build (which covers `src/` only). The deep modules it calls are unit-tested. (Same split the jeeves-bot work-dir tools use.)
- Per the PRD, the X read client is "exercised by the e2e deploy smoke rather than unit tests" — I added focused unit tests anyway since they're cheap and pin the shaping + 401-retry behavior.
- Default model is `openrouter/openai/gpt-4o-mini` (PRD flags Google broken on fresh installs); override with `--provider/--model`.
- **Next:** #152 (mentions + my-timeline) extends `XReadClient`; #153 (Neon feed reader) adds the public-data path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)