### PR TITLE
chore(twitter): leak-free OAuth bootstrap (--out-secrets) + ignore .env*

### DIFF
--- a/examples/twitter-habitat/.gitignore
+++ b/examples/twitter-habitat/.gitignore
@@ -2,3 +2,6 @@
 secrets.json
 sessions/
 dist/
+# Local credential files used to seed the OAuth bootstrap
+.env
+.env.*

--- a/examples/twitter-habitat/bootstrap-oauth.ts
+++ b/examples/twitter-habitat/bootstrap-oauth.ts
@@ -27,6 +27,8 @@
 
 import { createServer } from 'node:http';
 import { randomBytes } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import {
   buildAuthorizeUrl,
   createPkcePair,
@@ -100,18 +102,39 @@ async function main() {
   console.log('\nExchanging authorization code for tokens ...');
   const tokens = await exchangeCode(client, { code, redirectUri, verifier });
 
-  console.log('\n✅ Success. Store these as Habitat secrets:\n');
-  console.log(`   TWITTER_CLIENT_ID=${clientId}`);
-  console.log(`   TWITTER_CLIENT_SECRET=${clientSecret}`);
-  console.log(`   TWITTER_REFRESH_TOKEN=${tokens.refresh_token}\n`);
-  console.log('e.g.:');
-  console.log(
-    `   dotenvx run -- pnpm run cli habitat secrets set TWITTER_REFRESH_TOKEN '${tokens.refresh_token}'\n`,
-  );
+  const secretValues = {
+    TWITTER_CLIENT_ID: clientId,
+    TWITTER_CLIENT_SECRET: clientSecret,
+    TWITTER_REFRESH_TOKEN: tokens.refresh_token,
+  };
+
+  const outDir = arg('out-secrets');
+  if (outDir) {
+    // Write straight into the habitat's secrets.json (mode 0600) — never print the
+    // values. Merge with any existing secrets.
+    const path = join(outDir, 'secrets.json');
+    let existing: Record<string, string> = {};
+    try {
+      existing = JSON.parse(await readFile(path, 'utf-8'));
+    } catch {
+      /* no existing secrets file */
+    }
+    const merged = { ...existing, ...secretValues };
+    await writeFile(path, JSON.stringify(merged, null, 2) + '\n', { mode: 0o600 });
+    console.log(`\n✅ Wrote TWITTER_CLIENT_ID, TWITTER_CLIENT_SECRET, TWITTER_REFRESH_TOKEN to ${path}`);
+    console.log(`   (refresh token ${tokens.refresh_token.length} chars; values not printed).\n`);
+  } else {
+    console.log('\n✅ Success. Store these as Habitat secrets:\n');
+    console.log(`   TWITTER_CLIENT_ID=${clientId}`);
+    console.log(`   TWITTER_CLIENT_SECRET=${clientSecret}`);
+    console.log(`   TWITTER_REFRESH_TOKEN=${tokens.refresh_token}\n`);
+    console.log('   (Tip: pass --out-secrets <habitat-dir> to write these straight into');
+    console.log('   the habitat secrets.json instead of printing them.)\n');
+  }
   console.log(
     'Note: X rotates refresh tokens single-use. The habitat persists each rotated\n' +
-      'token back to its secrets.json (on a fly volume), so this bootstrap value is\n' +
-      'only the seed — do not reuse it once the habitat has refreshed at least once.\n',
+      'token back to its secrets.json, so this bootstrap value is only the seed —\n' +
+      'do not reuse it once the habitat has refreshed at least once.\n',
   );
 }
 


### PR DESCRIPTION
Small hardening to the Twitter habitat OAuth bootstrap, discovered while bringing the habitat up live and pulling real bookmarks.

## What changed
- **`bootstrap-oauth.ts`** — new `--out-secrets <habitat-dir>` flag: merges `TWITTER_CLIENT_ID/SECRET/REFRESH_TOKEN` straight into the habitat's `secrets.json` (mode 0600) and prints **only lengths**, never the values. The original print-to-stdout path stays for manual use but now nudges operators to the safer flag.
- **`.gitignore`** — ignore `.env` / `.env.*` in the example so the credential-seed file you feed the bootstrap (`dotenvx run -f examples/twitter-habitat/.env.bootstrap …`) can't be committed.

## Why
Running the bootstrap with secrets on the command line + stdout tee'd to a logfile leaks the client secret and refresh token into shell history, process args, and log files. `--out-secrets` keeps them out of all of those — credentials go env-file → `secrets.json` and nowhere else.

## Verified
Live end-to-end: `bootstrap --out-secrets` → `secrets.json` → `habitat serve` → `habitat chat "show my bookmarks"` returned real X bookmarks. Example standalone `tsc` build clean; `pnpm test:run` 24/24.

Follow-up to #150/#151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)