### PR TITLE
feat(twitter): mentions + my-timeline read tools (#152)

### DIFF
--- a/examples/twitter-habitat/STIMULUS.md
+++ b/examples/twitter-habitat/STIMULUS.md
@@ -10,9 +10,15 @@ and tell the user what is needed; do not invent a result.
 - **Bookmarks** — show the tweets the user has saved. Use the `bookmarks` tool
   when they ask things like "show my bookmarks", "what did I save", or "my recent
   bookmarks". Pass a `limit` when they ask for a specific number.
+- **Mentions / replies** — show who replied to or mentioned the user. Use the
+  `mentions` tool when they ask "who replied to me?", "who mentioned me?", or
+  about recent replies aimed at them.
+- **Home timeline** — show what the people the user follows are posting. Use the
+  `my_timeline` tool when they ask "what's on my timeline?", "my home feed", or
+  "what are the people I follow saying?".
 
-(More capabilities — mentions/replies, specific people, list digests, and a
-combined "what's new" briefing — are coming in later slices.)
+(More capabilities — specific people, list digests, and a combined "what's new"
+briefing — are coming in later slices.)
 
 ## How to answer
 

--- a/examples/twitter-habitat/src/x-oauth.ts
+++ b/examples/twitter-habitat/src/x-oauth.ts
@@ -31,10 +31,14 @@ export const X_AUTHORIZE_URL = 'https://x.com/i/oauth2/authorize';
 /**
  * Scopes for the read-only Twitter habitat. `offline.access` is REQUIRED — without
  * it X issues no refresh token at all and the daemon cannot stay authenticated.
+ * `follows.read` is REQUIRED for the home timeline (`/timelines/reverse_chronological`),
+ * which is derived from the follow graph; a token minted without it 403s on that read
+ * (see reports/2026-06-16-x-api-v2-mentions-timeline.md).
  */
 export const X_DEFAULT_SCOPES = [
   'tweet.read',
   'users.read',
+  'follows.read',
   'bookmark.read',
   'like.read',
   'list.read',

--- a/examples/twitter-habitat/src/x-read-client.test.ts
+++ b/examples/twitter-habitat/src/x-read-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { XReadClient, type TokenProvider } from './x-read-client.js';
+import { XAuthError } from './x-oauth.js';
 
 // ── Test doubles ─────────────────────────────────────────────────────
 
@@ -144,5 +145,137 @@ describe('XReadClient.getBookmarks', () => {
 
     // /users/me fetched once; two bookmark fetches.
     expect(calls.filter((c) => c.url.includes('/users/me'))).toHaveLength(1);
+  });
+});
+
+// A generic timeline page (same envelope as bookmarks) reused by mentions + home timeline.
+function timelinePage() {
+  return {
+    json: {
+      data: [
+        {
+          id: 'm1',
+          text: '@me nice work',
+          created_at: '2026-06-10T00:00:00.000Z',
+          author_id: 'a1',
+          public_metrics: { like_count: 3, retweet_count: 1, reply_count: 0, quote_count: 0 },
+        },
+      ],
+      includes: { users: [{ id: 'a1', username: 'alice', name: 'Alice' }] },
+    },
+  };
+}
+
+describe('XReadClient.getMentions', () => {
+  it('returns shaped mentions with author, metrics, and permalink', async () => {
+    const tokens = fakeTokens();
+    const { fn } = fakeFetch([ME, timelinePage()]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    const mentions = await client.getMentions();
+
+    expect(mentions).toHaveLength(1);
+    expect(mentions[0]).toMatchObject({
+      id: 'm1',
+      text: '@me nice work',
+      author: { id: 'a1', username: 'alice', name: 'Alice' },
+      metrics: { likes: 3, retweets: 1, replies: 0, quotes: 0 },
+      url: 'https://x.com/alice/status/m1',
+    });
+  });
+
+  it("requests the authenticated user's mentions timeline", async () => {
+    const tokens = fakeTokens();
+    const { fn, calls } = fakeFetch([ME, timelinePage()]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    await client.getMentions();
+
+    expect(calls[0].url).toContain('/users/me');
+    expect(calls[1].url).toContain('/users/u-me/mentions');
+    expect(calls[1].url).toContain('expansions=author_id');
+  });
+
+  it('floors max_results at 5 (the X minimum for mentions) and caps at 100', async () => {
+    const tokens = fakeTokens();
+    const { fn, calls } = fakeFetch([ME, timelinePage(), timelinePage()]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    await client.getMentions({ maxResults: 2 });
+    expect(calls[1].url).toContain('max_results=5');
+
+    await client.getMentions({ maxResults: 9999 });
+    expect(calls[2].url).toContain('max_results=100');
+  });
+
+  it('force-refreshes the token and retries once on a 401', async () => {
+    const tokens = fakeTokens();
+    const { fn, calls } = fakeFetch([ME, { status: 401, body: 'unauthorized' }, timelinePage()]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    const mentions = await client.getMentions();
+
+    expect(mentions).toHaveLength(1);
+    expect(tokens.forceCount).toBe(1);
+    expect(calls[2].authorization).toBe('Bearer token-refreshed');
+  });
+});
+
+describe('XReadClient.getHomeTimeline', () => {
+  it('returns shaped timeline posts', async () => {
+    const tokens = fakeTokens();
+    const { fn } = fakeFetch([ME, timelinePage()]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    const posts = await client.getHomeTimeline();
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toMatchObject({ id: 'm1', author: { username: 'alice' } });
+  });
+
+  it("requests the authenticated user's reverse_chronological timeline by their own id", async () => {
+    const tokens = fakeTokens();
+    const { fn, calls } = fakeFetch([ME, timelinePage()]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    await client.getHomeTimeline({ maxResults: 50 });
+
+    expect(calls[1].url).toContain('/users/u-me/timelines/reverse_chronological');
+    expect(calls[1].url).toContain('max_results=50');
+  });
+});
+
+describe('XReadClient 403 handling', () => {
+  it('raises a non-retryable needs_reauth error on 403 (no force-refresh, no retry)', async () => {
+    const tokens = fakeTokens();
+    // me OK, then a 403 from the home timeline (missing follows.read / not enrolled).
+    const { fn, calls } = fakeFetch([
+      ME,
+      { status: 403, body: '{"detail":"client-not-enrolled"}' },
+    ]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    await expect(client.getHomeTimeline()).rejects.toMatchObject({
+      name: 'XAuthError',
+      kind: 'needs_reauth',
+      status: 403,
+    });
+    // A 403 must NOT trigger a forced refresh or a retry.
+    expect(tokens.forceCount).toBe(0);
+    expect(calls).toHaveLength(2); // me + the 403, nothing after
+  });
+
+  it('surfaces the X reason text in the error', async () => {
+    const tokens = fakeTokens();
+    // ME (cached after the first call), then a 403 for each of the two getMentions calls.
+    const { fn } = fakeFetch([
+      ME,
+      { status: 403, body: 'client-not-enrolled' },
+      { status: 403, body: 'client-not-enrolled' },
+    ]);
+    const client = new XReadClient(tokens, { fetchFn: fn });
+
+    await expect(client.getMentions()).rejects.toThrow(/client-not-enrolled/);
+    await expect(client.getMentions()).rejects.toBeInstanceOf(XAuthError);
   });
 });

--- a/examples/twitter-habitat/src/x-read-client.ts
+++ b/examples/twitter-habitat/src/x-read-client.ts
@@ -5,13 +5,25 @@
  * a {@link TokenProvider} (the {@link XTokenStore} from token-store.ts) and returns
  * shaped data; the Agent tools that consume it embed no HTTP or auth logic.
  *
- * This slice (#151) implements only the **bookmarks** call. Later slices (#152)
- * extend the same client with mentions + my-timeline.
+ * Endpoints (all GET, user-context bearer token):
+ *  - #151: bookmarks       — `/users/:id/bookmarks`
+ *  - #152: mentions        — `/users/:id/mentions`                       ("who replied to me")
+ *  - #152: home timeline   — `/users/:id/timelines/reverse_chronological` (people you follow)
  *
- * Reactive 401 handling, per reports/2026-06-16-x-oauth2-token-refresh.md: a 401
- * from a resource call means the access token went stale before its clock expiry,
- * so we force a refresh and retry the request exactly once.
+ * All three return the same envelope (`data[]` + `includes.users[]`), so the tweet
+ * shaping is shared in one private {@link XReadClient.shapeTweets} helper.
+ *
+ * Auth error handling, per reports/2026-06-16-x-oauth2-token-refresh.md and
+ * reports/2026-06-16-x-api-v2-mentions-timeline.md:
+ *  - **401**: the access token went stale before its clock expiry → force a refresh
+ *    and retry the request exactly once.
+ *  - **403**: a permission/tier problem (app not enrolled in a paid tier, or the
+ *    stored token is missing a scope such as `follows.read`, which the home timeline
+ *    requires). A refresh CANNOT fix this, so we do not retry — we raise a
+ *    non-retryable {@link XAuthError} of kind `needs_reauth` that the tool surfaces.
  */
+
+import { XAuthError } from './x-oauth.js';
 
 /** Anything that can hand out a valid X access token — implemented by XTokenStore. */
 export interface TokenProvider {
@@ -31,8 +43,11 @@ export interface XUser {
   name?: string;
 }
 
-/** A bookmarked tweet, shaped for the agent. */
-export interface XBookmark {
+/**
+ * A tweet shaped for the agent — a bookmark, a mention, or a home-timeline post.
+ * The shape is endpoint-agnostic; the three read methods all return it.
+ */
+export interface XTweet {
   id: string;
   text: string;
   createdAt?: string;
@@ -42,13 +57,23 @@ export interface XBookmark {
   url?: string;
 }
 
+/** @deprecated Use {@link XTweet}. Kept as an alias so existing imports keep working. */
+export type XBookmark = XTweet;
+
 export interface XReadClientOptions {
   fetchFn?: FetchLike;
   /** Override the API base (defaults to the canonical api.x.com host). */
   baseUrl?: string;
 }
 
+/** Options shared by every paged read. */
+export interface XReadOptions {
+  /** Page size. Clamped per-endpoint (mentions floors at 5; others at 1). */
+  maxResults?: number;
+}
+
 const DEFAULT_BASE_URL = 'https://api.x.com/2';
+const DEFAULT_PAGE = 20;
 
 // X public_metrics → our flat shape.
 interface PublicMetrics {
@@ -69,6 +94,18 @@ interface RawUser {
   username?: string;
   name?: string;
 }
+/** The common timeline envelope shared by bookmarks, mentions, and the home timeline. */
+interface TimelineBody {
+  data?: RawTweet[];
+  includes?: { users?: RawUser[] };
+}
+
+/** Tweet fields + expansions every read requests — identical across the three endpoints. */
+const TWEET_QUERY = {
+  'tweet.fields': 'created_at,public_metrics,author_id',
+  expansions: 'author_id',
+  'user.fields': 'username,name',
+} as const;
 
 export class XReadClient {
   private readonly tokens: TokenProvider;
@@ -82,7 +119,10 @@ export class XReadClient {
     this.baseUrl = opts.baseUrl ?? DEFAULT_BASE_URL;
   }
 
-  /** GET a JSON resource with a bearer token; on 401, force-refresh and retry once. */
+  /**
+   * GET a JSON resource with a bearer token. On 401, force-refresh the token and
+   * retry once. On 403, raise a non-retryable needs-reauth error (refresh can't help).
+   */
   private async authedGetJson(path: string): Promise<unknown> {
     const url = `${this.baseUrl}${path}`;
     let token = await this.tokens.getValidToken();
@@ -93,6 +133,20 @@ export class XReadClient {
       res = await this.fetchFn(url, { headers: { Authorization: `Bearer ${token}` } });
     }
 
+    // 403 is a permission/tier problem, not a stale token — refreshing won't fix it.
+    // Most common causes: the X app isn't enrolled in a paid tier, or the stored
+    // token lacks a required scope (the home timeline needs `follows.read`).
+    if (res.status === 403) {
+      const body = await res.text().catch(() => '');
+      throw new XAuthError(
+        `X denied this read (403). The X app likely needs Basic+/pay-per-use enrollment, ` +
+          `or the stored token is missing a required scope (the home timeline needs ` +
+          `follows.read) — re-run the OAuth bootstrap to re-authorize. ${body.slice(0, 200)}`,
+        'needs_reauth',
+        403,
+      );
+    }
+
     if (!res.ok) {
       const body = await res.text().catch(() => '');
       throw new Error(`X read failed: ${res.status} ${body.slice(0, 200)}`);
@@ -100,34 +154,8 @@ export class XReadClient {
     return res.json();
   }
 
-  /** The authenticated user (cached after the first call). */
-  async getMe(): Promise<XUser> {
-    if (this.me) return this.me;
-    const data = (await this.authedGetJson('/users/me?user.fields=username,name')) as {
-      data?: RawUser;
-    };
-    if (!data.data?.id) throw new Error('X /users/me returned no user');
-    this.me = { id: data.data.id, username: data.data.username, name: data.data.name };
-    return this.me;
-  }
-
-  /**
-   * The authenticated user's bookmarks, most-recent first, shaped for the agent.
-   * @param opts.maxResults 1–100 (X caps the page at 100); defaults to 20.
-   */
-  async getBookmarks(opts: { maxResults?: number } = {}): Promise<XBookmark[]> {
-    const max = Math.min(Math.max(opts.maxResults ?? 20, 1), 100);
-    const me = await this.getMe();
-    const params = new URLSearchParams({
-      max_results: String(max),
-      'tweet.fields': 'created_at,public_metrics,author_id',
-      expansions: 'author_id',
-      'user.fields': 'username,name',
-    });
-    const body = (await this.authedGetJson(
-      `/users/${me.id}/bookmarks?${params.toString()}`,
-    )) as { data?: RawTweet[]; includes?: { users?: RawUser[] } };
-
+  /** Map an X timeline envelope into our flat {@link XTweet}s (shared by all reads). */
+  private shapeTweets(body: TimelineBody): XTweet[] {
     const usersById = new Map<string, RawUser>();
     for (const u of body.includes?.users ?? []) usersById.set(u.id, u);
 
@@ -153,4 +181,68 @@ export class XReadClient {
       };
     });
   }
+
+  /** The authenticated user (cached after the first call). */
+  async getMe(): Promise<XUser> {
+    if (this.me) return this.me;
+    const data = (await this.authedGetJson('/users/me?user.fields=username,name')) as {
+      data?: RawUser;
+    };
+    if (!data.data?.id) throw new Error('X /users/me returned no user');
+    this.me = { id: data.data.id, username: data.data.username, name: data.data.name };
+    return this.me;
+  }
+
+  /**
+   * The authenticated user's bookmarks, most-recent first, shaped for the agent.
+   * @param opts.maxResults 1–100 (X caps the page at 100); defaults to 20.
+   */
+  async getBookmarks(opts: XReadOptions = {}): Promise<XTweet[]> {
+    const max = clamp(opts.maxResults ?? DEFAULT_PAGE, 1, 100);
+    const me = await this.getMe();
+    const params = new URLSearchParams({ max_results: String(max), ...TWEET_QUERY });
+    const body = (await this.authedGetJson(
+      `/users/${me.id}/bookmarks?${params.toString()}`,
+    )) as TimelineBody;
+    return this.shapeTweets(body);
+  }
+
+  /**
+   * Recent tweets that mention/reply to the authenticated user, most-recent first.
+   * Answers "who replied to me?". Reads `/users/:id/mentions`.
+   * @param opts.maxResults 5–100 (X requires a minimum of 5 here); defaults to 20.
+   */
+  async getMentions(opts: XReadOptions = {}): Promise<XTweet[]> {
+    // NOTE: mentions floors max_results at 5 (not 1) — a smaller value 400s.
+    const max = clamp(opts.maxResults ?? DEFAULT_PAGE, 5, 100);
+    const me = await this.getMe();
+    const params = new URLSearchParams({ max_results: String(max), ...TWEET_QUERY });
+    const body = (await this.authedGetJson(
+      `/users/${me.id}/mentions?${params.toString()}`,
+    )) as TimelineBody;
+    return this.shapeTweets(body);
+  }
+
+  /**
+   * The authenticated user's reverse-chronological home timeline — recent posts,
+   * retweets, and replies from the accounts they follow. Reads
+   * `/users/:id/timelines/reverse_chronological`, which is user-context only and
+   * REQUIRES `:id` to be the authenticated user's own id (always `me.id`) plus the
+   * `follows.read` scope.
+   * @param opts.maxResults 1–100; defaults to 20.
+   */
+  async getHomeTimeline(opts: XReadOptions = {}): Promise<XTweet[]> {
+    const max = clamp(opts.maxResults ?? DEFAULT_PAGE, 1, 100);
+    const me = await this.getMe(); // id MUST be the authenticated user — always me.id
+    const params = new URLSearchParams({ max_results: String(max), ...TWEET_QUERY });
+    const body = (await this.authedGetJson(
+      `/users/${me.id}/timelines/reverse_chronological?${params.toString()}`,
+    )) as TimelineBody;
+    return this.shapeTweets(body);
+  }
+}
+
+/** Clamp n into [lo, hi]. */
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(Math.max(n, lo), hi);
 }

--- a/examples/twitter-habitat/tools/mentions/TOOL.md
+++ b/examples/twitter-habitat/tools/mentions/TOOL.md
@@ -1,0 +1,11 @@
+---
+name: mentions
+description: "Show recent tweets that mention or reply to the authenticated user on X (Twitter). Use this whenever the user asks 'who replied to me?', 'who mentioned me?', or about their recent replies/mentions. Returns each mention's text, author, engagement metrics, and a permalink. Reads the user's own X OAuth token from Habitat secrets — no argument needed beyond an optional limit."
+---
+
+Show the tweets that recently mentioned or replied to the authenticated user.
+
+Private data, read through the user's own official X OAuth token (managed by the
+X token store, which refreshes and rotates it automatically). Optional `limit`
+controls how many mentions to return (default 20, min 5, max 100 — the X mentions
+endpoint requires a minimum page size of 5).

--- a/examples/twitter-habitat/tools/mentions/handler.ts
+++ b/examples/twitter-habitat/tools/mentions/handler.ts
@@ -1,0 +1,53 @@
+/**
+ * `mentions` Agent tool — factory pattern.
+ *
+ * "Who replied to / mentioned me?" Reads the authenticated user's X mentions
+ * timeline through their own OAuth token (managed by the X token store) and the
+ * X read client. Stays thin: no HTTP, no auth, no SQL.
+ *
+ * Mirrors the bookmarks tool — see tools/bookmarks/handler.ts for the shared
+ * factory shape and why credentials come from Habitat secrets, never env globals.
+ */
+
+import { tool } from 'ai';
+import { z } from 'zod';
+import { XTokenStore, habitatSecretStore } from '../../src/token-store.js';
+import { XReadClient } from '../../src/x-read-client.js';
+import { XAuthError } from '../../src/x-oauth.js';
+
+interface HabitatLike {
+  getSecret(name: string): string | undefined;
+  setSecret(name: string, value: string): Promise<void>;
+}
+
+export default (habitat: unknown) => {
+  const secrets = habitatSecretStore(habitat as HabitatLike);
+  const tokens = new XTokenStore({ secrets });
+  const client = new XReadClient(tokens);
+
+  return tool({
+    description:
+      'Show recent tweets that mention or reply to the authenticated user on X (Twitter). ' +
+      'Use when the user asks "who replied to me?", "who mentioned me?", or about replies/mentions.',
+    inputSchema: z.object({
+      limit: z
+        .number()
+        .int()
+        .min(5)
+        .max(100)
+        .optional()
+        .describe('How many mentions to return (default 20, min 5, max 100).'),
+    }),
+    async execute({ limit }) {
+      try {
+        const mentions = await client.getMentions({ maxResults: limit ?? 20 });
+        return { count: mentions.length, mentions };
+      } catch (err) {
+        if (err instanceof XAuthError && err.kind === 'needs_reauth') {
+          return { error: err.message, kind: err.kind };
+        }
+        return { error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  });
+};

--- a/examples/twitter-habitat/tools/my_timeline/TOOL.md
+++ b/examples/twitter-habitat/tools/my_timeline/TOOL.md
@@ -1,0 +1,14 @@
+---
+name: my_timeline
+description: "Show the authenticated user's X (Twitter) home timeline — the recent posts, retweets, and replies from the accounts they follow, newest first. Use this whenever the user asks 'what's on my timeline?', 'my home feed', or 'what are the people I follow posting?'. Returns each post's text, author, engagement metrics, and a permalink. Reads the user's own X OAuth token from Habitat secrets — no argument needed beyond an optional limit."
+---
+
+Show the authenticated user's reverse-chronological home timeline (people they follow).
+
+Private data, read through the user's own official X OAuth token (managed by the
+X token store, which refreshes and rotates it automatically). Optional `limit`
+controls how many posts to return (default 20, max 100).
+
+The home timeline requires the `follows.read` OAuth scope; if the stored token was
+authorized without it, this tool returns a "needs reauth" message and the operator
+must re-run the OAuth bootstrap to re-authorize.

--- a/examples/twitter-habitat/tools/my_timeline/handler.ts
+++ b/examples/twitter-habitat/tools/my_timeline/handler.ts
@@ -1,0 +1,56 @@
+/**
+ * `my_timeline` Agent tool — factory pattern.
+ *
+ * The authenticated user's reverse-chronological home timeline: recent posts,
+ * retweets, and replies from the accounts they follow. Reads through their own
+ * OAuth token (managed by the X token store) and the X read client. Stays thin:
+ * no HTTP, no auth, no SQL.
+ *
+ * Mirrors the bookmarks tool — see tools/bookmarks/handler.ts. NOTE: the home
+ * timeline needs the `follows.read` scope; a token minted without it returns 403,
+ * which surfaces here as a needs-reauth message telling the operator to re-bootstrap.
+ */
+
+import { tool } from 'ai';
+import { z } from 'zod';
+import { XTokenStore, habitatSecretStore } from '../../src/token-store.js';
+import { XReadClient } from '../../src/x-read-client.js';
+import { XAuthError } from '../../src/x-oauth.js';
+
+interface HabitatLike {
+  getSecret(name: string): string | undefined;
+  setSecret(name: string, value: string): Promise<void>;
+}
+
+export default (habitat: unknown) => {
+  const secrets = habitatSecretStore(habitat as HabitatLike);
+  const tokens = new XTokenStore({ secrets });
+  const client = new XReadClient(tokens);
+
+  return tool({
+    description:
+      "Show the authenticated user's X (Twitter) home timeline — recent posts, retweets, " +
+      'and replies from the accounts they follow, newest first. Use when the user asks ' +
+      '"what\'s on my timeline?", "my home feed", or "what are the people I follow posting?".',
+    inputSchema: z.object({
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('How many timeline posts to return (default 20, max 100).'),
+    }),
+    async execute({ limit }) {
+      try {
+        const posts = await client.getHomeTimeline({ maxResults: limit ?? 20 });
+        return { count: posts.length, posts };
+      } catch (err) {
+        if (err instanceof XAuthError && err.kind === 'needs_reauth') {
+          return { error: err.message, kind: err.kind };
+        }
+        return { error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  });
+};

--- a/reports/2026-06-16-x-api-v2-mentions-timeline.md
+++ b/reports/2026-06-16-x-api-v2-mentions-timeline.md
@@ -1,0 +1,234 @@
+# X API v2 READ endpoints: User Mentions + Reverse-Chronological Home Timeline
+
+**Date:** 2026-06-16
+**Scope:** Implementation notes for two new methods on the existing thin `XReadClient` (`examples/twitter-habitat/src/x-read-client.ts`), which already does `GET /2/users/:id/bookmarks` with an OAuth 2.0 user-context bearer token.
+**Audience:** the engineer adding `getMentions()` and `getHomeTimeline()`.
+
+---
+
+## TL;DR
+
+| | User mentions | Home timeline (reverse-chron) |
+|---|---|---|
+| Path | `GET /2/users/{id}/mentions` | `GET /2/users/{id}/timelines/reverse_chronological` |
+| `{id}` | the user you want mentions *of* (use **me**) | **MUST be the authenticated user's own id** |
+| `max_results` | min **5**, max **100**, default 10 | min **1**, max **100**, default 10 |
+| Auth | User-context **or** App-only | **User-context only** (no app-only/bearer-app) |
+| OAuth 2.0 scopes | `tweet.read`, `users.read` | `tweet.read`, `users.read`, **`follows.read`** |
+| Rate limit (per user) | 300 / 15 min | 180 / 15 min |
+| Rate limit (per app) | 450 / 15 min | — (per-user only) |
+| Lookback ceiling | 800 most-recent mentions | 3,200 posts, or last 7 days |
+
+Both share the **same** `public_metrics` field names as bookmarks, so the existing parsing maps over unchanged.
+
+**Canonical host: `https://api.x.com/2`.** The X-docs curl examples now use `api.x.com`; `api.twitter.com` still resolves (alias) but `api.x.com` is the current canonical host and is what your client already uses. Keep `DEFAULT_BASE_URL = 'https://api.x.com/2'`.
+
+---
+
+## 1. User Mentions Timeline — "who replied to / mentioned me"
+
+### Path
+```
+GET /2/users/{id}/mentions
+```
+`{id}` is the user whose mentions you want. For "mentions of me", pass the authenticated user's id (you already cache it via `getMe()`). Unlike the home timeline, `{id}` does **not** have to be the authenticated user — but for this client's purpose it always will be.
+
+### Query parameters
+| Param | Notes |
+|---|---|
+| `max_results` | Range **5–100** (note: min is 5, not 1, unlike bookmarks/timeline). Default 10. |
+| `tweet.fields` | Comma list. Use `created_at,public_metrics,author_id`. |
+| `expansions` | `author_id` to hydrate the mentioning user into `includes.users[]`. |
+| `user.fields` | `username,name` (matches bookmarks). |
+| `pagination_token` | Pass `meta.next_token` from the prior page to go forward. |
+| `start_time` / `end_time` | `YYYY-MM-DDTHH:mm:ssZ`. Window by time. |
+| `since_id` / `until_id` | Bound by tweet id. `since_id` **takes precedence over** `start_time`; `until_id` over `end_time`. `since_id` is the clean way to poll "new since last seen". |
+| `media.fields`, `poll.fields`, `place.fields` | Available; not needed for this client. |
+
+### Response shape
+```jsonc
+{
+  "data": [
+    {
+      "id": "1234567890",
+      "text": "@you nice work",
+      "created_at": "2026-06-16T12:00:00.000Z",
+      "author_id": "999",
+      "public_metrics": {
+        "like_count": 0, "retweet_count": 0,
+        "reply_count": 0, "quote_count": 0
+      }
+    }
+  ],
+  "includes": {
+    "users": [ { "id": "999", "username": "someone", "name": "Some One" } ]
+  },
+  "meta": {
+    "result_count": 1,
+    "newest_id": "...",
+    "oldest_id": "...",
+    "next_token": "...",
+    "previous_token": "..."
+  }
+}
+```
+Identical structural shape to bookmarks: `data[]` tweets, `includes.users[]` to join on `author_id`, `meta` for pagination. **Reuse the bookmarks parsing verbatim.**
+
+### Scopes (OAuth 2.0 user-context)
+- `tweet.read`
+- `users.read`
+
+(No `follows.read` — mentions are not follow-graph-scoped.)
+
+### Rate limits
+- Per user: **300 / 15 min**
+- Per app: **450 / 15 min**
+- Hard ceiling: only the **800 most recent** mentions are reachable via pagination.
+
+---
+
+## 2. Reverse-Chronological Home Timeline — the authenticated user's feed
+
+### Path
+```
+GET /2/users/{id}/timelines/reverse_chronological
+```
+
+### `{id}` MUST be the authenticated user — CONFIRMED
+This endpoint returns "the most recent Posts, Retweets and replies posted by **you and the accounts you follow**." It is **user-context only** (app-only / app-bearer auth is rejected), and the `{id}` must be the id of the authenticated (token-owning) user. Passing any other user's id is not a supported "read someone else's home feed" operation. In code: always pass `me.id` from `getMe()`; do not accept an arbitrary id from the caller.
+
+### Query parameters
+| Param | Notes |
+|---|---|
+| `max_results` | Range **1–100**, default 10. |
+| `tweet.fields` | `created_at,public_metrics,author_id`. |
+| `expansions` | `author_id`. |
+| `user.fields` | `username,name`. |
+| `pagination_token` | `meta.next_token` to page forward. |
+| `start_time` / `end_time` | Same `YYYY-MM-DDTHH:mm:ssZ` windowing. |
+| `since_id` / `until_id` | Same precedence rules as mentions. `since_id` is the poll-for-new primitive. |
+
+### Response shape
+Same envelope as mentions/bookmarks: `data[]`, `includes.users[]`, `meta`. The home feed mixes original posts, retweets and replies; if you later want to distinguish them, add `referenced_tweets` to `tweet.fields` (a retweet has a `referenced_tweets[].type === "retweeted"`). Not required for a first pass.
+
+> Caveat from the dev community: this endpoint's `public_metrics` are returned, but some *non-public* metric fields are not available on the timeline endpoint the way they are on `/2/users/:id/tweets`. `public_metrics` (the four counts you use) **are** present — no change for this client.
+
+### Scopes (OAuth 2.0 user-context)
+- `tweet.read`
+- `users.read`
+- **`follows.read`** ← required because the feed is derived from your follow graph. This is the one scope difference vs. bookmarks/mentions.
+
+Make sure the OAuth authorize step (`x-oauth.ts`) requests `follows.read` (and `offline.access` for refresh) or this call returns 403 even with a valid token. If the existing token was minted without `follows.read`, **the home-timeline call will 403 and the user must re-authorize** with the expanded scope set — a forced `forceRefresh` will NOT fix it (refresh cannot widen scope).
+
+### Rate limits
+- Per user: **180 / 15 min**
+- No per-app limit (the endpoint is inherently per-user).
+- Reachable history: last **3,200 posts** or **7 days**, whichever is hit first.
+
+---
+
+## Gotchas / Access-Tier
+
+1. **Host.** Use `https://api.x.com/2`. Already correct in the client. `api.twitter.com` is a legacy alias; don't switch to it.
+
+2. **`public_metrics` field names match bookmarks exactly.** `like_count`, `retweet_count`, `reply_count`, `quote_count`. Your existing `PublicMetrics` interface and flat-mapping (`likes/retweets/replies/quotes`) work unchanged for both new endpoints.
+
+3. **`max_results` minimum differs.** Bookmarks and home-timeline accept min 1; **mentions requires min 5**. If you clamp with the bookmarks helper `Math.min(Math.max(n,1),100)`, a caller asking for `maxResults: 2` on mentions will send `2` and get a 400. For mentions, clamp to **`Math.min(Math.max(n,5),100)`**.
+
+4. **Home timeline is user-context only and follow-scoped.** App-bearer tokens are rejected outright; needs `follows.read`. This is the most likely source of a "works for bookmarks, 403 for timeline" surprise. The fix is a scope change at authorize time, not a token refresh.
+
+5. **Access tier — the big one (2025–2026).** Both endpoints are **not on the Free tier** for general use. As of the 2025 tier model they require **Basic ($) or higher**; X's Free tier is write-mostly (post/delete + `/users/me`) and read endpoints like timelines/mentions are gated. **As of ~Feb 2026, X moved to a pay-per-use default model** replacing the old fixed tiers for new apps; the practical effect is the same — these reads consume paid quota / require an enrolled (project-attached, paid) app. If the habitat's X app is on Free/unenrolled, **both calls will fail with 403 `client-not-enrolled`** regardless of correct scopes. This is an account/billing problem, surface it as such, do not retry.
+
+6. **Monthly post-pull cap.** On Basic, pulled posts count against a monthly cap (e.g. the documented ~10k–15k/month Basic read cap historically). A high-`max_results` polling loop on the home timeline can exhaust it fast. Keep `max_results` modest and lean on `since_id` to avoid re-pulling.
+
+### Error responses — distinguishing "needs reauth" from "tier doesn't allow this"
+
+| Status | Meaning | Client action |
+|---|---|---|
+| **401 Unauthorized** | Token missing/expired/invalid. | This is the **reauth/refresh** signal. Your existing 401→`forceRefresh`→retry-once logic handles the "stale token" case. If it 401s *again after* a forced refresh, the token is truly dead → surface "needs re-login". |
+| **403 Forbidden, `client-not-enrolled`** (with `required_enrollment: "Appropriate Level of API Access"`) | App is not attached to a paid/enrolled project, or the tier doesn't include this endpoint. | **Tier/billing problem.** Do NOT refresh, do NOT retry. Surface "your X app needs Basic+ / pay-per-use enrollment." |
+| **403 Forbidden, missing scope** | Token valid but lacks `follows.read` (home timeline) or the needed scope. | **Re-authorize with wider scope.** A refresh will not help (refresh can't widen scope). Surface "re-connect X to grant the home-timeline permission." |
+| **400 Bad Request** | Bad param — most commonly `max_results` below the per-endpoint minimum (5 for mentions). | Fix the request; not auth-related. |
+| **429 Too Many Requests** | Rate limit hit. Honor `x-rate-limit-reset` header. | Back off; not auth-related. |
+
+**Key distinction for the client:** `401` ⇒ token problem (your refresh-and-retry path). `403` ⇒ permission/tier problem (refresh won't help — either re-authorize for scope, or fix enrollment/billing). The current client throws a generic `Error("X read failed: <status> ...")` for any non-OK; consider branching so `401` keeps the refresh path while `403` raises a distinct, non-retryable "needs reauth/enrollment" error that the agent surfaces to the user.
+
+---
+
+## TypeScript-shaped implementation notes
+
+The two new methods are near-clones of `getBookmarks()`. They differ only in path, the `max_results` clamp (mentions), and (for the type system) nothing — the response envelope and parsing are identical.
+
+### `getMentions()`
+```ts
+async getMentions(opts: { maxResults?: number; sinceId?: string; paginationToken?: string } = {}): Promise<XBookmark[]> {
+  const max = Math.min(Math.max(opts.maxResults ?? 20, 5), 100); // NOTE: min 5, not 1
+  const me = await this.getMe();
+  const params = new URLSearchParams({
+    max_results: String(max),
+    'tweet.fields': 'created_at,public_metrics,author_id',
+    expansions: 'author_id',
+    'user.fields': 'username,name',
+  });
+  if (opts.sinceId) params.set('since_id', opts.sinceId);
+  if (opts.paginationToken) params.set('pagination_token', opts.paginationToken);
+
+  const body = (await this.authedGetJson(
+    `/users/${me.id}/mentions?${params.toString()}`,
+  )) as { data?: RawTweet[]; includes?: { users?: RawUser[] } };
+
+  return this.shapeTweets(body); // factor the bookmarks map() into a shared private helper
+}
+```
+
+### `getHomeTimeline()`
+```ts
+async getHomeTimeline(opts: { maxResults?: number; sinceId?: string; paginationToken?: string } = {}): Promise<XBookmark[]> {
+  const max = Math.min(Math.max(opts.maxResults ?? 20, 1), 100);
+  const me = await this.getMe(); // id MUST be the authenticated user — always me.id
+  const params = new URLSearchParams({
+    max_results: String(max),
+    'tweet.fields': 'created_at,public_metrics,author_id',
+    expansions: 'author_id',
+    'user.fields': 'username,name',
+  });
+  if (opts.sinceId) params.set('since_id', opts.sinceId);
+  if (opts.paginationToken) params.set('pagination_token', opts.paginationToken);
+
+  const body = (await this.authedGetJson(
+    `/users/${me.id}/timelines/reverse_chronological?${params.toString()}`,
+  )) as { data?: RawTweet[]; includes?: { users?: RawUser[] } };
+
+  return this.shapeTweets(body);
+}
+```
+
+### Suggested refactor
+Extract the bookmarks `.map(...)` block into a private `shapeTweets(body): XBookmark[]` so all three methods share it. The `XBookmark` shape (id/text/createdAt/author/metrics/url) is already generic enough to represent a mention or a timeline post; either reuse it or rename to a neutral `XTweet` and alias `XBookmark = XTweet`.
+
+### Response parsing pulls (unchanged from bookmarks)
+- `body.data[]` → tweets.
+- Build `Map<author_id, user>` from `body.includes.users[]`.
+- Per tweet: `id`, `text`, `created_at`, `author_id` → joined user; `public_metrics.{like_count,retweet_count,reply_count,quote_count}` → flat `{likes,retweets,replies,quotes}` (default 0).
+- `url`: `https://x.com/${author.username}/status/${id}` when the handle is known.
+- For pagination/polling, also read `body.meta.next_token` and `body.meta.newest_id` (expose if you add looping later — not in scope for a first pass).
+
+### Scope reminder for `x-oauth.ts`
+Authorize scope set must include, at minimum: `tweet.read users.read follows.read offline.access`. The first two cover mentions; `follows.read` is mandatory for the home timeline; `offline.access` is what gives you the refresh token the client's 401-retry relies on. If the stored token predates `follows.read`, the home-timeline method 403s and the user must reconnect.
+
+---
+
+## Sources (official X developer docs + dev community)
+
+- User mentions timeline reference — https://docs.x.com/x-api/posts/user-mention-timeline-by-user-id
+- User mentions quickstart — https://docs.x.com/x-api/posts/timelines/quickstart/user-mention-quickstart
+- Reverse-chronological home timeline quickstart — https://docs.x.com/x-api/posts/timelines/quickstart/reverse-chron-quickstart
+- Timelines integration guide (auth requirements, lookback ceilings) — https://docs.x.com/x-api/posts/timelines/integrate
+- Timelines introduction — https://docs.x.com/x-api/posts/timelines/introduction
+- Data dictionary (Tweet / User / public_metrics fields) — https://docs.x.com/x-api/fundamentals/data-dictionary
+- Rate limits reference — https://docs.x.com/x-api/fundamentals/rate-limits
+- Reverse-chronological reference (legacy) — https://developer.x.com/en/docs/x-api/tweets/timelines/api-reference/get-users-id-reverse-chronological
+- Reverse-chron vs `/users/:id/tweets` (metrics caveat) — https://devcommunity.x.com/t/what-is-the-difference-between-2-users-id-timelines-reverse-chronological-and-2-users-id-tweets-and-why-cant-timeline-endpoint-return-non-public-metrics/192842
+- Reverse-chron home timeline & Basic-tier monthly cap — https://devcommunity.x.com/t/reverse-chronological-home-timeline-and-basic-tier-monthly-tweet-pull-cap/191136
+- 403 `client-not-enrolled` (tier/enrollment, not scope/auth) — https://devcommunity.x.com/t/403-forbidden-with-reason-client-not-enrolled/259555 and https://devcommunity.x.com/t/pay-per-use-apps-returning-403-on-all-v2-endpoints-client-not-enrolled/262449
+- HTTP 401 vs 403 semantics — https://en.wikipedia.org/wiki/HTTP_403


### PR DESCRIPTION
## What this builds

Issue #152 — the remaining private-account X reads for the Twitter habitat, both chattable through `habitat chat`. Extends the deep modules and `tools/` that landed in #150 (token store) and #151 (read client + bookmarks tool).

### Changes

- **`x-read-client.ts`**
  - `getMentions()` → `GET /2/users/:id/mentions` ("who replied to / mentioned me"). Clamps `max_results` to the **X-required 5–100** range (mentions floors at 5, unlike bookmarks).
  - `getHomeTimeline()` → `GET /2/users/:id/timelines/reverse_chronological` (people you follow). Always passes the **authenticated user's own id** (the endpoint is user-context-only and rejects any other id).
  - Refactored the bookmarks `.map()` into a shared private **`shapeTweets()`** helper — all three reads use it. `XBookmark` is now an alias of a neutral **`XTweet`**.
  - New **403 branch**: a 403 is a permission/tier problem (app not enrolled in a paid tier, or token missing a scope like `follows.read`) that a refresh can't fix — it raises a **non-retryable** `XAuthError(needs_reauth)` instead of force-refreshing. 401 keeps the existing refresh-and-retry-once path.
- **`x-oauth.ts`** — added **`follows.read`** to `X_DEFAULT_SCOPES` (the home timeline requires it; future bootstraps mint a token that can read it).
- **`tools/mentions/`** + **`tools/my_timeline/`** — factory-pattern Agent tools mirroring bookmarks; thin (no HTTP/auth/SQL), credentials from Habitat secrets via the token store. They surface a clear needs-reauth message on 403.
- **`STIMULUS.md`** — documents the two new capabilities.
- **`reports/2026-06-16-x-api-v2-mentions-timeline.md`** — endpoint research (paths, params, scopes, rate limits, the 401-vs-403 disambiguation).

No duplicated auth — both tools reuse the token store + read client.

## Acceptance criteria — how to verify

All commands run from the repo root.

> Real verification needs the X OAuth secrets on the habitat work dir (`TWITTER_CLIENT_ID/SECRET/REFRESH_TOKEN`), seeded by the #150 bootstrap. Without them, the tools return a clear "needs reauth" message instead of data — which is itself the correct error path.

### ☑ A `mentions` tool returns recent replies/mentions of the authenticated user
```bash
dotenvx run -- pnpm run cli habitat -w examples/twitter-habitat --skip-onboard \
  "Who replied to me or mentioned me recently? Show up to 5."
```
Expect a `[TOOL CALL] mentions` line and a list of real mentions with author + permalink. ✅ Verified live (returned 5 real mentions).

### ☑ A `my_timeline` tool returns the home timeline
```bash
dotenvx run -- pnpm run cli habitat -w examples/twitter-habitat --skip-onboard \
  "What's on my home timeline? Show 5 posts from people I follow."
```
Expect a `[TOOL CALL] my_timeline` line and recent posts from followed accounts. ✅ Verified live (returned 5 real posts).

### ☑ `habitat chat` "who replied to me?" returns real mention data, streamed
The one-shot above exercises the same path. For the interactive/streamed REPL:
```bash
dotenvx run -- pnpm run cli habitat -w examples/twitter-habitat --skip-onboard
# then type: who replied to me?
```

### ☑ Both reuse the token store + read client from earlier slices (no duplicated auth)
Both handlers build `new XTokenStore({ secrets })` + `new XReadClient(tokens)` — identical to the bookmarks tool. No new auth/HTTP code:
```bash
grep -n "XTokenStore\|XReadClient" examples/twitter-habitat/tools/*/handler.ts
```

### ☑ Verified against a running habitat; `pnpm test:run` passes
```bash
cd examples/twitter-habitat && dotenvx run -f ../../.env -- pnpm test:run
# 3 files, 32 tests passing
```
New read-client tests cover: shaped results, the **mentions min-5 clamp**, the **reverse_chronological path by me.id**, 401 refresh-and-retry, and **403 → non-retryable needs_reauth** (no force-refresh, no retry).

## Worth knowing / follow-ups

- **Access tier (2025–2026):** both endpoints are off X's Free tier — they need Basic+/pay-per-use enrollment. An unenrolled app gets `403 client-not-enrolled` on both regardless of scopes; the new 403 branch surfaces this as a needs-reauth/enrollment message rather than looping a refresh. (Details in the report.)
- **`follows.read` on existing tokens:** a refresh token minted before this change lacks `follows.read`, so the home timeline could 403 until re-bootstrapped. In practice the live token already covered it (timeline returned data). New bootstraps get the scope automatically.
- **Single-use refresh token:** verification cold-starts a refresh, which rotates the refresh token and persists it to `secrets.json` (working as designed for restarts) — keep the work dir on a persistent volume in deploy (#155).
- Unblocks **#154** (feed-assembly "what's new" briefing) together with #153.

Closes #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
