### PR TITLE
docs(examples): basic-agent + pi-coder reference habitats (isolated)

### DIFF
--- a/examples/basic-agent/.gitignore
+++ b/examples/basic-agent/.gitignore
@@ -1,0 +1,5 @@
+# Runtime state written by `habitat serve` — never commit it.
+secrets.json
+sessions/
+meta.json
+*.log

--- a/examples/basic-agent/README.md
+++ b/examples/basic-agent/README.md
@@ -1,0 +1,45 @@
+# basic-agent — a minimal habitat agent (default runtime)
+
+The smallest complete habitat: a persona, a model, and one custom tool. Chatting
+with it runs the **default Interaction runtime** (LLM + tools) — the standard
+conversational path.
+
+Self-contained: no machine-specific paths, no external state. Runtime files
+(`secrets.json`, `sessions/`) are gitignored.
+
+## Layout
+
+```
+basic-agent/
+  config.json              # name, provider/model, toolsDir
+  STIMULUS.md              # the persona
+  tools/coin_flip/
+    TOOL.md                # tool frontmatter (name + description)
+    handler.ts            # factory: (habitat) => Tool — reads secrets if needed
+```
+
+## Run it
+
+From the repo root (needs a provider key in `.env`; this example uses
+OpenRouter — change `defaultProvider`/`defaultModel` in `config.json` for
+another):
+
+```bash
+# Terminal 1 — serve the habitat over A2A
+dotenvx run -- pnpm run cli habitat serve --work-dir examples/basic-agent --port 7470 --host 127.0.0.1
+
+# Terminal 2 — chat with it (streaming A2A client)
+dotenvx run -- pnpm run cli habitat chat --url http://127.0.0.1:7470 --one-shot "Who are you?"
+dotenvx run -- pnpm run cli habitat chat --url http://127.0.0.1:7470 --one-shot "Flip a coin."
+```
+
+Expected: it introduces itself as Scout, and "Flip a coin" invokes the custom
+`coin_flip` tool.
+
+## The custom tool pattern
+
+`tools/<name>/` is auto-loaded by `Habitat.create` (`toolsDir` in config). Each
+tool is a `TOOL.md` (frontmatter) plus a `handler.ts` that default-exports a
+Vercel AI SDK `tool()`. Use the **factory form** `(habitat) => tool(...)` when
+the tool needs habitat context — e.g. `habitat.getSecret("SOME_TOKEN")`. This is
+exactly the shape the Twitter habitat's tools use.

--- a/examples/basic-agent/STIMULUS.md
+++ b/examples/basic-agent/STIMULUS.md
@@ -1,0 +1,4 @@
+You are Scout, a concise, friendly assistant.
+
+You have a `coin_flip` tool — use it when asked to flip a coin or make a 50/50
+decision. Keep replies short.

--- a/examples/basic-agent/config.json
+++ b/examples/basic-agent/config.json
@@ -1,0 +1,6 @@
+{
+  "name": "basic-agent",
+  "defaultProvider": "openrouter",
+  "defaultModel": "openai/gpt-4o-mini",
+  "toolsDir": "tools"
+}

--- a/examples/basic-agent/tools/coin_flip/TOOL.md
+++ b/examples/basic-agent/tools/coin_flip/TOOL.md
@@ -1,0 +1,6 @@
+---
+name: coin_flip
+description: "Flip a fair coin. Returns heads or tails."
+---
+
+Flip a fair coin and return the result.

--- a/examples/basic-agent/tools/coin_flip/handler.ts
+++ b/examples/basic-agent/tools/coin_flip/handler.ts
@@ -1,0 +1,19 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+/**
+ * Custom habitat tool, factory form.
+ *
+ * The habitat passes itself in as `context`, so a real tool can read secrets
+ * (`habitat.getSecret(...)`) or call other habitat APIs. This one is a trivial
+ * pure tool — it just shows the TOOL.md + handler.ts shape the loader expects.
+ */
+export default (_habitat: unknown) =>
+  tool({
+    description: "Flip a fair coin. Returns heads or tails.",
+    parameters: z.object({}),
+    execute: async () => {
+      const result = Math.random() < 0.5 ? "heads" : "tails";
+      return { result };
+    },
+  });

