### PR TITLE
feat(twitter): Neon-backed feed reader + people/list/digest tools (#153)

### DIFF
--- a/examples/twitter-habitat/README.md
+++ b/examples/twitter-habitat/README.md
@@ -18,8 +18,10 @@ pnpm test:run       # token-store + OAuth + X read-client unit tests (vitest)
 > Status: scaffolding in progress. #150 shipped the **auth foundation** (X OAuth
 > token store + bootstrap). #151 adds the **habitat work dir** (config + persona +
 > `tools/`) and the first read tool — **bookmarks** — chattable end-to-end. The
-> X read client is introduced here (bookmarks call only). Mentions/timeline,
-> the Neon feed reader, the full persona, and the fly deploy land in #152–#155.
+> X read client is introduced here (bookmarks call only). #153 adds the **Neon
+> feed reader** (public-data path) + the `person_recent`, `list_digest`, and
+> `high_engagement` tools. The full persona ("what's new" briefing) and the fly
+> deploy land in #154–#155.
 
 ## Run it as a habitat
 
@@ -57,7 +59,44 @@ streamed back through the chat.
   OAuth user token. Handled by the **X token store** (`src/token-store.ts` →
   `XTokenStore`).
 - **Public** (specific people, lists, digests, engagement) → read from the Neon