--- a/examples/pi-coder/.gitignore
+++ b/examples/pi-coder/.gitignore
@@ -1,0 +1,10 @@
+# Runtime state written by `habitat serve` — never commit it.
+secrets.json
+sessions/
+meta.json
+*.log
+
+# The pi agent edits ./project at runtime. Keep the baseline app.js committed,
+# but ignore anything pi generates there during a run.
+project/*
+!project/app.js

--- a/examples/pi-coder/README.md
+++ b/examples/pi-coder/README.md
@@ -1,0 +1,60 @@
+# pi-coder — a habitat agent on the pi coding runtime
+
+Same A2A surface as [`basic-agent`](../basic-agent/), but chatting with it
+dispatches your message to the **pi coding runtime** instead of the default
+LLM loop: it spawns `pi --mode json -p` against a code project and pi does real
+work (read / edit / write files), streaming progress back over A2A.
+
+This demonstrates the RuntimeRunner seam (#118/#122): the runtime is chosen
+per-channel in `routing.json`, not by changing any agent code.
+
+## Layout
+
+```
+pi-coder/
+  config.json              # a "coder" agent whose projectPath is ./project
+  routing.json             # binds the a2a channel to runtime: "pi"
+  STIMULUS.md              # coder persona (used by the default path)
+  project/app.js           # the sample project pi operates on
+```
+
+The binding that selects pi:
+
+```json
+// routing.json
+{ "platformDefaults": { "a2a": { "agentId": "coder", "runtime": "pi" } } }
+```
+
+## Prerequisites
+
+- `pi` on your `PATH` (the pi coding agent), configured with a working model.
+- A provider key in `.env`.
+
+## Run it
+
+`projectPath` is `./project`, resolved relative to the CLI's working directory.
+`run.sh` pins that directory to this example so the relative path resolves to
+this example's `project/` and pi only ever touches files in here — fully
+isolated. (For a real deployment, set `projectPath` to an absolute path.)
+
+```bash
+# Terminal 1 — serve (run.sh keeps the working dir pinned here)
+examples/pi-coder/run.sh --port 7471
+
+# Terminal 2 — chat (this triggers a real pi run against ./project)
+dotenvx run -- pnpm run cli habitat chat --url http://127.0.0.1:7471 --one-shot "Create a file greeting.txt containing: hello from pi"
+```
+
+Expected: pi runs against `project/`, creates `project/greeting.txt`, and the
+chat replies "Created greeting.txt." Files pi generates under `project/` are
+gitignored (only the baseline `app.js` is committed), and nothing is written
+outside this example dir.
+
+## How it differs from basic-agent
+
+| | basic-agent | pi-coder |
+|---|---|---|
+| Runtime | default Interaction (LLM + tools) | pi coding subprocess |
+| Good for | conversation, tool calls | editing a code project |
+| Selected by | (default) | `routing.json` → `runtime: "pi"` |
+| Native session | habitat transcript | linked pi session log (`nativeSessionRef`) |

--- a/examples/pi-coder/STIMULUS.md
+++ b/examples/pi-coder/STIMULUS.md
@@ -1,0 +1,1 @@
+You are a coding agent. Make the requested code changes in the project.

--- a/examples/pi-coder/config.json
+++ b/examples/pi-coder/config.json
@@ -1,0 +1,12 @@
+{
+  "name": "pi-coder",
+  "defaultProvider": "openrouter",
+  "defaultModel": "openai/gpt-4o-mini",
+  "agents": [
+    {
+      "id": "coder",
+      "name": "Coder",
+      "projectPath": "./project"
+    }
+  ]
+}

--- a/examples/pi-coder/project/app.js
+++ b/examples/pi-coder/project/app.js
@@ -1,0 +1,3 @@
+// Sample project the pi coding agent operates on.
+// Ask the pi-coder habitat to modify files here — pi runs against this directory.
+console.log("hello");

--- a/examples/pi-coder/routing.json
+++ b/examples/pi-coder/routing.json
@@ -1,0 +1,5 @@
+{
+  "platformDefaults": {
+    "a2a": { "agentId": "coder", "runtime": "pi" }
+  }
+}

--- a/examples/pi-coder/run.sh
+++ b/examples/pi-coder/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Serve the pi-coder habitat with the working directory pinned to THIS example
+# dir, so config.json's relative "./project" resolves to this example's
+# project/ (and pi only ever touches files in here — fully isolated).
+#
+# Pass extra flags through, e.g.:  ./run.sh --port 7471
+#
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$DIR/../.." && pwd)"
+cd "$DIR"
+exec dotenvx run -f "$REPO/.env" -- \
+  "$REPO/node_modules/.bin/tsx" "$REPO/packages/cli/src/entry.ts" \
+  habitat serve --work-dir . --host 127.0.0.1 "$@"


### PR DESCRIPTION
Two minimal, self-contained example habitats that demonstrate the habitat runtime seam — committed from the live demos we built while validating the agent-build path (ahead of the Twitter habitat work, PRD #149).

## What's here

**`examples/basic-agent/`** — the default Interaction runtime (LLM + tools).
- `config.json` + `STIMULUS.md` persona ("Scout") + a custom `tools/coin_flip/` tool (`TOOL.md` + factory-pattern `handler.ts`).
- Shows the `tools/<name>/` loader shape the Twitter habitat will use, including the `(habitat) => tool(...)` factory form that can read secrets.

**`examples/pi-coder/`** — the pi coding runtime.
- `routing.json` binds the A2A channel to pi: `{ "platformDefaults": { "a2a": { "agentId": "coder", "runtime": "pi" } } }`. Chatting it spawns `pi --mode json -p` against `./project` and pi edits files there.
- Demonstrates the RuntimeRunner seam (#118/#122): the runtime is chosen by config, not agent code.

## Isolation (the explicit ask)

- **No machine-specific paths committed** (no `/tmp`, no `/Users/...`) — verified by grep.
- **Runtime state gitignored**: `secrets.json`, `sessions/`, `meta.json`, and pi-generated files under `project/` (only the baseline `project/app.js` is tracked).
- **pi-coder ships `run.sh`** which pins the CLI working directory to the example so the relative `projectPath: "./project"` resolves to *this example's* `project/` — not the repo root. Verified live: pi wrote `examples/pi-coder/project/isolated.txt` and created **zero repo-root pollution**.

## Verify

```bash
# basic-agent
dotenvx run -- pnpm run cli habitat serve --work-dir examples/basic-agent --port 7470 --host 127.0.0.1 &
dotenvx run -- pnpm run cli habitat chat --url http://127.0.0.1:7470 --one-shot "Flip a coin."   # → invokes coin_flip

# pi-coder (run.sh keeps the working dir pinned)
examples/pi-coder/run.sh --port 7471 &
dotenvx run -- pnpm run cli habitat chat --url http://127.0.0.1:7471 --one-shot "Create greeting.txt with: hello from pi"
ls examples/pi-coder/project/   # greeting.txt appears here (gitignored); repo root stays clean
```

Both were run end-to-end during authoring (basic-agent answered + called its tool; pi-coder created files via a real pi subprocess). Docs-only / examples — no `src` changes, so no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)