-  database that the existing `twitter-feed` pipeline syncs. (Issue #153.)
+  database that the existing `twitter-feed` pipeline syncs. Handled by the
+  **feed reader** (`src/feed-reader.ts` → `FeedReader`), surfaced as the
+  `person_recent`, `list_digest`, and `high_engagement` tools (#153).
+
+## Public-data tools (the feed reader)
+
+The `FeedReader` (`src/feed-reader.ts`) is a read-only consumer of the Neon tables
+the `twitter-feed` pipeline populates (`cached_tweets`, `twitter_profiles`,
+`twitter_lists` / `twitter_list_members`, `summaries`). It holds **no**
+twitterapi.io key — only a `DATABASE_URL` (a habitat secret, or the `DATABASE_URL`
+env var; fly.io injects secrets as env). Engagement is ranked by
+`likes + retweets + replies`, matching the pipeline's own formula. The Postgres
+boundary is an injected `QueryExecutor`, bound to `@neondatabase/serverless`'s
+`neon()` in production and a seeded in-memory fake in unit tests. Schema +
+driver notes: `reports/2026-06-16-twitter-feed-neon-schema.md` and
+`reports/2026-06-16-neon-serverless-readonly-driver.md`.
+
+Three factory-pattern Agent tools (`tools/{person-recent,list-digest,high-engagement}/`):
+
+| Tool             | Question it answers                    | Key args                    |
+| ---------------- | -------------------------------------- | --------------------------- |
+| `person_recent`  | "what's @person been posting?"         | `handle`, `limit`, `sinceHours` |
+| `list_digest`    | "digest the AI engineers list"         | `list` (slug or name), `limit`, `sinceHours` |
+| `high_engagement`| "what's notable right now?"            | `limit`, `sinceHours`       |
+
+```bash
+# Seed the Neon connection string (the public-data path needs only this secret):
+dotenvx run -- pnpm run cli habitat secrets set DATABASE_URL 'postgres://...' --work-dir examples/twitter-habitat
+
+# Serve, then chat:
+dotenvx run -- pnpm run cli habitat serve --work-dir examples/twitter-habitat --port 7430
+dotenvx run -- pnpm run cli habitat chat --url http://localhost:7430 --one-shot "what's @karpathy been posting?"
+dotenvx run -- pnpm run cli habitat chat --url http://localhost:7430 --one-shot "digest the ai-engineers list"
+dotenvx run -- pnpm run cli habitat chat --url http://localhost:7430 --one-shot "what are the top tweets right now?"
+```
+
+An unknown list degrades to a friendly "I don't track that list"; a missing
+`DATABASE_URL` returns an actionable config error rather than crashing.
 
 ## Authentication: the X token store
 

--- a/examples/twitter-habitat/package.json
+++ b/examples/twitter-habitat/package.json
@@ -10,6 +10,9 @@
     "build": "tsc",
     "bootstrap": "tsx bootstrap-oauth.ts"
   },
+  "dependencies": {
+    "@neondatabase/serverless": "^1.1.0"
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "tsx": "^4.19.0",

--- a/examples/twitter-habitat/pnpm-lock.yaml
+++ b/examples/twitter-habitat/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@neondatabase/serverless':
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -196,6 +200,10 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@neondatabase/serverless@1.1.0':
+    resolution: {integrity: sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==}
+    engines: {node: '>=19.0.0'}
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
@@ -731,6 +739,8 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@neondatabase/serverless@1.1.0': {}
 
   '@oxc-project/types@0.133.0': {}
 

--- a/examples/twitter-habitat/src/feed-reader.test.ts
+++ b/examples/twitter-habitat/src/feed-reader.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FeedReader,
+  normalizeHandle,
+  type QueryExecutor,
+} from './feed-reader.js';
+
+/**
+ * Tests drive the FeedReader through a seeded in-memory fixture that interprets
+ * the small, known set of queries the module issues — so ranking, windowing,
+ * handle-normalization and graceful degradation are asserted as *observable
+ * behavior* (the returned data), never as internal call sequencing. No real
+ * database. This is the "seeded fixture" path from issue #153's acceptance
+ * criteria.
+ */
+
+interface TweetFixture {
+  tweet_id: string;
+  username: string;
+  display_name?: string;
+  text: string;
+  created_at: string;
+  like_count: number;
+  retweet_count: number;
+  reply_count: number;
+  quote_count?: number;
+  impression_count?: number;
+}
+interface ListFixture {
+  id: string; // surrogate twitter_lists.id
+  file_id: string;
+  name: string;
+  description?: string;
+  member_count?: number;
+}
+interface MemberFixture {
+  list_id: string; // surrogate id
+  username: string;
+  display_name?: string;
+}
+interface SummaryFixture {
+  list_id: string; // file_id slug
+  report_date: string;
+  report_type: string;
+  title?: string;
+  content: string;
+  generated_at?: string;
+}
+interface Dataset {
+  tweets?: TweetFixture[];
+  profiles?: Record<string, string>;
+  lists?: ListFixture[];
+  members?: MemberFixture[];
+  summaries?: SummaryFixture[];
+}
+
+function eng(t: TweetFixture): number {
+  return t.like_count + t.retweet_count + t.reply_count;
+}
+
+/** A fixture executor: a tiny interpreter for the queries FeedReader emits. */
+function makeFixtureExecutor(ds: Dataset) {
+  const calls: Array<{ text: string; params: unknown[] }> = [];
+  const nowMs = Date.now();
+
+  const exec: QueryExecutor = async <T>(text: string, params: unknown[] = []) => {
+    calls.push({ text, params });
+
+    if (/FROM cached_tweets/.test(text)) {
+      let rows = (ds.tweets ?? []).slice();
+
+      if (/t\.username = \$1/.test(text)) {
+        rows = rows.filter((t) => t.username === params[0]);
+      }
+      const anyMatch = /t\.username = ANY\(\$(\d+)\)/.exec(text);
+      if (anyMatch) {
+        const arr = params[Number(anyMatch[1]) - 1] as string[];
+        rows = rows.filter((t) => arr.includes(t.username));
+      }
+      const sinceMatch = /make_interval\(hours => \$(\d+)\)/.exec(text);
+      if (sinceMatch) {
+        const hours = params[Number(sinceMatch[1]) - 1] as number;
+        const cutoff = nowMs - hours * 3600 * 1000;
+        rows = rows.filter((t) => new Date(t.created_at).getTime() >= cutoff);
+      }
+
+      if (/ORDER BY \(t\.like_count/.test(text)) {
+        rows.sort(
+          (a, b) =>
+            eng(b) - eng(a) ||
+            new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+        );
+      } else {
+        rows.sort(
+          (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+        );
+      }
+
+      const limit = params[params.length - 1] as number;
+      return rows.slice(0, limit).map((t) => ({
+        ...t,
+        display_name: t.display_name ?? ds.profiles?.[t.username],
+      })) as T[];
+    }
+
+    if (/FROM twitter_lists/.test(text)) {
+      const key = String(params[0]);
+      const l = (ds.lists ?? []).find(
+        (x) => x.file_id === key || x.name.toLowerCase() === key.toLowerCase(),
+      );
+      return (l ? [l] : []) as T[];
+    }
+
+    if (/FROM twitter_list_members/.test(text)) {
+      const sid = params[0];
+      return (ds.members ?? [])
+        .filter((m) => m.list_id === sid)
+        .map((m) => ({ username: m.username, display_name: m.display_name }))
+        .sort((a, b) => (a.username < b.username ? -1 : 1)) as T[];
+    }
+
+    if (/FROM summaries/.test(text)) {
+      const fid = params[0];
+      const ss = (ds.summaries ?? [])
+        .filter((s) => s.list_id === fid)
+        .sort((a, b) => (b.report_date > a.report_date ? 1 : -1));
+      return ss.slice(0, 1) as T[];
+    }
+
+    return [] as T[];
+  };
+
+  return { exec, calls };
+}
+
+function hoursAgo(h: number): string {
+  return new Date(Date.now() - h * 3600 * 1000).toISOString();
+}
+
+describe('normalizeHandle', () => {
+  it('strips @, lowercases, trims', () => {
+    expect(normalizeHandle('@Elon')).toBe('elon');
+    expect(normalizeHandle('  @@PaulG  ')).toBe('paulg');
+    expect(normalizeHandle('karpathy')).toBe('karpathy');
+  });
+});
+
+describe('FeedReader.getPersonRecent', () => {
+  const ds: Dataset = {
+    profiles: { karpathy: 'Andrej Karpathy' },
+    tweets: [
+      { tweet_id: '1', username: 'karpathy', text: 'old', created_at: hoursAgo(100), like_count: 5, retweet_count: 1, reply_count: 0 },
+      { tweet_id: '2', username: 'karpathy', text: 'new', created_at: hoursAgo(1), like_count: 9, retweet_count: 2, reply_count: 3, quote_count: 4, impression_count: 1000 },
+      { tweet_id: '3', username: 'someoneelse', text: 'noise', created_at: hoursAgo(2), like_count: 99, retweet_count: 99, reply_count: 99 },
+    ],
+  };
+
+  it('normalizes the handle and returns only that person, most-recent first', async () => {
+    const { exec, calls } = makeFixtureExecutor(ds);
+    const reader = new FeedReader(exec);
+    const out = await reader.getPersonRecent('@Karpathy');
+
+    expect(out.map((t) => t.id)).toEqual(['2', '1']); // recency order, no 'someoneelse'
+    expect(calls[0].params[0]).toBe('karpathy'); // normalized handle hit the boundary
+  });
+
+  it('maps engagement, metrics, display name, url and ISO timestamp', async () => {
+    const { exec } = makeFixtureExecutor(ds);
+    const reader = new FeedReader(exec);
+    const [newest] = await reader.getPersonRecent('karpathy');
+
+    expect(newest.id).toBe('2');
+    expect(newest.displayName).toBe('Andrej Karpathy');
+    expect(newest.engagement).toMatchObject({ likes: 9, retweets: 2, replies: 3, quotes: 4, impressions: 1000, total: 14 });
+    expect(newest.url).toBe('https://x.com/karpathy/status/2');
+    expect(newest.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('clamps the limit (max 100) and passes it as the last param', async () => {
+    const { exec, calls } = makeFixtureExecutor(ds);
+    const reader = new FeedReader(exec);
+    await reader.getPersonRecent('karpathy', { limit: 9999 });
+    expect(calls[0].params[calls[0].params.length - 1]).toBe(100);
+
+    const { exec: exec2, calls: calls2 } = makeFixtureExecutor(ds);
+    await new FeedReader(exec2).getPersonRecent('karpathy', { limit: 0 });
+    expect(calls2[0].params[calls2[0].params.length - 1]).toBe(1);
+
+    const { exec: exec3, calls: calls3 } = makeFixtureExecutor(ds);
+    await new FeedReader(exec3).getPersonRecent('karpathy');
+    expect(calls3[0].params[calls3[0].params.length - 1]).toBe(20); // default
+  });
+
+  it('applies a sinceHours window when set', async () => {
+    const { exec } = makeFixtureExecutor(ds);
+    const reader = new FeedReader(exec);
+    const out = await reader.getPersonRecent('karpathy', { sinceHours: 24 });
+    expect(out.map((t) => t.id)).toEqual(['2']); // tweet '1' (100h old) excluded
+  });
+});
+
+describe('FeedReader.getHighEngagement', () => {
+  const ds: Dataset = {
+    tweets: [
+      { tweet_id: 'a', username: 'u1', text: 'meh', created_at: hoursAgo(2), like_count: 1, retweet_count: 1, reply_count: 1 }, // 3
+      { tweet_id: 'b', username: 'u2', text: 'viral', created_at: hoursAgo(3), like_count: 100, retweet_count: 50, reply_count: 10 }, // 160
+      { tweet_id: 'c', username: 'u1', text: 'mid', created_at: hoursAgo(1), like_count: 20, retweet_count: 5, reply_count: 5 }, // 30
+      { tweet_id: 'd', username: 'u3', text: 'stale-viral', created_at: hoursAgo(200), like_count: 999, retweet_count: 999, reply_count: 999 },
+    ],
+  };
+
+  it('ranks by engagement (likes + retweets + replies) descending', async () => {
+    const { exec } = makeFixtureExecutor(ds);
+    const out = await new FeedReader(exec).getHighEngagement({ limit: 3, sinceHours: 48 });
+    expect(out.map((t) => t.id)).toEqual(['b', 'c', 'a']); // 160, 30, 3 — stale 'd' excluded by window
+    expect(out[0].engagement.total).toBe(160);
+  });
+
+  it('scopes to the given usernames when set', async () => {
+    const { exec } = makeFixtureExecutor(ds);
+    const out = await new FeedReader(exec).getHighEngagement({ usernames: ['@U1'], sinceHours: 48 });
+    expect(out.map((t) => t.id)).toEqual(['c', 'a']); // only u1, ranked by engagement
+  });
+
+  it('delegates engagement ordering to SQL', async () => {
+    const { exec, calls } = makeFixtureExecutor(ds);
+    await new FeedReader(exec).getHighEngagement({});
+    expect(calls[0].text).toMatch(/ORDER BY \(t\.like_count \+ t\.retweet_count \+ t\.reply_count\) DESC/);
+  });
+});
+
+describe('FeedReader.getListDigest', () => {
+  const ds: Dataset = {
+    lists: [{ id: 'srg-1', file_id: 'ai-engineers', name: 'AI Engineers', member_count: 2 }],
+    members: [
+      { list_id: 'srg-1', username: 'karpathy', display_name: 'Andrej Karpathy' },
+      { list_id: 'srg-1', username: 'swyx' },
+    ],
+    summaries: [
+      { list_id: 'ai-engineers', report_date: '2026-06-15', report_type: 'evening', title: 'Older', content: '# Older' },
+      { list_id: 'ai-engineers', report_date: '2026-06-16', report_type: 'morning', title: 'Latest digest', content: '# Latest digest\n...' },
+    ],
+    tweets: [
+      { tweet_id: 't1', username: 'karpathy', text: 'big', created_at: hoursAgo(1), like_count: 100, retweet_count: 10, reply_count: 5 }, // 115
+      { tweet_id: 't2', username: 'swyx', text: 'small', created_at: hoursAgo(2), like_count: 3, retweet_count: 0, reply_count: 0 }, // 3
+      { tweet_id: 't3', username: 'outsider', text: 'not in list', created_at: hoursAgo(1), like_count: 9999, retweet_count: 0, reply_count: 0 },
+    ],
+  };
+
+  it('assembles list, members, latest summary, and member top-tweets ranked by engagement', async () => {
+    const { exec } = makeFixtureExecutor(ds);
+    const digest = await new FeedReader(exec).getListDigest('ai-engineers');
+
+    expect(digest.found).toBe(true);
+    expect(digest.list?.name).toBe('AI Engineers');
+    expect(digest.members.map((m) => m.username)).toEqual(['karpathy', 'swyx']);
+    expect(digest.summary?.title).toBe('Latest digest'); // most-recent report_date wins
+    expect(digest.topTweets.map((t) => t.id)).toEqual(['t1', 't2']); // member tweets only, ranked; 'outsider' excluded
+  });
+
+  it('resolves a list by name (case-insensitive)', async () => {
+    const { exec } = makeFixtureExecutor(ds);
+    const digest = await new FeedReader(exec).getListDigest('ai engineers');
+    expect(digest.found).toBe(true);
+    expect(digest.list?.fileId).toBe('ai-engineers');
+  });
+
+  it('degrades gracefully for an unknown list — no member/summary/tweet queries issued', async () => {
+    const { exec, calls } = makeFixtureExecutor(ds);
+    const digest = await new FeedReader(exec).getListDigest('does-not-exist');
+
+    expect(digest).toEqual({ found: false, members: [], topTweets: [] });
+    // Only the list-resolution query ran; we never touched members/summaries/tweets.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].text).toMatch(/FROM twitter_lists/);
+  });
+});

--- a/examples/twitter-habitat/src/feed-reader.ts
+++ b/examples/twitter-habitat/src/feed-reader.ts
@@ -1,0 +1,359 @@
+/**
+ * Feed reader — the deep module behind the Twitter habitat's **public-data path**
+ * (issue #153). Read-only consumer of the Neon tables the external `twitter-feed`
+ * sync pipeline populates; the habitat holds no twitterapi.io key, only a
+ * `DATABASE_URL`.
+ *
+ * It answers the three public-data questions, ranked by engagement where it makes
+ * sense, and embeds the SQL here so the Agent tools that consume it stay thin:
+ *
+ *  - person recent   — "what's <person> been posting?"  (getPersonRecent)
+ *  - high engagement — most notable tweets, optionally windowed / list-scoped (getHighEngagement)
+ *  - list digest     — a tracked list's members + their top tweets + latest summary (getListDigest)
+ *
+ * The Postgres boundary is injected as a thin {@link QueryExecutor}
+ * (`(text, params) => rows`) so the module is fully unit-testable with an
+ * in-memory fake — no real database in tests. In production it is bound to
+ * `@neondatabase/serverless`'s `neon()` HTTP query path (see {@link neonExecutor}),
+ * matching the repo's existing NeonStore.
+ *
+ * Schema ground-truth + design notes:
+ *   reports/2026-06-16-twitter-feed-neon-schema.md
+ *   reports/2026-06-16-neon-serverless-readonly-driver.md
+ *
+ * Engagement formula matches the upstream pipeline
+ * (twitter-feed/src/tweets.ts#calculateEngagement) exactly:
+ *   engagement = like_count + retweet_count + reply_count
+ * so the habitat's ranking agrees with the pipeline's own reports. Quotes,
+ * bookmarks and impressions are surfaced but NOT counted toward the rank.
+ */
+
+/**
+ * Minimal parameterized-query boundary. Implemented over `neon()` in production
+ * (see {@link neonExecutor}) and by an in-memory fake in tests. Always called
+ * with `$1`-style placeholders + a params array — never string-concatenated SQL.
+ */
+export type QueryExecutor = <T = Record<string, unknown>>(
+  text: string,
+  params?: unknown[],
+) => Promise<T[]>;
+
+/** Engagement breakdown for a tweet. `total` is the ranked metric (likes+RTs+replies). */
+export interface Engagement {
+  likes: number;
+  retweets: number;
+  replies: number;
+  quotes: number;
+  impressions: number;
+  /** likes + retweets + replies — the value the feed ranks by. */
+  total: number;
+}
+
+/** A tweet from the public feed (cached_tweets ⨝ twitter_profiles), shaped for the agent. */
+export interface FeedTweet {
+  id: string;
+  username: string;
+  /** Display name from twitter_profiles, when known. */
+  displayName?: string;
+  text: string;
+  /** ISO-8601 timestamp. */
+  createdAt?: string;
+  engagement: Engagement;
+  url: string;
+}
+
+/** A tracked list (twitter_lists), addressed by its file_id slug or name. */
+export interface FeedList {
+  /** The file_id slug, e.g. "ai-engineers". */
+  fileId: string;
+  name: string;
+  description?: string;
+  memberCount?: number;
+}
+
+/** A list member (twitter_list_members). */
+export interface FeedListMember {
+  username: string;
+  displayName?: string;
+}
+
+/** A pre-generated list summary (summaries), markdown content. */
+export interface FeedSummary {
+  reportDate: string;
+  reportType: string;
+  title?: string;
+  content: string;
+  generatedAt?: string;
+}
+
+/** Result of a list digest. Degrades gracefully: unknown list → found=false, empty arrays. */
+export interface ListDigest {
+  found: boolean;
+  list?: FeedList;
+  members: FeedListMember[];
+  topTweets: FeedTweet[];
+  /** Latest summary for the list, if the pipeline has generated one. */
+  summary?: FeedSummary;
+}
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+function clampLimit(limit: number | undefined): number {
+  return Math.min(Math.max(Math.trunc(limit ?? DEFAULT_LIMIT), 1), MAX_LIMIT);
+}
+
+/** Normalize a handle to how it is stored in the DB: no leading '@', lowercased, trimmed. */
+export function normalizeHandle(handle: string): string {
+  return handle.trim().replace(/^@+/, '').toLowerCase();
+}
+
+function num(v: unknown): number {
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : 0;
+  }
+  return 0;
+}
+
+function str(v: unknown): string | undefined {
+  if (v == null) return undefined;
+  return String(v);
+}
+
+/** Postgres timestamptz comes back as a Date (pg type parser) or a string; normalize to ISO. */
+function toIso(v: unknown): string | undefined {
+  if (v == null) return undefined;
+  if (v instanceof Date) return v.toISOString();
+  return String(v);
+}
+
+/** Shape of a cached_tweets row joined with twitter_profiles.display_name. */
+interface TweetRow {
+  tweet_id: unknown;
+  username: unknown;
+  display_name?: unknown;
+  text: unknown;
+  created_at?: unknown;
+  like_count?: unknown;
+  retweet_count?: unknown;
+  reply_count?: unknown;
+  quote_count?: unknown;
+  impression_count?: unknown;
+}
+
+function mapTweet(row: TweetRow): FeedTweet {
+  const likes = num(row.like_count);
+  const retweets = num(row.retweet_count);
+  const replies = num(row.reply_count);
+  const username = String(row.username);
+  const id = String(row.tweet_id);
+  return {
+    id,
+    username,
+    displayName: str(row.display_name),
+    text: String(row.text ?? ''),
+    createdAt: toIso(row.created_at),
+    engagement: {
+      likes,
+      retweets,
+      replies,
+      quotes: num(row.quote_count),
+      impressions: num(row.impression_count),
+      total: likes + retweets + replies,
+    },
+    url: `https://x.com/${username}/status/${id}`,
+  };
+}
+
+// Selected columns shared by every tweet query (cached_tweets t ⨝ twitter_profiles p).
+const TWEET_COLUMNS = `
+  t.tweet_id, t.username, t.text, t.created_at,
+  t.like_count, t.retweet_count, t.reply_count, t.quote_count, t.impression_count,
+  p.display_name`;
+const TWEET_FROM = `
+  FROM cached_tweets t
+  LEFT JOIN twitter_profiles p ON p.username = t.username`;
+// Engagement rank expression — must match twitter-feed/src/tweets.ts#calculateEngagement.
+const ENGAGEMENT_EXPR = `(t.like_count + t.retweet_count + t.reply_count)`;
+
+export class FeedReader {
+  constructor(private readonly exec: QueryExecutor) {}
+
+  /**
+   * A person's recent tweets, most-recent first.
+   * @param handle  the @handle (with or without '@', any case).
+   * @param opts.limit       1–100 (default 20).
+   * @param opts.sinceHours  only tweets newer than this many hours, when set.
+   */
+  async getPersonRecent(
+    handle: string,
+    opts: { limit?: number; sinceHours?: number } = {},
+  ): Promise<FeedTweet[]> {
+    const username = normalizeHandle(handle);
+    const limit = clampLimit(opts.limit);
+    const params: unknown[] = [username];
+    let where = `WHERE t.username = $1`;
+    if (opts.sinceHours && opts.sinceHours > 0) {
+      params.push(opts.sinceHours);
+      where += ` AND t.created_at >= now() - make_interval(hours => $${params.length})`;
+    }
+    params.push(limit);
+    const sql = `SELECT ${TWEET_COLUMNS} ${TWEET_FROM}
+      ${where}
+      ORDER BY t.created_at DESC
+      LIMIT $${params.length}`;
+    const rows = await this.exec<TweetRow>(sql, params);
+    return rows.map(mapTweet);
+  }
+
+  /**
+   * The most notable tweets ranked by engagement (likes + retweets + replies).
+   * @param opts.limit       1–100 (default 20).
+   * @param opts.sinceHours  restrict to a recent window, when set.
+   * @param opts.usernames   restrict to these handles (e.g. a list's members), when set.
+   */
+  async getHighEngagement(
+    opts: { limit?: number; sinceHours?: number; usernames?: string[] } = {},
+  ): Promise<FeedTweet[]> {
+    const limit = clampLimit(opts.limit);
+    const params: unknown[] = [];
+    const clauses: string[] = [];
+
+    if (opts.usernames && opts.usernames.length > 0) {
+      const handles = opts.usernames.map(normalizeHandle);
+      params.push(handles);
+      clauses.push(`t.username = ANY($${params.length})`);
+    }
+    if (opts.sinceHours && opts.sinceHours > 0) {
+      params.push(opts.sinceHours);
+      clauses.push(`t.created_at >= now() - make_interval(hours => $${params.length})`);
+    }
+    const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
+    params.push(limit);
+    const sql = `SELECT ${TWEET_COLUMNS} ${TWEET_FROM}
+      ${where}
+      ORDER BY ${ENGAGEMENT_EXPR} DESC, t.created_at DESC
+      LIMIT $${params.length}`;
+    const rows = await this.exec<TweetRow>(sql, params);
+    return rows.map(mapTweet);
+  }
+
+  /** Resolve a list by its file_id slug or (case-insensitive) name. */
+  async getList(identifier: string): Promise<{ list: FeedList; surrogateId: string } | null> {
+    const key = identifier.trim();
+    const rows = await this.exec<{
+      id: unknown;
+      file_id: unknown;
+      name: unknown;
+      description?: unknown;
+      member_count?: unknown;
+    }>(
+      `SELECT id, file_id, name, description, member_count
+       FROM twitter_lists
+       WHERE file_id = $1 OR lower(name) = lower($1)
+       LIMIT 1`,
+      [key],
+    );
+    if (rows.length === 0) return null;
+    const r = rows[0];
+    return {
+      surrogateId: String(r.id),
+      list: {
+        fileId: String(r.file_id),
+        name: String(r.name ?? r.file_id),
+        description: str(r.description),
+        memberCount: r.member_count == null ? undefined : num(r.member_count),
+      },
+    };
+  }
+
+  /** A list's members. `surrogateId` is twitter_lists.id (NOT the file_id slug). */
+  async getListMembers(surrogateId: string): Promise<FeedListMember[]> {
+    const rows = await this.exec<{ username: unknown; display_name?: unknown }>(
+      `SELECT username, display_name
+       FROM twitter_list_members
+       WHERE list_id = $1
+       ORDER BY username ASC`,
+      [surrogateId],
+    );
+    return rows.map((r) => ({ username: String(r.username), displayName: str(r.display_name) }));
+  }
+
+  /** The latest pre-generated summary for a list, by file_id slug. */
+  async getLatestSummary(fileId: string): Promise<FeedSummary | undefined> {
+    const rows = await this.exec<{
+      report_date: unknown;
+      report_type: unknown;
+      title?: unknown;
+      content: unknown;
+      generated_at?: unknown;
+    }>(
+      `SELECT report_date, report_type, title, content, generated_at
+       FROM summaries
+       WHERE list_id = $1
+       ORDER BY report_date DESC, generated_at DESC
+       LIMIT 1`,
+      [fileId],
+    );
+    if (rows.length === 0) return undefined;
+    const r = rows[0];
+    return {
+      reportDate: String(r.report_date),
+      reportType: String(r.report_type),
+      title: str(r.title),
+      content: String(r.content ?? ''),
+      generatedAt: toIso(r.generated_at),
+    };
+  }
+
+  /**
+   * A tracked list's digest: the list, its members, their top tweets by engagement,
+   * and the latest pre-generated summary when one exists.
+   *
+   * Degrades gracefully — an unknown list returns `{ found: false, members: [],
+   * topTweets: [] }` rather than throwing, so the agent can say "I don't track
+   * that list" instead of erroring.
+   *
+   * @param identifier  the list file_id slug (e.g. "ai-engineers") or its name.
+   * @param opts.limit       top-N tweets to return (default 20).
+   * @param opts.sinceHours  window for the top tweets (default 48h).
+   */
+  async getListDigest(
+    identifier: string,
+    opts: { limit?: number; sinceHours?: number } = {},
+  ): Promise<ListDigest> {
+    const resolved = await this.getList(identifier);
+    if (!resolved) {
+      return { found: false, members: [], topTweets: [] };
+    }
+    const { list, surrogateId } = resolved;
+    const members = await this.getListMembers(surrogateId);
+    const summary = await this.getLatestSummary(list.fileId);
+
+    let topTweets: FeedTweet[] = [];
+    if (members.length > 0) {
+      topTweets = await this.getHighEngagement({
+        limit: opts.limit,
+        sinceHours: opts.sinceHours ?? 48,
+        usernames: members.map((m) => m.username),
+      });
+    }
+    return { found: true, list, members, topTweets, summary };
+  }
+}
+
+/**
+ * Bind a {@link QueryExecutor} to `@neondatabase/serverless`'s `neon()` HTTP query
+ * path. One handle per process is fine (it is a stateless fetch closure). Imported
+ * lazily so unit tests — which inject a fake executor — never load the driver.
+ */
+export async function neonExecutor(databaseUrl: string): Promise<QueryExecutor> {
+  const { neon } = await import('@neondatabase/serverless');
+  const sql = neon(databaseUrl);
+  // sql.query(text, params) already has the (text, params) => rows shape; cast past
+  // the caller-chosen generic T (the rows are validated/shaped by FeedReader).
+  const exec = (text: string, params?: unknown[]) => sql.query(text, params ?? []);
+  return exec as unknown as QueryExecutor;
+}

--- a/examples/twitter-habitat/src/feed-tool-support.ts
+++ b/examples/twitter-habitat/src/feed-tool-support.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared wiring for the public-data Agent tools (person-recent, list-digest,
+ * high-engagement). Keeps the tool handlers thin: they call into here for the
+ * one thing they all need — a {@link FeedReader} bound to the habitat's Neon
+ * `DATABASE_URL` — and embed no SQL or connection logic themselves.
+ *
+ * `DATABASE_URL` is read from Habitat secrets first, then `process.env`
+ * (fly.io injects secrets as env vars). It is the ONLY credential this path
+ * needs — no twitterapi.io key, no X OAuth token.
+ */
+
+import { FeedReader, neonExecutor } from './feed-reader.js';
+
+/** Secret/env name holding the Neon connection string the feed reader queries. */
+export const DATABASE_URL_SECRET = 'DATABASE_URL';
+
+/** Subset of the Habitat secret API these tools need. */
+export interface HabitatSecretReader {
+  getSecret(name: string): string | undefined;
+}
+
+/** Thrown when no DATABASE_URL is configured — the operator must set it. */
+export class MissingDatabaseUrlError extends Error {
+  constructor() {
+    super(
+      `No ${DATABASE_URL_SECRET} configured. Set the ${DATABASE_URL_SECRET} habitat ` +
+        `secret (or env var) to the Neon database the twitter-feed pipeline syncs.`,
+    );
+    this.name = 'MissingDatabaseUrlError';
+  }
+}
+
+/** Resolve the Neon connection string: Habitat secret first, then env. */
+export function resolveDatabaseUrl(habitat: HabitatSecretReader): string | undefined {
+  return habitat.getSecret(DATABASE_URL_SECRET) ?? process.env[DATABASE_URL_SECRET];
+}
+
+/**
+ * Build a getter that lazily constructs one {@link FeedReader} on first use and
+ * reuses it thereafter (the underlying `neon()` handle is a cheap stateless fetch
+ * closure). A missing DATABASE_URL is not cached, so setting the secret and
+ * retrying works without restarting the habitat.
+ */
+export function lazyFeedReader(habitat: HabitatSecretReader): () => Promise<FeedReader> {
+  let cached: FeedReader | undefined;
+  return async () => {
+    if (cached) return cached;
+    const url = resolveDatabaseUrl(habitat);
+    if (!url) throw new MissingDatabaseUrlError();
+    const exec = await neonExecutor(url);
+    cached = new FeedReader(exec);
+    return cached;
+  };
+}
+
+/** Map an error to a tool result, with a friendly message for the missing-DB case. */
+export function toErrorResult(err: unknown): { error: string; kind?: string } {
+  if (err instanceof MissingDatabaseUrlError) {
+    return { error: err.message, kind: 'config' };
+  }
+  return { error: err instanceof Error ? err.message : String(err) };
+}

--- a/examples/twitter-habitat/tools/high-engagement/TOOL.md
+++ b/examples/twitter-habitat/tools/high-engagement/TOOL.md
@@ -1,0 +1,11 @@
+---
+name: high_engagement
+description: "Show the most notable tweets across the tracked public feed, ranked by engagement (likes + retweets + replies). Use when the user asks what's notable, popular, or trending among tracked people, or for \"the top tweets right now\". Public data, read-only, no X login required. Optional limit and sinceHours (defaults to the last 24 hours); returns each tweet's text, author, engagement metrics, and a permalink."
+---
+
+Show the most notable tweets, ranked by engagement.
+
+Engagement is `likes + retweets + replies` — the same formula the `twitter-feed`
+pipeline uses, so the ranking matches its reports. Public data from Neon
+(`DATABASE_URL` only). Optional `limit` (default 20, max 100) and `sinceHours`
+(look-back window, default 24).

--- a/examples/twitter-habitat/tools/high-engagement/handler.ts
+++ b/examples/twitter-habitat/tools/high-engagement/handler.ts
@@ -1,0 +1,52 @@
+/**
+ * `high_engagement` Agent tool — factory pattern (public-data path, #153).
+ *
+ * The most notable tweets across the tracked public feed, ranked by engagement
+ * (likes + retweets + replies). Thin: delegates ranking to the FeedReader / SQL.
+ */
+
+import { tool } from 'ai';
+import { z } from 'zod';
+import { lazyFeedReader, toErrorResult, type HabitatSecretReader } from '../../src/feed-tool-support.js';
+
+/** Default window for "what's notable" so all-time blockbusters don't dominate. */
+const DEFAULT_SINCE_HOURS = 24;
+
+export default (habitat: unknown) => {
+  const getReader = lazyFeedReader(habitat as HabitatSecretReader);
+
+  return tool({
+    description:
+      'Show the most notable tweets across the tracked public feed, ranked by ' +
+      'engagement (likes + retweets + replies). Use when the user asks what is ' +
+      'notable / popular / trending among tracked people, or "what are the top ' +
+      'tweets right now". Public data, read-only. Defaults to the last 24 hours.',
+    inputSchema: z.object({
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('How many tweets to return (default 20, max 100).'),
+      sinceHours: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe('Look-back window in hours (default 24).'),
+    }),
+    async execute({ limit, sinceHours }) {
+      try {
+        const reader = await getReader();
+        const tweets = await reader.getHighEngagement({
+          limit,
+          sinceHours: sinceHours ?? DEFAULT_SINCE_HOURS,
+        });
+        return { count: tweets.length, sinceHours: sinceHours ?? DEFAULT_SINCE_HOURS, tweets };
+      } catch (err) {
+        return toErrorResult(err);
+      }
+    },
+  });
+};

--- a/examples/twitter-habitat/tools/list-digest/TOOL.md
+++ b/examples/twitter-habitat/tools/list-digest/TOOL.md
@@ -1,0 +1,13 @@
+---
+name: list_digest
+description: "Digest a tracked X list (e.g. \"ai-engineers\" / \"AI Engineers\"): its members, their high-signal recent tweets ranked by engagement, and the latest pre-generated summary when one exists. Use when the user asks to digest or summarize a list, or \"what's the AI engineers list up to?\". Public data, read-only, no X login required. Takes a list slug or name plus optional limit / sinceHours. Unknown lists return found=false instead of erroring."
+---
+
+Digest a tracked list.
+
+Resolves the list by its `file_id` slug (e.g. `ai-engineers`) or display name,
+then returns its members, their top recent tweets ranked by engagement
+(`likes + retweets + replies`), and the latest summary the `twitter-feed`
+pipeline generated, if any. Public data from Neon (`DATABASE_URL` only). Optional
+`limit` (top tweets, default 20) and `sinceHours` (window, default 48). An
+unknown list degrades gracefully to `found: false`.

--- a/examples/twitter-habitat/tools/list-digest/handler.ts
+++ b/examples/twitter-habitat/tools/list-digest/handler.ts
@@ -1,0 +1,65 @@
+/**
+ * `list_digest` Agent tool — factory pattern (public-data path, #153).
+ *
+ * Digest a tracked list: its members, their top tweets by engagement, and the
+ * latest pre-generated summary. Degrades gracefully for an unknown list so the
+ * agent can say "I don't track that list" instead of erroring.
+ */
+
+import { tool } from 'ai';
+import { z } from 'zod';
+import { lazyFeedReader, toErrorResult, type HabitatSecretReader } from '../../src/feed-tool-support.js';
+
+export default (habitat: unknown) => {
+  const getReader = lazyFeedReader(habitat as HabitatSecretReader);
+
+  return tool({
+    description:
+      'Digest a tracked list (e.g. "ai-engineers", "AI Engineers"): its high-signal ' +
+      'recent tweets ranked by engagement, plus the latest pre-generated summary ' +
+      'when one exists. Use when the user asks to digest/summarize a list or "what\'s ' +
+      'the AI engineers list up to?". Public data, read-only. Unknown lists return ' +
+      'found=false rather than an error.',
+    inputSchema: z.object({
+      list: z
+        .string()
+        .min(1)
+        .describe('The list to digest — its slug (e.g. "ai-engineers") or display name.'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('How many top tweets to include (default 20, max 100).'),
+      sinceHours: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe('Look-back window for the top tweets in hours (default 48).'),
+    }),
+    async execute({ list, limit, sinceHours }) {
+      try {
+        const reader = await getReader();
+        const digest = await reader.getListDigest(list, { limit, sinceHours });
+        if (!digest.found) {
+          return {
+            found: false,
+            message: `No tracked list matches "${list}". Ask for the tracked lists or try its slug.`,
+          };
+        }
+        return {
+          found: true,
+          list: digest.list,
+          memberCount: digest.members.length,
+          members: digest.members,
+          summary: digest.summary ?? null,
+          topTweets: digest.topTweets,
+        };
+      } catch (err) {
+        return toErrorResult(err);
+      }
+    },
+  });
+};

--- a/examples/twitter-habitat/tools/person-recent/TOOL.md
+++ b/examples/twitter-habitat/tools/person-recent/TOOL.md
@@ -1,0 +1,11 @@
+---
+name: person_recent
+description: "Show a specific person's recent tweets from the tracked public feed (the twitter-feed Neon store). Use whenever the user asks what someone has been posting or saying — e.g. \"what's @karpathy been up to?\" or \"show me swyx's latest tweets\". Public data, read-only, no X login required. Takes a handle (with or without @) and an optional limit / sinceHours; returns each tweet's text, author, engagement metrics, and a permalink."
+---
+
+Show a specific person's recent tweets, most-recent first.
+
+Public data, read from the Neon database the `twitter-feed` pipeline syncs (no
+twitterapi.io key, no X OAuth — only `DATABASE_URL`). `handle` is the X @handle
+(with or without the leading `@`). Optional `limit` (default 20, max 100) and
+`sinceHours` (restrict to a recent window).

--- a/examples/twitter-habitat/tools/person-recent/handler.ts
+++ b/examples/twitter-habitat/tools/person-recent/handler.ts
@@ -1,0 +1,51 @@
+/**
+ * `person_recent` Agent tool — factory pattern (public-data path, #153).
+ *
+ * "What's <person> been posting?" — reads a tracked person's recent tweets from
+ * the Neon store the twitter-feed pipeline syncs. Thin: pulls DATABASE_URL from
+ * the habitat, delegates to the FeedReader, embeds no SQL.
+ */
+
+import { tool } from 'ai';
+import { z } from 'zod';
+import { lazyFeedReader, toErrorResult, type HabitatSecretReader } from '../../src/feed-tool-support.js';
+
+export default (habitat: unknown) => {
+  const getReader = lazyFeedReader(habitat as HabitatSecretReader);
+
+  return tool({
+    description:
+      "Show a specific person's recent tweets from the tracked public feed (the " +
+      'twitter-feed Neon store). Use when the user asks what someone has been ' +
+      'posting or saying, e.g. "what\'s @karpathy been up to?". Public data — no ' +
+      "X login needed. Returns each tweet's text, engagement, and a permalink.",
+    inputSchema: z.object({
+      handle: z
+        .string()
+        .min(1)
+        .describe('The X @handle to look up (with or without the leading @).'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe('How many recent tweets to return (default 20, max 100).'),
+      sinceHours: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe('Only tweets newer than this many hours, when set.'),
+    }),
+    async execute({ handle, limit, sinceHours }) {
+      try {
+        const reader = await getReader();
+        const tweets = await reader.getPersonRecent(handle, { limit, sinceHours });
+        return { handle, count: tweets.length, tweets };
+      } catch (err) {
+        return toErrorResult(err);
+      }
+    },
+  });
+};

--- a/reports/2026-06-16-neon-serverless-readonly-driver.md
+++ b/reports/2026-06-16-neon-serverless-readonly-driver.md
@@ -1,0 +1,64 @@
+# Read-Only Querying of Neon (Serverless Postgres) with `@neondatabase/serverless`
+
+Research report (web-researcher subagent, 2026-06-16). Practical guidance for the
+Twitter habitat feed-reader (issue #153): a long-lived fly.io container running
+many small, parameterized, read-only `SELECT`s against Neon.
+
+## 1. HTTP `neon()` vs `Pool`
+Use **`neon()` (HTTP)**. Each query is a single stateless HTTPS fetch — no
+connection pool, no cold-start handshake, no leaked connections. Connection
+caching is always on since 0.9.0. `Pool`/WebSocket is only needed for interactive
+transactions / sessions / `LISTEN`-`NOTIFY`, none of which a read-only feed reader
+needs. Create one `const sql = neon(DATABASE_URL)` at module load and reuse it.
+
+## 2. Parameterized queries
+Two safe forms:
+- Tagged template: `` sql`SELECT * FROM posts WHERE id = ${id}` `` (interpolations
+  become `$1`-placeholders, never concatenated).
+- `sql.query(text, params)` — `sql.query('... WHERE id = $1', [id])`. Added in
+  v1.0.0. **This is the executor seam.**
+
+`sql('string', [params])` (plain-function call with a string) was removed in 1.0.0
+as injection-prone — it throws now. `sql.unsafe(str)` is only for trusted
+identifiers (table/column names), never user input.
+
+## 3. Read-only safety
+Enforce outside the app: use a Postgres role granted only `SELECT`, and/or point
+`DATABASE_URL` at a Neon **read replica** (rejects writes with SQLSTATE 25006).
+Avoid `neondb_owner` (bypasses RLS). `sql.transaction([...], { readOnly: true })`
+is a per-call extra but only applies to the transaction helper.
+
+## 4. Error handling
+HTTP path throws **`NeonDbError`** (exported). Branch on `.code` (Postgres
+SQLSTATE — `42P01` undefined table, `25006` write-in-read-only) vs `.sourceError`
+(connectivity, e.g. `fetch failed` TypeError → transient/retryable). Set a timeout
+via `fetchOptions: { signal: AbortSignal.timeout(ms) }`.
+
+## 5. Testability — inject a thin executor
+```ts
+export type QueryExecutor = <T = Record<string, unknown>>(
+  text: string, params?: unknown[]
+) => Promise<T[]>;
+
+// prod:
+const sql = neon(process.env.DATABASE_URL!);
+const exec: QueryExecutor = (text, params) => sql.query(text, params);
+
+// test: a fake that asserts on (text, params) and returns canned rows
+```
+Prefer the `(text, params)` seam over mocking the tagged template
+(`TemplateStringsArray` is awkward to fake; the driver reduces the tag to
+`query(text, params)` internally anyway). Inside the module still build queries
+with `$1` placeholders + params array so user input never reaches SQL text.
+
+## 6. 2024–2026 API caveats
+- **1.0.0 (2025-03):** GA. `sql.query()` + `sql.unsafe()` added; string-call form
+  removed; **Node ≥ 19 required**; `NeonDbError` captures stack traces.
+- **1.1.0 (2026-04):** type declarations fully inlined.
+- HTTP request/response capped at 64 MB — paginate large result sets.
+- Repo already uses `neon()` (NeonStore) at `^1.1.0`, so `sql.query()` is present.
+
+### References
+Neon serverless-driver docs, GitHub README/CHANGELOG/CONFIG, Neon "SQL template
+tags" blog, GitHub issues #51 (NeonDbError fields) and #146 (fetch failed), Neon
+read-replica + database-access docs. Full URLs in the orchestrator transcript.

--- a/reports/2026-06-16-twitter-feed-neon-schema.md
+++ b/reports/2026-06-16-twitter-feed-neon-schema.md
@@ -1,0 +1,97 @@
+# twitter-feed Neon schema + feed-reader design (issue #153)
+
+This is the ground-truth schema the Twitter habitat's **public-data path** reads.
+It is populated by the external `twitter-feed` sync pipeline
+(`~/The-Focus-AI/twitter-feed`, `src/db-storage.ts`). The habitat is a **read-only
+consumer** — it holds no twitterapi.io key, only `DATABASE_URL`.
+
+Captured by reading `twitter-feed/src/db-storage.ts`, `src/tweets.ts`,
+`src/types.ts`, and `src/cli.ts` directly (not guessed). If the upstream pipeline
+changes its schema, re-read those files.
+
+## Tables the feed-reader uses
+
+### `cached_tweets` — the core feed
+| column            | type        | notes                                   |
+| ----------------- | ----------- | --------------------------------------- |
+| `tweet_id`        | text PK     | X tweet id                              |
+| `author_id`       | text        | X user id of author                     |
+| `username`        | text        | lowercased handle (no `@`)              |
+| `text`            | text        | tweet body                              |
+| `created_at`      | timestamptz | tweet time                              |
+| `conversation_id` | text null   |                                         |
+| `retweet_count`   | int         |                                         |
+| `reply_count`     | int         |                                         |
+| `like_count`      | int         |                                         |
+| `quote_count`     | int         |                                         |
+| `bookmark_count`  | int         |                                         |
+| `impression_count`| int         |                                         |
+| `synced_at`       | timestamptz | when the pipeline last wrote this row   |
+
+`username` is stored **lowercased** (`username.toLowerCase()` on write), so all
+lookups must lowercase the handle and strip a leading `@`.
+
+### `twitter_profiles` — for display names / profile metrics
+Keyed by `username` (lowercased, UNIQUE). Columns include `twitter_id`,
+`display_name`, `description`, `followers_count`, `following_count`,
+`tweet_count`, etc. The feed-reader joins this to resolve a handle's display name.
+
+### `twitter_lists` + `twitter_list_members` — tracked lists
+- `twitter_lists`: surrogate `id` (PK), `list_id` (X list id or `local-<file_id>`),
+  `file_id` (UNIQUE — the slug like `ai-engineers`, matches the JSON file under
+  `twitter-feed/lists/`), `name`, `description`, `member_count`, ...
+- `twitter_list_members`: `list_id` → **`twitter_lists.id`** (the surrogate, not the
+  X list id), `username` (lowercased), `display_name`, `twitter_id`.
+  UNIQUE `(list_id, username)`.
+
+A list is addressed by its **`file_id` slug** (e.g. `ai-engineers`). To get a
+list's members: join `twitter_lists` (by `file_id` or `name`) → `twitter_list_members`.
+
+### `summaries` — pre-generated list digests (markdown)
+| column        | type        | notes                                            |
+| ------------- | ----------- | ------------------------------------------------ |
+| `id`          | uuid PK     |                                                  |
+| `list_id`     | text        | **= the list `file_id` slug** (NOT lists.id)     |
+| `report_date` | date/text   |                                                  |
+| `report_type` | text        | morning/midday/evening/daily/recent/weekly/other |
+| `content`     | text        | markdown report body                             |
+| `title`       | text null   | first H1 of content                              |
+| `generated_at`| timestamptz |                                                  |
+| `sent_at`     | timestamptz |                                                  |
+
+UNIQUE `(list_id, report_date, report_type)`. Latest = `ORDER BY report_date DESC,
+generated_at DESC`. Note `summaries.list_id` is the **file_id slug**, while
+`twitter_list_members.list_id` is the **surrogate `twitter_lists.id`** — different
+keys, easy to confuse.
+
+(Other tables — `cached_replies`, `email_subscriptions` — exist but the v1
+feed-reader does not need them.)
+
+## Engagement formula (must match upstream)
+`twitter-feed/src/tweets.ts#calculateEngagement`:
+
+```
+engagement = like_count + retweet_count + reply_count
+```
+
+Quotes/bookmarks/impressions are **not** counted. The feed-reader ranks by this
+exact expression so its ordering matches the pipeline's own reports.
+
+## The three queries (issue #153)
+1. **person recent** — `WHERE username = $1 ORDER BY created_at DESC LIMIT $2`
+   (lowercase + strip `@` first). Optionally also rank-by-engagement.
+2. **high engagement** — `ORDER BY (like_count + retweet_count + reply_count) DESC`,
+   optionally windowed (`created_at >= now() - interval`) and/or scoped to a list's
+   members.
+3. **list digest** — resolve list by `file_id`/`name` → members → their top recent
+   tweets by engagement; plus the latest `summaries` row (markdown) when present.
+   Degrades gracefully: unknown list → empty members + no summary, not an error.
+
+## DB client decision
+Use **`@neondatabase/serverless`** `neon()` (HTTP path), matching the repo's
+existing `NeonStore` (`packages/protocols/src/mcp-serve/neon-store.ts`,
+`@neondatabase/serverless@^1.1.0`). The feed-reader depends on a thin injected
+`QueryExecutor = (text, params) => Promise<rows[]>` bound to `sql.query(text,
+params)` in production and a fake in unit tests. All queries use `$1` placeholders
++ a params array — never string concatenation. See companion report
+`2026-06-16-neon-serverless-readonly-driver.md`.


### PR DESCRIPTION
Closes #153. Parent PRD: #149.

## What this builds

The **public-data path** for the Twitter habitat — a read-only consumer of the Neon
tables the existing `twitter-feed` pipeline syncs. The habitat holds **no
twitterapi.io key**; it reads only `DATABASE_URL`.

### Deep module — `FeedReader` (`src/feed-reader.ts`)
Answers the three public-data questions, embedding the SQL so the Agent tools stay thin:
- **person recent** — a tracked person's recent tweets (`getPersonRecent`)
- **high engagement** — most notable tweets, ranked by `likes + retweets + replies` (`getHighEngagement`)
- **list digest** — a list's members + their top tweets by engagement + the latest pre-generated summary (`getListDigest`)

The Postgres boundary is an injected `QueryExecutor = (text, params) => rows`, bound to
`@neondatabase/serverless`'s `neon()` HTTP query path in production (`neonExecutor`) and a
**seeded in-memory fake** in unit tests — so the module is fully tested with no database.
Engagement ranking matches `twitter-feed/src/tweets.ts#calculateEngagement` exactly, so the
habitat's ordering agrees with the pipeline's own reports. All queries use `$1` placeholders +
a params array (no string concatenation).

### Thin adapters — three factory-pattern Agent tools
`tools/person-recent`, `tools/list-digest`, `tools/high-engagement` — each pulls `DATABASE_URL`
from Habitat secrets (or env) via `src/feed-tool-support.ts`, calls the `FeedReader`, and returns
shaped results. A missing `DATABASE_URL` → actionable config error; an unknown list → graceful
`found: false`.

### Schema ground-truth
The schema was read directly from the local `twitter-feed` source (not guessed) and documented in
`reports/2026-06-16-twitter-feed-neon-schema.md`; Neon driver best-practices in
`reports/2026-06-16-neon-serverless-readonly-driver.md`.

## Acceptance criteria

- [x] **A feed-reader module answers person-recent, list-digest, and high-engagement queries from the Neon tables** — `FeedReader.getPersonRecent` / `getListDigest` / `getHighEngagement`.
- [x] **Tools expose these and are chattable** — `person_recent`, `list_digest`, `high_engagement` load in the real habitat runtime (verified, see below).
- [x] **Results are ranked by engagement where applicable** — `ORDER BY (like_count + retweet_count + reply_count) DESC`; unit-tested ranking order.
- [x] **The habitat reads only `DATABASE_URL` for this path (no twitterapi.io key)** — `feed-tool-support.ts` reads only `DATABASE_URL`.
- [x] **Verified against a seeded fixture; `pnpm test:run` passes** — 35 tests pass; ranking/windowing/normalization/graceful-degradation asserted through a seeded in-memory fixture executor.

## How to verify

### 1. Unit tests + build (no network, no DB)
```bash
cd examples/twitter-habitat
pnpm install
pnpm test:run   # 35 passed (incl. seeded feed-reader fixture)
pnpm build      # tsc clean
```

### 2. Tools load + safe error path in the real runtime (no DB needed)
Confirms discovery, factory construction, and the missing-`DATABASE_URL` config error. Run from the repo root:
```bash
dotenvx run -f /dev/null -- pnpm tsx -e '
import { loadToolsFromDirectory } from "./packages/core/src/stimulus/tools/loader.js";
const wt = "examples/twitter-habitat";
const tools = await loadToolsFromDirectory(wt, "tools", { getSecret: () => undefined, setSecret: async () => {} });
console.log("tools:", Object.keys(tools).sort());
console.log(await tools.person_recent.execute({ handle: "@karpathy" }, {}));
'
```
Expected: `tools: [ bookmarks, high_engagement, list_digest, person_recent ]` and a `kind: "config"` error telling the operator to set `DATABASE_URL`.

### 3. Chattable against real twitter-feed data (manual — needs a Neon `DATABASE_URL`)
```bash
dotenvx run -- pnpm run cli habitat secrets set DATABASE_URL 'postgres://...' --work-dir examples/twitter-habitat
dotenvx run -- pnpm run cli habitat serve --work-dir examples/twitter-habitat --port 7430
# another terminal:
dotenvx run -- pnpm run cli habitat chat --url http://localhost:7430 --one-shot "what's @karpathy been posting?"
dotenvx run -- pnpm run cli habitat chat --url http://localhost:7430 --one-shot "digest the ai-engineers list"
dotenvx run -- pnpm run cli habitat chat --url http://localhost:7430 --one-shot "what are the top tweets right now?"
```
Point `DATABASE_URL` at the same Neon DB the `twitter-feed` pipeline syncs.

## Worth knowing / further work
- **`summaries.list_id` is the list `file_id` slug** (e.g. `ai-engineers`), while
  `twitter_list_members.list_id` is the surrogate `twitter_lists.id` — different keys. The
  feed reader handles both; noted in the schema report so #154 doesn't trip on it.
- **Real-DB ranking/window correctness** is exercised by the seeded fixture (which replays the
  exact query semantics) + the manual chat path. There is no automated integration test against a
  live Neon (the issue scoped it to "a Neon DB **or** a seeded fixture").
- `high_engagement` defaults to a **24h** window so all-time blockbusters don't dominate; `list_digest` top-tweets default to **48h**. Both overridable via `sinceHours`.
- Per the example's convention, the tool **handlers** run under the monorepo habitat runtime and are not part of the standalone `tsc`/`vitest` build (which covers `src/`); the deep `FeedReader` they call is unit-tested.
- Unblocks **#154** (the "what's new" briefing persona), which orchestrates these tools with bookmarks/mentions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)