### PR TITLE
feat(twitter): Gaia-orchestrated deploy — twitter-habitat image + Gaia compose + runbook (#155)

### DIFF
--- a/deploy/gaia/.env.example
+++ b/deploy/gaia/.env.example
@@ -1,0 +1,14 @@
+# Copy to deploy/gaia/.env and fill in. Used by docker-compose.yml.
+
+# --- Gaia's own chat model (orchestrator brain) ---
+GAIA_PROVIDER=openrouter
+GAIA_MODEL=openai/gpt-4o-mini
+GAIA_PORT=7420
+
+# Provider key Gaia uses for its own chat. Set the one matching GAIA_PROVIDER.
+OPENROUTER_API_KEY=
+# GOOGLE_GENERATIVE_AI_API_KEY=
+
+# NOTE: child-habitat secrets (X OAuth, DATABASE_URL, child provider keys) are
+# NOT set here — they go into Gaia's master vault after boot (see the runbook),
+# and Gaia binds only the named subset each habitat needs.

--- a/deploy/gaia/README.md
+++ b/deploy/gaia/README.md
@@ -1,0 +1,230 @@
+# Deploy runbook — Gaia orchestrator + Twitter habitat
+
+This runbook stands up **Gaia** (the habitat orchestrator) as a single
+container on a Docker host, then runs the **Twitter habitat** (PRD #149) under
+it as a Gaia-managed container. Gaia becomes the coordination layer: add more
+habitats later with no new infra.
+
+Background on why Gaia is deployed this way (it shells out to the host's
+`docker` CLI to spawn sibling containers, so it can't run on fly.io/Cloud Run):
+`reports/2026-06-18-gaia-deployment-and-habitat-orchestration.md`.
+
+> **Host requirement: Linux with Docker.** A VPS or a GCE VM both work
+> identically — pick by where your Neon DB / other services live and who
+> administers the box. The containerized-Gaia path uses **host networking**,
+> which is a Linux Docker feature; it does **not** work on Docker Desktop for
+> macOS/Windows. For local dev on a Mac, use the standalone single-container
+> path at the end of this doc, or run `pnpm run cli habitat gaia` directly.
+
+---
+
+## 0. Provision the host
+
+A small Linux VM is enough to start (2 vCPU / 4 GB RAM hosts Gaia + a few
+habitats; each habitat container is ~1 GB like the fly `[[vm]]`).
+
+```bash
+# Install Docker Engine + compose plugin (Debian/Ubuntu)
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker "$USER" && newgrp docker   # run docker without sudo
+
+# Clone the repo (the images build from the monorepo root)
+git clone https://github.com/The-Focus-AI/umwelten.git
+cd umwelten
+```
+
+On **GCE**: a `e2-medium` (or larger) VM with the above is equivalent to a VPS.
+Open only the ports you need (see §6 — prefer reaching Gaia over SSH tunnel or
+a reverse proxy, not a public 7420).
+
+---
+
+## 1. Build the images
+
+Both build from the monorepo root. The Twitter image layers onto the base.
+
+```bash
+docker build -t habitat          -f packages/habitat/Dockerfile .
+docker build -t twitter-habitat  -f packages/habitat/Dockerfile.twitter-habitat .
+```
+
+> Requires **BuildKit** (the default in Docker ≥ 23; else `export DOCKER_BUILDKIT=1`).
+> The Twitter build relies on `packages/habitat/Dockerfile.twitter-habitat.dockerignore`
+> to include `examples/twitter-habitat` (the root `.dockerignore` excludes
+> `examples/`); per-Dockerfile ignore files are a BuildKit-only feature.
+
+`twitter-habitat` bakes `examples/twitter-habitat/{tools,src,STIMULUS.md}` and,
+on every boot, seeds them onto the container's `/data` volume, symlinks
+`/data/node_modules → /habitat/node_modules` (so the tool's `ai`/`zod`/`../../src`
+imports resolve), and merges `toolsDir`/`stimulusFile` into the Gaia-seeded
+`config.json`.
+
+---
+
+## 2. Launch Gaia (containerized)
+
+```bash
+cd deploy/gaia
+cp .env.example .env          # set OPENROUTER_API_KEY (or GOOGLE_…) + GAIA_*
+sudo mkdir -p /opt/gaia-data  # identity bind-mount target (see compose header)
+
+docker compose up -d
+docker compose logs -f gaia   # watch for "[gaia] Orchestrator at http://0.0.0.0:7420"
+```
+
+Gaia is now at `http://<host>:7420` (host networking → binds the host directly).
+The dashboard has Chat / Habitats / Secrets / Create tabs. Verify:
+
+```bash
+curl -s http://localhost:7420/health
+# → {"status":"ok","role":"gaia-orchestrator",...,"docker":true,...}
+```
+
+`docker: true` confirms Gaia can reach the host daemon through the mounted
+socket.
+
+---
+
+## 3. Add the master secrets
+
+Gaia holds a **master vault**; each habitat receives only the named secrets you
+bind to it. Add everything the Twitter habitat needs (and Gaia's own provider
+key if not already in `.env`):
+
+```bash
+gaia() { curl -s -X POST http://localhost:7420/api/secrets \
+  -H 'Content-Type: application/json' -d "$1"; }
+
+gaia '{"name":"TWITTER_CLIENT_ID","value":"<x-app-client-id>"}'
+gaia '{"name":"TWITTER_CLIENT_SECRET","value":"<x-app-client-secret>"}'
+gaia '{"name":"TWITTER_REFRESH_TOKEN","value":"<bootstrap-refresh-token>"}'
+gaia '{"name":"DATABASE_URL","value":"<neon-postgres-url>"}'        # feed reader (#153)
+gaia '{"name":"OPENROUTER_API_KEY","value":"<key>"}'               # child LLM provider
+```
+
+`TWITTER_REFRESH_TOKEN` is the **seed** from the one-time OAuth bootstrap
+(`examples/twitter-habitat/bootstrap-oauth.ts` — see that dir's README). After
+the first refresh, X rotates it and the habitat persists the new one itself
+(see §5).
+
+---
+
+## 4. Create + start the Twitter habitat
+
+Create a registry entry that runs the **`twitter-habitat`** image and binds the
+secrets. (Gaia injects each into the child's `/data/secrets.json`.)
+
+```bash
+curl -s -X POST http://localhost:7420/api/habitats \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "id": "twitter",
+    "name": "Twitter",
+    "image": "twitter-habitat",
+    "provider": "openrouter",
+    "model": "openai/gpt-4o-mini",
+    "secretBindings": [
+      "TWITTER_CLIENT_ID", "TWITTER_CLIENT_SECRET", "TWITTER_REFRESH_TOKEN",
+      "DATABASE_URL", "OPENROUTER_API_KEY"
+    ]
+  }'
+
+curl -s -X POST http://localhost:7420/api/habitats/twitter/start
+# → {"started": true, "port": 7440}
+```
+
+Or just tell Gaia in the **Chat** tab: *"Create a habitat called twitter using
+the twitter-habitat image and openrouter openai/gpt-4o-mini. Bind the Twitter
+and DATABASE_URL and OpenRouter secrets, then start it."*
+
+---
+
+## 5. Verify the habitat
+
+Everything below goes **through Gaia's proxy**, which injects the child's bearer
+token automatically (children bind to `127.0.0.1` only — they're not exposed
+directly).
+
+```bash
+# Health
+curl -s http://localhost:7420/api/habitats/twitter/health        # → {"status":"ok",...}
+
+# Agent card (name/description synced from STIMULUS.md)
+curl -s http://localhost:7420/api/habitats/twitter/agent-card | jq .name   # → "Twitter"
+
+# Tools loaded (bookmarks should be present)
+curl -s http://localhost:7420/api/habitats/twitter/logs?tail=80 | grep -i bookmark
+```
+
+Chat end-to-end (relays an A2A message to the habitat):
+
+> In Gaia chat: *"Ask twitter to show my recent bookmarks."*
+
+A correct setup returns real bookmarks. If auth isn't seeded, the tool returns a
+clear `needs_reauth` message (re-check §3's `TWITTER_REFRESH_TOKEN`).
+
+**Refresh-token persistence (the restart test):** the habitat persists the
+rotated refresh token to `/data/secrets.json` on its named volume
+(`gaia-twitter-data`). Confirm it survives a restart:
+
+```bash
+docker run --rm -v gaia-twitter-data:/data alpine cat /data/secrets.json | jq -r .TWITTER_REFRESH_TOKEN | cut -c1-8
+curl -s -X POST http://localhost:7420/api/habitats/twitter/stop
+curl -s -X POST http://localhost:7420/api/habitats/twitter/start
+# token unchanged unless a refresh happened in between; never lost
+```
+
+---
+
+## 6. Attach to the habitats SaaS
+
+The SaaS "+ Umwelten agent" flow needs an A2A endpoint + bearer token. Reach the
+Gaia-managed habitat through Gaia's proxy:
+
+- **A2A endpoint:** `https://<gaia-host>/api/habitats/twitter/a2a`
+- **Bearer token:** Gaia's own `HABITAT_API_KEY` (the proxy forwards to the child
+  with the child's token; the SaaS authenticates to Gaia).
+
+Put a TLS reverse proxy (Caddy/nginx) in front of Gaia for `https://` — do not
+expose `7420` publicly unauthenticated. The agent card's name/description sync
+on attach; a rotated token shows the SaaS's "needs reconnect" state.
+
+> If you prefer the SaaS to talk to the habitat **directly** (no Gaia in the
+> request path), publish the child port and point the SaaS at
+> `https://<host>:<childport>/a2a` with that child's `HABITAT_API_KEY`. The
+> proxy path above is the default because children bind to `127.0.0.1`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `health` shows `"docker": false` | Socket not mounted / no daemon access. Check `/var/run/docker.sock` mount + the host user is in the `docker` group. |
+| Gaia can't reach a started child (proxy 502) | Not on Linux host networking. Containerized Gaia requires `network_mode: host` (this compose) on a Linux host. |
+| `Image "twitter-habitat" not found` | Build it on this host (§1). Gaia only auto-builds the default `habitat` image. |
+| Child session dirs empty on host | Data dir not identity-mounted. Keep `/opt/gaia-data:/opt/gaia-data` (same path in/out). |
+| Bookmarks tool: `needs_reauth` | `TWITTER_REFRESH_TOKEN` missing/expired — re-run the OAuth bootstrap and re-set the secret, then `rebuild` the habitat. |
+
+---
+
+## Standalone alternative (no Gaia)
+
+The **same `twitter-habitat` image** runs as a lone container — useful for local
+dev (incl. macOS) or a fly.io deploy where you don't need orchestration:
+
+```bash
+docker run -d --name twitter -p 7430:8080 \
+  -v twitter-data:/data \
+  -e HABITAT_API_KEY=$(openssl rand -hex 16) \
+  -e OPENROUTER_API_KEY=$OPENROUTER_API_KEY \
+  twitter-habitat
+# seed secrets onto the volume, then:
+curl -s http://localhost:7430/.well-known/agent-card.json | jq .name
+```
+
+For **fly.io**, mirror `examples/oura-mcp/fly.toml`: build this image, mount a
+volume at `/data`, set `HABITAT_API_KEY` + the Twitter/Neon/provider secrets via
+`fly secrets set`, and use `min_machines_running = 1` + `auto_stop_machines = "off"`
+so the volume (and the rotated refresh token) stays put. Details:
+`reports/2026-06-18-flyio-habitat-container-deploy.md`.

--- a/deploy/gaia/docker-compose.yml
+++ b/deploy/gaia/docker-compose.yml
@@ -1,0 +1,55 @@
+# Gaia orchestrator — containerized deploy (Docker-out-of-Docker).
+#
+# Gaia spawns sibling habitat containers by driving the HOST docker daemon via
+# the mounted socket. Two non-obvious requirements make that work:
+#
+#   1. network_mode: host
+#      Gaia reaches its children at 127.0.0.1:<port> (DockerManager publishes
+#      each child on 127.0.0.1:7440-7499). Inside a bridged container that
+#      loopback is the container's own — not the host's. Host networking puts
+#      Gaia in the host network namespace so 127.0.0.1:<port> hits the
+#      published child ports. (Linux only — see the runbook. On macOS/Docker
+#      Desktop use the standalone single-container path instead.)
+#
+#   2. Identity bind mount for the data dir (/opt/gaia-data:/opt/gaia-data)
+#      Gaia bind-mounts each child's sessions dir at <dataDir>/sessions/<id>.
+#      That path is resolved by the HOST daemon, so the data dir must live at
+#      the SAME path inside the Gaia container and on the host. Mounting it at
+#      an identical path makes child bind mounts line up.
+#
+# Prereqs: `docker build -t habitat -f packages/habitat/Dockerfile .` and
+# `docker build -t twitter-habitat -f packages/habitat/Dockerfile.twitter-habitat .`
+# have been run on this host. See deploy/gaia/README.md for the full runbook.
+
+services:
+  gaia:
+    image: habitat
+    container_name: gaia
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      # Gaia's own chat model. openrouter avoids the fresh-install
+      # @ai-sdk/google v3 vs ai@5 break (PRD #149 "Further Notes").
+      GAIA_PROVIDER: ${GAIA_PROVIDER:-openrouter}
+      GAIA_MODEL: ${GAIA_MODEL:-openai/gpt-4o-mini}
+      GAIA_PORT: ${GAIA_PORT:-7420}
+      HABITAT_WORK_DIR: /opt/gaia-data
+      # The provider key Gaia uses for its own chat. Child habitats get their
+      # own keys via the master vault + secret bindings, not from here.
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
+    volumes:
+      # Drive the host docker daemon (spawn/seed/stop child habitats).
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Identity mount — see header note #2. Registry + master secrets persist
+      # here; child session dirs are bind-mounted from subpaths of it.
+      - /opt/gaia-data:/opt/gaia-data
+    command:
+      - sh
+      - -c
+      - >
+        pnpm exec tsx packages/cli/src/entry.ts habitat gaia
+        --port "$$GAIA_PORT"
+        --data-dir /opt/gaia-data
+        --provider "$$GAIA_PROVIDER"
+        --model "$$GAIA_MODEL"

--- a/packages/habitat/Dockerfile.twitter-habitat
+++ b/packages/habitat/Dockerfile.twitter-habitat
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1.4
+#
+# Twitter Habitat Container — the Twitter/X agent on the habitat base (#155, PRD #149).
+#
+# Layers onto the habitat serve image (build that first):
+#   - The Twitter work dir (custom `tools/` + their deep modules `src/` + the
+#     persona STIMULUS.md) baked at /opt/twitter-habitat
+#   - An entrypoint wrapper that seeds those onto the /data volume on boot,
+#     symlinks /data/node_modules → /habitat/node_modules so the work-dir tools
+#     can import `ai`/`zod`/`../../src`, and merges toolsDir/stimulusFile into
+#     config.json (idempotent — Gaia-seeded fields are preserved).
+#   - The rotated X refresh token persists to /data/secrets.json on the volume,
+#     so it survives container restarts (PRD requirement).
+#
+# CMD is unchanged from the base — the container server (A2A + MCP + chat).
+#
+# Build (from monorepo root; requires BuildKit — default in Docker >= 23):
+#   docker build -t habitat -f packages/habitat/Dockerfile .
+#   docker build -t twitter-habitat -f packages/habitat/Dockerfile.twitter-habitat .
+#
+# The root .dockerignore excludes examples/; the adjacent
+# Dockerfile.twitter-habitat.dockerignore re-includes examples/twitter-habitat
+# for this build (a per-Dockerfile ignore is a BuildKit feature).
+#
+# Smoke check:
+#   scripts/smoke-twitter-habitat.sh
+#
+# Deploy via Gaia: create a registry entry with "image": "twitter-habitat" and
+# bind TWITTER_CLIENT_ID / TWITTER_CLIENT_SECRET / TWITTER_REFRESH_TOKEN,
+# DATABASE_URL (feed reader), and an LLM provider key. Or fly.io: volume at
+# /data, HABITAT_API_KEY + the same secrets as fly secrets.
+
+ARG BASE_IMAGE=habitat
+FROM ${BASE_IMAGE}
+
+# Bake the Twitter work dir. Build context is the monorepo root (same as the
+# base image), so these paths are repo-relative.
+COPY examples/twitter-habitat/tools      /opt/twitter-habitat/tools/
+COPY examples/twitter-habitat/src        /opt/twitter-habitat/src/
+COPY examples/twitter-habitat/STIMULUS.md /opt/twitter-habitat/STIMULUS.md
+
+# Seeder + entrypoint wrapper
+COPY packages/habitat/twitter-habitat/seed-config.mjs /opt/twitter-habitat/seed-config.mjs
+COPY packages/habitat/twitter-habitat/entrypoint.sh   /twitter-habitat-entrypoint.sh
+RUN chmod +x /twitter-habitat-entrypoint.sh
+
+ENTRYPOINT ["/twitter-habitat-entrypoint.sh"]
+CMD ["pnpm", "exec", "tsx", "packages/cli/src/entry.ts", "habitat", "serve", "--port", "8080", "--host", "0.0.0.0", "--skip-onboard"]

--- a/packages/habitat/Dockerfile.twitter-habitat.dockerignore
+++ b/packages/habitat/Dockerfile.twitter-habitat.dockerignore
@@ -1,0 +1,18 @@
+# Dedicated ignore file for Dockerfile.twitter-habitat (BuildKit uses
+# <dockerfile>.dockerignore when present, overriding the root .dockerignore).
+#
+# The root .dockerignore excludes examples/ wholesale, which would break this
+# image's `COPY examples/twitter-habitat/...`. This variant keeps that dir while
+# still dropping the heavy / irrelevant paths so the build context stays small.
+# It does NOT affect the base `habitat` or `coding-agent` builds — those have no
+# matching per-Dockerfile ignore file and keep using the root .dockerignore.
+
+**/node_modules/
+**/dist/
+.git/
+.env
+.env.*
+output/
+reports/
+docs/
+.claude/

--- a/packages/habitat/src/twitter-habitat-seed.test.ts
+++ b/packages/habitat/src/twitter-habitat-seed.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the twitter-habitat config seeder (#155).
+ *
+ * The seeder (`twitter-habitat/seed-config.mjs`) is the one branching piece of
+ * the deploy wrapper: it must point a habitat config at the seeded work-dir
+ * assets WITHOUT clobbering whatever Gaia already wrote (name/provider/model/
+ * secret bindings). We run the real script against temp files and assert the
+ * externally observable result — the config.json on disk.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const run = promisify(execFile);
+
+const SEEDER = resolve(
+  fileURLToPath(import.meta.url),
+  "..",
+  "..",
+  "twitter-habitat",
+  "seed-config.mjs",
+);
+
+async function seed(configPath: string) {
+  await run("node", [SEEDER, configPath]);
+}
+
+describe("twitter-habitat seed-config.mjs", () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "twitter-seed-"));
+    configPath = join(dir, "config.json");
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("creates a standalone config when none exists", async () => {
+    await seed(configPath);
+    const config = JSON.parse(await readFile(configPath, "utf8"));
+    expect(config.name).toBe("Twitter");
+    expect(config.toolsDir).toBe("tools");
+    expect(config.stimulusFile).toBe("STIMULUS.md");
+  });
+
+  it("fills in toolsDir/stimulusFile without clobbering Gaia-seeded fields", async () => {
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        name: "Twitter",
+        defaultProvider: "openrouter",
+        defaultModel: "openai/gpt-4o-mini",
+        agents: [{ id: "x", name: "X" }],
+      }),
+    );
+    await seed(configPath);
+    const config = JSON.parse(await readFile(configPath, "utf8"));
+    // Added
+    expect(config.toolsDir).toBe("tools");
+    expect(config.stimulusFile).toBe("STIMULUS.md");
+    // Preserved
+    expect(config.defaultProvider).toBe("openrouter");
+    expect(config.defaultModel).toBe("openai/gpt-4o-mini");
+    expect(config.agents).toEqual([{ id: "x", name: "X" }]);
+  });
+
+  it("does not override an operator's explicit toolsDir/stimulusFile", async () => {
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        name: "Twitter",
+        toolsDir: "custom-tools",
+        stimulusFile: "PERSONA.md",
+      }),
+    );
+    await seed(configPath);
+    const config = JSON.parse(await readFile(configPath, "utf8"));
+    expect(config.toolsDir).toBe("custom-tools");
+    expect(config.stimulusFile).toBe("PERSONA.md");
+  });
+
+  it("is idempotent — a second run makes no further changes", async () => {
+    await seed(configPath);
+    const first = await readFile(configPath, "utf8");
+    await seed(configPath);
+    const second = await readFile(configPath, "utf8");
+    expect(second).toBe(first);
+  });
+});

--- a/packages/habitat/twitter-habitat/entrypoint.sh
+++ b/packages/habitat/twitter-habitat/entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -e
+
+# Twitter-habitat entrypoint wrapper (#155).
+#
+# The base `habitat` image seeds nothing into /data — Gaia (or a plain
+# `docker run`) only puts config.json + secrets.json on the volume. This
+# wrapper layers the Twitter work dir (custom tools + their deep modules +
+# persona) onto the volume on every boot, then chains the base entrypoint.
+#
+# Why the node_modules symlink: the work-dir tools are loaded by the habitat
+# runtime via `import(file:///data/tools/.../handler.ts)`. Node resolves bare
+# specifiers (`ai`, `zod`) from node_modules walking up from the handler's
+# path — i.e. /data/.../node_modules, never /habitat/node_modules. Symlinking
+# /data/node_modules → /habitat/node_modules makes those imports (and the
+# deep modules under /data/src) resolve inside the container.
+
+WORK_DIR="${HABITAT_WORK_DIR:-/data}"
+SEED_DIR=/opt/twitter-habitat
+HABITAT_ROOT="${HABITAT_ROOT:-/habitat}"
+
+mkdir -p "$WORK_DIR"
+
+# Code (tools + deep modules): the image is the source of truth, so refresh
+# these every boot. Operators customize behavior via secrets/persona, not by
+# editing baked code on the volume.
+rm -rf "$WORK_DIR/tools" "$WORK_DIR/src"
+cp -r "$SEED_DIR/tools" "$WORK_DIR/tools"
+cp -r "$SEED_DIR/src" "$WORK_DIR/src"
+echo "[twitter-habitat] Seeded tools/ and src/ into $WORK_DIR."
+
+# Persona: seed only when absent so an operator's edit (or a Gaia-managed
+# STIMULUS.md) wins.
+if [ ! -f "$WORK_DIR/STIMULUS.md" ]; then
+	cp "$SEED_DIR/STIMULUS.md" "$WORK_DIR/STIMULUS.md"
+	echo "[twitter-habitat] Seeded default STIMULUS.md (Twitter persona)."
+fi
+
+# Make bare imports from the work-dir tools resolve against the monorepo deps.
+ln -sfn "$HABITAT_ROOT/node_modules" "$WORK_DIR/node_modules"
+
+# Config: ensure toolsDir/stimulusFile point at the seeded assets (idempotent
+# merge — Gaia-seeded name/provider/model/secret fields are preserved).
+node "$SEED_DIR/seed-config.mjs" "$WORK_DIR/config.json"
+
+mkdir -p "$WORK_DIR/sessions"
+
+exec /entrypoint.sh "$@"

--- a/packages/habitat/twitter-habitat/seed-config.mjs
+++ b/packages/habitat/twitter-habitat/seed-config.mjs
@@ -1,0 +1,54 @@
+/**
+ * Idempotent config.json seeder for the twitter-habitat image (#155).
+ *
+ * Ensures the habitat config points at the seeded work-dir assets:
+ *   - toolsDir     = "tools"        (so the bookmarks tool loads from /data/tools)
+ *   - stimulusFile = "STIMULUS.md"  (so the Twitter persona is used)
+ *
+ * Never overwrites existing fields: a Gaia-seeded config.json keeps its name,
+ * provider/model, secret bindings, and any agents it already declares. Only the
+ * two work-dir-pointing fields are filled in when missing. Creates a minimal
+ * standalone config when the volume is empty (plain `docker run`, no Gaia).
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+
+const configPath = process.argv[2];
+if (!configPath) {
+  console.error("usage: seed-config.mjs <path-to-config.json>");
+  process.exit(1);
+}
+
+let config;
+let existed = true;
+try {
+  config = JSON.parse(readFileSync(configPath, "utf8"));
+} catch {
+  existed = false;
+  // Minimal standalone default. Provider/model come from env or an operator
+  // edit; Gaia normally seeds those before this runs.
+  config = { name: "Twitter" };
+}
+
+if (config === null || typeof config !== "object" || Array.isArray(config)) {
+  config = { name: "Twitter" };
+  existed = false;
+}
+
+let changed = false;
+if (config.toolsDir === undefined) {
+  config.toolsDir = "tools";
+  changed = true;
+}
+if (config.stimulusFile === undefined) {
+  config.stimulusFile = "STIMULUS.md";
+  changed = true;
+}
+if (config.name === undefined) {
+  config.name = "Twitter";
+  changed = true;
+}
+
+if (changed || !existed) {
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  console.log(`[twitter-habitat] Seeded config.json (toolsDir, stimulusFile).`);
+}

--- a/reports/2026-06-18-flyio-habitat-container-deploy.md
+++ b/reports/2026-06-18-flyio-habitat-container-deploy.md
@@ -1,0 +1,289 @@
+# Deploying an umwelten Habitat Container to Fly.io
+
+**Date:** 2026-06-18
+**Scope:** A single always-on Node.js container running `habitat serve`, exposing an authenticated A2A/HTTP surface on internal port **8080**, backed by a **persistent volume** for mutable state, with **secrets injected as environment variables**. Dockerfile lives at `packages/habitat/Dockerfile` and must build from the **monorepo root** as context.
+
+> **TL;DR.** Use `min_machines_running = 1` + `auto_stop_machines = "off"` so the single machine never stops — this is the only safe config for a service that must persist a rotated OAuth refresh token to a file on its one volume. Build from the monorepo root with `fly deploy --dockerfile packages/habitat/Dockerfile` (the **CLI flag**, not just `[build]` in fly.toml, is the reliable way to keep the root as build context). Put every sensitive value in `fly secrets set` (encrypted vault, injected as env vars at boot); keep only non-sensitive config in `[env]`.
+
+---
+
+## 1. fly.toml structure (Dockerfile-built app with a volume)
+
+A complete `fly.toml` for the Habitat container:
+
+```toml
+app = "umwelten-habitat"
+primary_region = "iad"           # pick the region where your volume lives
+
+[build]
+  # Path to the Dockerfile, relative to the build context (the monorepo root).
+  # NOTE: this field alone does NOT change the build context — see Section 6.
+  dockerfile = "packages/habitat/Dockerfile"
+
+[env]
+  # Non-sensitive config ONLY. These are plaintext in the repo. Never put
+  # OAuth secrets, DATABASE_URL, or the bearer key here.
+  PORT = "8080"
+  NODE_ENV = "production"
+  HABITAT_DATA_DIR = "/data"
+
+[mounts]
+  source = "habitat_data"        # volume NAME (must already exist in the region)
+  destination = "/data"          # mount point inside the machine (cannot be "/")
+  initial_size = "10gb"          # only used when fly creates the volume on first deploy
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"     # never stop the machine (see Section 2)
+  auto_start_machines = false
+  min_machines_running = 1       # keep exactly one machine alive
+
+[[vm]]
+  size = "shared-cpu-1x"         # or set cpu_kind/cpus/memory explicitly
+  cpu_kind = "shared"
+  cpus = 1
+  memory = "1gb"
+```
+
+Field reference ([App configuration (fly.toml)](https://fly.io/docs/reference/configuration/)):
+
+- **`[build] dockerfile`** — relative path/URL to the Dockerfile. By default `flyctl` looks for `Dockerfile` in the app root. **Critical caveat from the docs:** *"This option will not change the Docker context path, which is set to the project root directory by default."* See Section 6 for the monorepo implication.
+- **`[mounts]`** — `source` is the **volume name** (the volume must exist in some region); `destination` is the in-machine path and **cannot be `/`**; `initial_size` is consulted only by `fly launch`/`fly deploy` when creating a new volume.
+- **`[http_service]`** — `internal_port` is the port your app listens on inside the container (default `8080`); `force_https` redirects HTTP→HTTPS at the Fly Proxy edge. `auto_stop_machines` accepts `"off"`, `"stop"`, or `"suspend"`.
+- **`[[vm]]`** — use `size` for a preset (`fly platform vm-sizes` lists them) or set `cpu_kind` (`"shared"`/`"performance"`), `cpus` (1/2/4/8/16), and `memory` (`"1gb"`, `"512mb"`, or plain MB integer) explicitly.
+
+> Make sure your Dockerfile path is **not** excluded by `.dockerignore`, and that anything the build needs (the whole pnpm workspace) is inside the build context and not ignored.
+
+---
+
+## 2. Volume persistence semantics (the most important section)
+
+### How Fly volumes relate to machines
+
+A Fly volume is a slice of NVMe storage pinned to one physical host. The pairing is strictly one-to-one ([Volumes overview](https://fly.io/docs/volumes/overview/)):
+
+> *"A Machine can only mount one volume at a time and a volume can be attached to only one Machine."*
+
+For a single-machine Habitat that's exactly what we want: one machine, one volume at `/data`.
+
+### Survival across restart and redeploy
+
+Volume data is **durable across machine restarts and redeploys**. The ephemeral root filesystem is wiped on every restart; the volume is not. The docs say to use a volume *"for any information that needs to persist after deploy or restart."* So a rotated OAuth refresh token written to `/data/oauth/refresh-token.json` survives `fly deploy`, secret updates, machine restarts, and crashes.
+
+### The scale-to-zero gotcha (this is the trap)
+
+The Fly default that `fly launch` writes is `auto_stop_machines = "stop"`, `auto_start_machines = true`, `min_machines_running = 0` ([Autostop/autostart](https://fly.io/docs/launch/autostop-autostart/)). For a stateless web app that's fine. For a single-volume stateful service it is dangerous:
+
+- The volume cannot move hosts. With only one machine, all your state lives on that one machine's volume.
+- With `min_machines_running = 0`, the proxy stops the machine when idle. The data still exists on the NVMe slice (it is not deleted), but **the service is down until a request wakes it**, and any in-process state, in-flight token rotation, or background timer is lost on stop. A suspended/stopped machine with a volume **still bills you for the volume** ([community thread](https://community.fly.io/t/setting-a-minimum-number-of-instances-to-keep-running-when-using-auto-start-stop/12861)).
+- `fly launch` only ever provisions **one** machine when a volume is mounted, because *"volumes don't automatically replicate your data"* — you would have to set up replication yourself before adding machines.
+
+### Correct config for a token-persisting, always-on service
+
+`min_machines_running` has **no effect** unless `auto_stop_machines` is `"stop"` or `"suspend"`. Two valid always-on shapes:
+
+**Option A — fully disable autostop (recommended for this service):**
+
+```toml
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = false
+  min_machines_running = 1
+```
+
+**Option B — allow autostop but always keep one:**
+
+```toml
+[http_service]
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+```
+
+Both keep one machine running in the primary region. For a service that owns a rotated OAuth refresh token and must respond to A2A traffic at any time, **Option A** is the cleanest: the machine simply never stops, so background token refresh and any in-memory session state stay alive, and the volume is always mounted and writable.
+
+> `min_machines_running` only applies to the **primary region**; it does not keep machines alive in secondary regions. For this single-machine deploy that's irrelevant — keep everything in one region matching the volume.
+
+**Durability caveat:** a single volume on a single host is a single point of failure. Fly does **not** replicate volume data automatically. For a refresh token you cannot afford to lose, also rely on Fly's automatic volume **snapshots** (default 5-day retention) and/or write the token to your Postgres `DATABASE_URL` as the source of truth, treating the file on the volume as a cache ([Volumes overview](https://fly.io/docs/volumes/overview/)).
+
+---
+
+## 3. Secrets vs `[env]`
+
+Use the right channel for each value ([App secrets](https://fly.io/docs/apps/secrets/)):
+
+| Channel | Storage | Use for |
+|---|---|---|
+| `fly secrets set` | Encrypted in a vault, decrypted and **injected as env vars at boot** | X OAuth client id/secret/refresh token, `DATABASE_URL`, `HABITAT_API_KEY` bearer token, all Tavily/provider API keys |
+| `[env]` in fly.toml | **Plaintext** in your repo | `PORT`, `NODE_ENV`, non-secret paths/flags |
+
+Key facts:
+
+- **Injection.** When a machine launches, the Fly host agent decrypts your secrets and injects them as environment variables at boot. Your Node process reads them with `process.env` exactly like the `[env]` values — no code change needed to switch a value from `[env]` to a secret.
+- **Setting a secret triggers a restart.** *"`fly secrets set` … updates each Machine belonging to that Fly App. This involves a restart of the Machine and a consequent reset of its ephemeral file system."* The volume at `/data` survives that restart, so a persisted refresh token is unaffected — but be aware each `secrets set` bounces the machine.
+- **Batch + stage.** Set multiple secrets in one command to incur a single restart, or use `--stage` to defer the restart until your next `fly deploy`:
+
+```bash
+# All at once (one restart):
+fly secrets set \
+  X_CLIENT_ID="..." \
+  X_CLIENT_SECRET="..." \
+  X_REFRESH_TOKEN="..." \
+  DATABASE_URL="postgres://user:pass@host/db" \
+  HABITAT_API_KEY="$(openssl rand -hex 32)"
+
+# Stage now, apply on next deploy (no immediate restart):
+fly secrets set HABITAT_API_KEY="..." --stage
+```
+
+- **Warning from the docs.** Secrets are readable by your own application code. *"People with deploy access can deploy code that reads secret values and prints them to logs."* Make sure Habitat never logs `process.env` wholesale.
+- `fly secrets list` shows names + digests (never values); `fly secrets unset NAME` removes one.
+
+> **Initial refresh token vs rotated token.** Seed the initial OAuth refresh token via `fly secrets set X_REFRESH_TOKEN=...`. After that, the rotated token should be written by the app to a file on the **volume** (`/data/...`) — secrets are read-only to the app at runtime, so the volume is the right place for the value that changes.
+
+---
+
+## 4. First-time, single-container deploy commands
+
+Recommended order of operations for an app needing a volume + secrets **before** first deploy:
+
+```bash
+# 0. (optional) Authenticate
+fly auth login
+
+# 1. Scaffold WITHOUT deploying, so you can edit fly.toml first.
+#    --no-deploy lets you fix the build/mounts/secrets before going live.
+fly launch --no-deploy --name umwelten-habitat --region iad
+#    Or, to skip flyctl's scanners entirely and use a hand-written fly.toml:
+#    fly apps create umwelten-habitat
+
+# 2. Edit fly.toml: set [build] dockerfile, [mounts], [http_service] (Section 1-2).
+#    GOTCHA: `fly launch` regenerates/overwrites fly.toml from its scanners and
+#    may flip auto_stop_machines back to "stop" and min_machines_running to 0,
+#    and may not preserve your [build]/[mounts] block. Re-check the file after
+#    every `fly launch`. Prefer `fly apps create` + hand-written fly.toml if you
+#    want full control.
+
+# 3. Create the volume in the SAME region as primary_region.
+fly volumes create habitat_data --size 10 --region iad -a umwelten-habitat
+#    --size is in GB. The volume NAME must match [mounts] source.
+
+# 4. Set secrets (batch them — see Section 3). These stage onto the app.
+fly secrets set \
+  X_CLIENT_ID="..." X_CLIENT_SECRET="..." X_REFRESH_TOKEN="..." \
+  DATABASE_URL="postgres://..." HABITAT_API_KEY="$(openssl rand -hex 32)" \
+  -a umwelten-habitat
+
+# 5. First deploy — build from monorepo root (see Section 6).
+fly deploy --dockerfile packages/habitat/Dockerfile -a umwelten-habitat
+```
+
+Notes:
+
+- **`fly launch` overwrites fly.toml.** Treat any `fly launch` re-run as destructive to your hand-edited `[build]`/`[mounts]`/autostop settings. Diff the file afterward.
+- `fly volumes create` with `--size N` creates an `N` GB volume; it must be in the same region as the machine that will mount it.
+- Setting secrets before the first deploy means they're present at first boot.
+
+---
+
+## 5. Verifying the deployed container
+
+```bash
+# App + machine state, region, and (when expanded) mounts
+fly status -a umwelten-habitat
+fly status --all -a umwelten-habitat
+
+# Live logs — confirm `habitat serve` bound to 0.0.0.0:8080 and secrets loaded
+fly logs -a umwelten-habitat
+
+# Confirm the volume exists and is attached to the machine
+fly volumes list -a umwelten-habitat
+#   -> shows the volume id, name (habitat_data), size, region, and ATTACHED machine id
+
+# Inspect a machine to see its mounts and config
+fly machine list -a umwelten-habitat
+fly machine status <machine-id> -a umwelten-habitat
+
+# Hit the public health/A2A endpoint (force_https is on)
+curl -i https://umwelten-habitat.fly.dev/health
+
+# Authenticated A2A surface — bearer token = the HABITAT_API_KEY secret
+curl -i https://umwelten-habitat.fly.dev/.well-known/agent.json \
+  -H "Authorization: Bearer $HABITAT_API_KEY"
+
+# Confirm secrets are present (names only, never values)
+fly secrets list -a umwelten-habitat
+
+# Optional: open a shell on the machine and verify the mount + persisted token
+fly ssh console -a umwelten-habitat
+#   then inside: ls -la /data && mount | grep /data
+```
+
+What "good" looks like:
+
+- `fly status` shows **one** machine, state `started`, in your primary region, and (with `--all`/machine status) a mount at `/data`.
+- `fly volumes list` shows `habitat_data` **attached** to that machine.
+- `fly logs` shows the server listening on port 8080 and no "secret undefined" errors.
+- The health endpoint returns 200 over HTTPS; the A2A endpoint rejects unauthenticated requests and accepts the bearer token.
+
+---
+
+## 6. Building from a non-root context (the monorepo question)
+
+**This is the subtle one.** From [App configuration](https://fly.io/docs/reference/configuration/) and the [monorepo guide](https://fly.io/docs/launch/monorepo/):
+
+- The **build context** (the files shipped to the builder) defaults to the **project root** — i.e., the directory `fly deploy` runs from (or its `[WORKING_DIRECTORY]` argument).
+- The `[build] dockerfile` field / `--dockerfile` flag only chooses **which Dockerfile** to use. Per the docs: *"This option will not change the Docker context path."*
+
+So the two knobs are independent:
+
+- **Working directory argument** → sets the build context (what files Docker can see).
+- **`--dockerfile`** → which Dockerfile, **relative to that working directory**.
+
+### Recommended for this repo
+
+Run from the **monorepo root** and point at the nested Dockerfile with the flag:
+
+```bash
+# cwd = monorepo root  => build context = monorepo root (entire pnpm workspace)
+fly deploy --dockerfile packages/habitat/Dockerfile -a umwelten-habitat
+```
+
+This gives the Dockerfile access to the whole workspace (root `pnpm-workspace.yaml`, `package.json`, all `packages/*`) while building from `packages/habitat/Dockerfile`. The Dockerfile's `COPY` paths are relative to the **root**, e.g. `COPY packages/habitat ./packages/habitat`.
+
+**Does `[build] dockerfile = "packages/habitat/Dockerfile"` in fly.toml alone work?** It selects the right Dockerfile, and because the docs state the context defaults to the project root, running `fly deploy` from the monorepo root *should* keep the root as context. **But** the reliable, documented pattern is the explicit `--dockerfile` flag run from the root — the config-file `[build] dockerfile` field is less consistently honored for context across flyctl behavior, and the monorepo docs only demonstrate the CLI flag. Use the flag; keep the fly.toml field too for documentation, but don't rely on it alone.
+
+**Anti-pattern to avoid:** `fly deploy packages/habitat` (passing the subdir as the working directory). That would make `packages/habitat` the build context, and the Dockerfile would lose access to the rest of the workspace — breaking any `pnpm install` that needs the root lockfile/workspace.
+
+Ensure the **root `.dockerignore`** does not exclude `packages/`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml`.
+
+---
+
+## Quick reference checklist
+
+- [ ] `fly.toml`: `[build] dockerfile = "packages/habitat/Dockerfile"`, `[mounts]` source `habitat_data` → `/data`, `[http_service]` `internal_port = 8080` + `force_https`.
+- [ ] `auto_stop_machines = "off"`, `auto_start_machines = false`, `min_machines_running = 1` (never scale this stateful service to zero).
+- [ ] Volume created in the **same region** as `primary_region`.
+- [ ] All credentials via `fly secrets set` (one batched call); only non-sensitive config in `[env]`.
+- [ ] Rotated OAuth refresh token written to a file on the **volume** (`/data/...`), with Postgres as the durable backstop; initial token seeded as a secret.
+- [ ] Deploy from monorepo root: `fly deploy --dockerfile packages/habitat/Dockerfile`.
+- [ ] Re-diff `fly.toml` after any `fly launch` (it overwrites your edits).
+- [ ] Verify with `fly status`, `fly volumes list`, `fly logs`, and an authenticated curl to the A2A endpoint.
+
+---
+
+## Sources
+
+1. [App configuration (fly.toml) reference — Fly Docs](https://fly.io/docs/reference/configuration/)
+2. [Volumes overview — Fly Docs](https://fly.io/docs/volumes/overview/)
+3. [App secrets — Fly Docs](https://fly.io/docs/apps/secrets/)
+4. [Autostop/autostart Machines — Fly Docs](https://fly.io/docs/launch/autostop-autostart/)
+5. [Monorepo and multi-environment deployments — Fly Docs](https://fly.io/docs/launch/monorepo/)
+6. [Create and launch a new app — Fly Docs](https://fly.io/docs/launch/create/)
+7. [flyctl deploy command reference — Fly Docs](https://fly.io/docs/flyctl/deploy/)
+8. [Resilient apps use multiple Machines — Fly Docs](https://fly.io/docs/blueprints/resilient-apps-multiple-machines/)
+9. [Keeping a minimum number of instances running — Fly.io Community](https://community.fly.io/t/setting-a-minimum-number-of-instances-to-keep-running-when-using-auto-start-stop/12861)
+10. [Deploying a monorepo application from the root directory — Fly.io Community](https://community.fly.io/t/how-to-correctly-deploy-a-monorepo-application-from-the-root-directory/25592)

--- a/reports/2026-06-18-gaia-deployment-and-habitat-orchestration.md
+++ b/reports/2026-06-18-gaia-deployment-and-habitat-orchestration.md
@@ -1,0 +1,153 @@
+# Gaia deployment & how it spins up habitats
+
+> Research note — 2026-06-18. Context: issue #155 ("Twitter habitat: fly.toml +
+> container deploy config + runbook") assumes a standalone fly.io deploy, but the
+> question on the table is whether the Twitter habitat should instead be spun up
+> and coordinated by **Gaia**. This note documents how Gaia actually works today
+> (from the code), where it can run, and what each path means for #155.
+
+## TL;DR
+
+- **Gaia spins up habitats by shelling out to the `docker` CLI on its own host.**
+  It builds the `habitat` image, creates a named volume, seeds `config.json` +
+  filtered `secrets.json` into it, and `docker run`s the image on a private
+  `gaia-net` network with a localhost-only port (7440–7499) and an injected
+  `HABITAT_API_KEY`. This is fully built and documented (`docs/guide/gaia-orchestrator.md`).
+- **Therefore Gaia must run on a host where it controls a Docker daemon** — a VPS
+  ("our own server") or a **GCE VM**, with Docker installed. It **cannot** run on
+  fly.io or GCP Cloud Run / Vercel / Lambda, because those don't give a process the
+  ability to spawn sibling containers.
+- **There is no existing production deploy artifact for Gaia.** Today it's a
+  dev/local tool launched with `pnpm run cli habitat gaia`. No `fly.toml`, no
+  compose file, no systemd unit, no decision recorded. The aspirational
+  multi-target story in `docs/architecture/habitat-deployment.md` (a `habitat deploy
+  --target gcp|fly|vps|...` command, RuntimeTarget adapters) is **mostly unbuilt**.
+- **Two real, divergent deploy paths exist for the Twitter habitat** (details below).
+  #155 only scoped the standalone one. Picking the Gaia path changes the deliverable.
+
+## How Gaia spins up a habitat (from the code)
+
+Source: `packages/habitat/src/tools/gaia/{gaia.ts,docker.ts,gaia-tools/habitats.ts,gaia-tools/seed-files.ts}`.
+
+1. **Gaia is itself a normal habitat.** `Gaia.start()` (`gaia.ts`) boots a
+   `startContainerServer` on **7420** with the standard container tool sets **plus**
+   a `gaiaToolSet` of ~14 orchestrator tools. So Gaia gets sessions, MCP, A2A,
+   artifacts, and bearer auth for free.
+2. **It owns a `DockerManager`** (`docker.ts`) constructed with `(dataDir, projectRoot)`.
+   `projectRoot` is the umwelten repo root — used as the `docker build` context.
+3. **`create_habitat`** (`gaia-tools/habitats.ts`) writes a registry entry, generates
+   a `gaia_`-prefixed API key, and seeds the volume.
+4. **`buildSeedFiles`** (`seed-files.ts`) produces exactly **two files**:
+   `config.json` (the habitat config) and `secrets.json` (only the master-vault
+   secrets bound to this habitat). **It does not seed custom `tools/` or `src/` code.**
+5. **`start_habitat` → `DockerManager.startContainer`** runs:
+   ```
+   docker run -d --name gaia-<id> --network gaia-net \
+     -v gaia-<id>-data:/data \
+     -v <gaiaDataDir>/sessions/<id>:/data/sessions \
+     --env HABITAT_API_KEY=<entry.apiKey> \
+     -p 127.0.0.1:<7440-7499>:8080 \
+     <image>            # default "habitat", or entry.image
+   ```
+6. The container's `entrypoint.sh` runs at boot. If `config.json` has a `gitUrl`,
+   it **clones that repo into `/data/project/`** and runs `mise install`. Then it
+   `exec`s `habitat serve --port 8080`.
+
+### Two ways a custom-code habitat (like Twitter) gets its tools in
+
+The default seed is config + secrets only, so the Twitter habitat's `tools/` +
+`src/` must arrive one of two ways:
+
+- **(A) Git provisioning** — `create_habitat` with a `gitUrl`; the entrypoint clones
+  the agent repo into `/data/project/`. This is the documented "production agents
+  live in their own repo with custom tools/skills/persona" path
+  (`gaia-orchestrator.md` Part 12). It would require the Twitter habitat work dir
+  to be its own git repo (or a subdir the entrypoint can target).
+- **(B) Custom image** — `create_habitat({ image: "twitter-habitat" })`. Gaia runs a
+  pre-built image that bakes the work dir in, instead of the default `habitat`
+  image. The image must already exist on the host (`docker.ts` hard-errors if a
+  named `entry.image` is missing — it only auto-builds the default `habitat` image).
+
+## Where Gaia can run
+
+Gaia's whole job is `docker build` / `docker run` / `docker volume` / `docker network`
+against a daemon. So:
+
+| Target | Can host Gaia? | Why |
+|---|---|---|
+| **Our own server / VPS** (Docker installed) | ✅ Best fit | Gaia drives the host daemon directly; sibling containers + named volumes + `gaia-net` all work as designed. |
+| **GCE VM** (Docker installed) | ✅ Same as VPS | Identical model; just GCP-hosted. Pick a machine type with enough RAM for N child containers (each `[[vm]]` analog is ~1 GB). |
+| **GCP Cloud Run** | ❌ | No Docker daemon; filesystem ephemeral; can't spawn sibling containers. |
+| **fly.io** | ❌ for Gaia | A fly *machine* is itself a container; you don't get a host daemon to spawn siblings on. (fly is fine for a *single* habitat — see below — just not for the orchestrator.) |
+| **Vercel / Lambda** | ❌ | Serverless, no Docker. |
+
+**Containerizing Gaia itself** is possible via Docker-out-of-Docker: run the
+`habitat` image (it already installs the Docker CLI — see the Dockerfile comment
+"for Gaia to manage child containers via mounted socket") with
+`-v /var/run/docker.sock:/var/run/docker.sock`. Gotcha: Gaia bind-mounts a host
+sessions dir into each child (`hostSessionsDir`), and those paths are resolved by
+the **host** daemon — so when Gaia runs in a container the bind paths must line up
+with host paths. Simplest first deploy is to run Gaia **directly on the VM** (under
+systemd / `pnpm run cli habitat gaia`), not containerized.
+
+## What this means for issue #155 — two divergent paths
+
+### Path 1 — Standalone single container (what #155 / PRD #149 scoped)
+
+The Twitter habitat is its **own** deployable service. Work dir (config + STIMULUS
++ tools + src) baked into a custom image; a volume for `secrets.json`/sessions so
+the rotated X refresh token survives restarts; `HABITAT_API_KEY` bearer auth on
+`/a2a`. The habitats SaaS attaches to its A2A endpoint **directly**. Gaia is not
+involved. Mirrors the existing `examples/twitter-mcp` and `examples/oura-mcp` fly
+apps. Host can be fly.io **or** a VPS/GCE VM via `docker run` / compose — the image
+is host-agnostic.
+
+- ✔ Matches the ticket and the PRD exactly; smallest, self-contained.
+- ✔ The SaaS attach flow (A2A endpoint + bearer) already exists end-to-end.
+- ✘ Doesn't give you a coordination layer; each agent is an island.
+
+### Path 2 — Gaia-orchestrated (what the question is really about)
+
+Deploy **Gaia** on a Docker host (own server / GCE VM). The Twitter habitat becomes
+a Gaia-managed container — provisioned by git (A) or a custom image (B), started on
+`gaia-net` at a localhost port. Coordination, secret isolation, multi-habitat A2A
+fan-out, and the dashboard all come from Gaia.
+
+- ✔ Real coordination substrate; add more habitats later with no new infra.
+- ✔ Secret isolation via the master vault; one place to manage many agents.
+- ✘ **New, unscoped work:** Gaia has no production deploy artifact today. Need to
+  (1) stand up the host, (2) deploy Gaia (systemd unit or socket-mounted container),
+  (3) decide git-provisioning vs custom-image for Twitter's tools, (4) expose the
+  habitats SaaS to the Twitter habitat **through Gaia's proxy** (`/api/habitats/twitter/a2a`)
+  or publish the child port — the SaaS currently expects a direct A2A endpoint.
+- ✘ Child containers bind to `127.0.0.1` only; reaching them from outside the host
+  needs Gaia's proxy or a reverse proxy in front.
+
+### They're not mutually exclusive
+
+The same `habitat` image + the same work dir power both. You can ship Path 1 now
+(standalone Twitter agent the SaaS chats with) and adopt Path 2 later (move it under
+a Gaia you stand up), because the container is identical — only the wrapper differs.
+
+## Open decisions (for the human)
+
+1. **Is #155 still "standalone fly.io," or has the target shifted to a Gaia we
+   stand up on our own server / GCE VM?** This decides whether the deliverable is a
+   `fly.toml` + runbook, a `docker-compose`/systemd + runbook, or a Gaia-deploy +
+   register-Twitter runbook.
+2. **If Gaia: own server or GCE VM?** Both work identically; choice is operational
+   (where the Neon DB + other services already live, cost, who administers the box).
+3. **If Gaia: git-provisioning (A) or custom image (B) for Twitter's tools?** (A) needs
+   the work dir to be a git repo; (B) needs an out-of-band image build + push.
+4. **External reachability of a Gaia-managed Twitter habitat** for the habitats SaaS:
+   through Gaia's `/api/habitats/:id/a2a` proxy, or expose the child port directly?
+
+## Sources
+
+- `packages/habitat/src/tools/gaia/gaia.ts` — orchestrator boot.
+- `packages/habitat/src/tools/gaia/docker.ts` — `DockerManager` (build/run/seed/volume).
+- `packages/habitat/src/tools/gaia/gaia-tools/{habitats.ts,seed-files.ts}` — create/start, seed files.
+- `packages/habitat/Dockerfile`, `entrypoint.sh` — the shared habitat image; git provisioning.
+- `docs/guide/gaia-orchestrator.md` — the operator guide (authoritative on the runtime model).
+- `docs/architecture/habitat-deployment.md` — aspirational multi-target deploy (mostly unbuilt).
+- Prior art: `examples/twitter-mcp/{fly.toml,Dockerfile}`, `examples/oura-mcp/{fly.toml,Dockerfile}`.

--- a/scripts/smoke-twitter-habitat.sh
+++ b/scripts/smoke-twitter-habitat.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Smoke check for the twitter-habitat image (#155, PRD #149). Not part of the
+# unit suite — needs Docker and ~5 minutes on a cold build.
+#
+#   scripts/smoke-twitter-habitat.sh             # build base + twitter image, boot, assert
+#   SKIP_BUILD=1 scripts/smoke-twitter-habitat.sh    # reuse existing images
+#
+# Asserts:
+#   1. image builds from the habitat base
+#   2. container boots the container server; /health is OK; bearer auth gates /api/*
+#   3. the agent card is served (name "Twitter")
+#   4. work dir seeded onto the volume: tools/, src/, STIMULUS.md, and the
+#      node_modules symlink that makes the tool's `ai`/`zod`/`../../src` resolve
+#   5. config.json points at the seeded assets (toolsDir/stimulusFile)
+#   6. the `bookmarks` work-dir tool actually loads (imports resolve in-container)
+#   7. volume contents survive a stop/start; seeds are not destructively re-stamped
+
+IMAGE_BASE="${IMAGE_BASE:-habitat}"
+IMAGE="${IMAGE:-twitter-habitat}"
+NAME="smoke-twitter-habitat"
+VOLUME="smoke-twitter-habitat-data"
+PORT="${PORT:-7438}"
+API_KEY="smoke-key-123"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1" >&2; cleanup; exit 1; }
+
+cleanup() {
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+  docker volume rm "$VOLUME" >/dev/null 2>&1 || true
+}
+
+cexec() { docker exec "$NAME" "$@"; }
+
+echo "── 1. build"
+# BuildKit is required so the per-Dockerfile ignore
+# (Dockerfile.twitter-habitat.dockerignore) is honored and examples/ is included.
+export DOCKER_BUILDKIT=1
+if [ -z "${SKIP_BUILD:-}" ]; then
+  docker image inspect "$IMAGE_BASE" >/dev/null 2>&1 \
+    || docker build -t "$IMAGE_BASE" -f packages/habitat/Dockerfile .
+  docker build -t "$IMAGE" -f packages/habitat/Dockerfile.twitter-habitat \
+    --build-arg "BASE_IMAGE=$IMAGE_BASE" .
+fi
+pass "image $IMAGE built (base: $IMAGE_BASE)"
+
+cleanup
+docker volume create "$VOLUME" >/dev/null
+docker run -d --name "$NAME" -v "$VOLUME:/data" \
+  -e "HABITAT_API_KEY=$API_KEY" -p "127.0.0.1:$PORT:8080" "$IMAGE" >/dev/null
+
+echo "── 2. boot + auth"
+for i in $(seq 1 60); do
+  if curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then break; fi
+  if [ "$i" = 60 ]; then docker logs "$NAME" | tail -30; fail "server did not become healthy in 60s"; fi
+  sleep 1
+done
+curl -sf "http://127.0.0.1:$PORT/health" | grep -q '"status":"ok"' || fail "/health not ok"
+pass "/health ok"
+[ "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/api/contexts/smoke")" = "401" ] \
+  || fail "unauthenticated gated /api/* not rejected"
+[ "$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $API_KEY" "http://127.0.0.1:$PORT/api/contexts/smoke")" = "404" ] \
+  || fail "bearer-authenticated gated /api/* not served"
+pass "bearer auth gates registered /api/* routes"
+
+echo "── 3. agent card"
+curl -sf -H "Authorization: Bearer $API_KEY" "http://127.0.0.1:$PORT/.well-known/agent-card.json" \
+  | grep -q '"name":"Twitter"' || fail "agent card not served / wrong name"
+pass "A2A agent card served (Twitter)"
+
+echo "── 4. volume seeding"
+cexec test -f /data/tools/bookmarks/handler.ts || fail "tools/ not seeded"
+cexec test -f /data/src/token-store.ts || fail "src/ not seeded"
+cexec test -f /data/STIMULUS.md || fail "STIMULUS.md not seeded"
+cexec test -L /data/node_modules || fail "/data/node_modules symlink missing"
+cexec test -e /data/node_modules/ai || fail "ai not resolvable via the node_modules symlink"
+pass "tools/, src/, STIMULUS.md seeded; node_modules symlinked to monorepo deps"
+
+echo "── 5. config seeded"
+cexec node -e 'const c=JSON.parse(require("fs").readFileSync("/data/config.json","utf8")); if(c.toolsDir!=="tools"||c.stimulusFile!=="STIMULUS.md") process.exit(1)' \
+  || fail "config.json toolsDir/stimulusFile not seeded"
+pass "config.json points at toolsDir/stimulusFile"
+
+echo "── 6. bookmarks tool loads"
+# The work-dir tool is loaded via dynamic import of its .ts handler; if the
+# node_modules symlink were wrong its `ai`/`zod`/`../../src` imports would throw
+# and the loader would warn "failed to load handler". Assert no such warning.
+if docker logs "$NAME" 2>&1 | grep -qi "failed to load handler"; then
+  docker logs "$NAME" 2>&1 | grep -i "failed to load handler" | tail -5
+  fail "bookmarks handler failed to load (import resolution broken)"
+fi
+pass "no handler-load failures (bookmarks tool imports resolve)"
+
+echo "── 7. stop/start persistence"
+cexec sh -c 'echo smoke-marker > /data/sessions/smoke-marker.txt'
+cexec sh -c 'printf "{\"TWITTER_REFRESH_TOKEN\":\"rotated-xyz\"}" > /data/secrets.json'
+docker restart "$NAME" >/dev/null
+for i in $(seq 1 60); do
+  if curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then break; fi
+  if [ "$i" = 60 ]; then fail "server did not come back after restart"; fi
+  sleep 1
+done
+[ "$(cexec cat /data/sessions/smoke-marker.txt)" = "smoke-marker" ] || fail "volume contents lost across restart"
+cexec grep -q "rotated-xyz" /data/secrets.json || fail "rotated refresh token lost across restart"
+pass "volume survives restart; rotated refresh token persists"
+
+cleanup
+echo ""
+echo "PASS — twitter-habitat image smoke check complete."


### PR DESCRIPTION
Closes #155. Parent PRD: #149.

## What this is

A **scope pivot** decided with the maintainer (2026-06-18): instead of a standalone fly.io deploy, the Twitter habitat is deployed **under Gaia** — Gaia runs as a single container and spins up the Twitter habitat as a managed sibling container, becoming the coordination layer for this and future habitats. fly.io / plain `docker run` remain documented **standalone** alternatives (the same image powers all three). Background research: `reports/2026-06-18-gaia-deployment-and-habitat-orchestration.md` and `reports/2026-06-18-flyio-habitat-container-deploy.md`.

## How it works

Gaia orchestrates by shelling out to the host's `docker` CLI; it seeds each child's volume with only `config.json`+`secrets.json`. So the Twitter habitat ships as a **specialized image** (`Dockerfile.twitter-habitat`, mirroring `Dockerfile.coding-agent`) that, on every boot:
- seeds `tools/` + `src/` + `STIMULUS.md` onto `/data`,
- **symlinks `/data/node_modules → /habitat/node_modules`** so the work-dir tool's `ai`/`zod`/`../../src` imports resolve in-container (the loader uses ESM `import()`, which resolves bare specifiers from the handler's path),
- merges `toolsDir`/`stimulusFile` into the Gaia-seeded `config.json` (idempotent; preserves Gaia's name/provider/model/secret fields).

The rotated X refresh token persists to `secrets.json` on the named volume, so it survives restarts.

Containerized Gaia (`deploy/gaia/docker-compose.yml`) needs two non-obvious things, both handled + documented: **host networking** (Gaia reaches children at `127.0.0.1:<port>`) and an **identity bind-mount** of the data dir (child session bind-paths are resolved by the host daemon).

## Files
- `packages/habitat/Dockerfile.twitter-habitat` + `.dockerignore` (re-includes `examples/`, which the root `.dockerignore` excludes — BuildKit per-Dockerfile ignore)
- `packages/habitat/twitter-habitat/{entrypoint.sh,seed-config.mjs}`
- `deploy/gaia/{docker-compose.yml,.env.example,README.md}` (the runbook)
- `scripts/smoke-twitter-habitat.sh`
- `packages/habitat/src/twitter-habitat-seed.test.ts`
- `reports/2026-06-18-*.md`

## Verification

**Automated (run here):**
```bash
pnpm test:run        # 1444 passed, incl. 4 new seed-config tests
```
- `docker compose -f deploy/gaia/docker-compose.yml config` → valid
- `bash -n scripts/smoke-twitter-habitat.sh`, `sh -n .../entrypoint.sh` → clean

> ⚠️ The **Docker image build + smoke script were NOT run here** — no Docker daemon in this environment. They must be run on a Docker host. Steps below are copy-pastable.

### Acceptance criteria

- [ ] **`Dockerfile.twitter-habitat` builds on the `habitat` base + seeds the work dir on boot**
  ```bash
  docker build -t habitat -f packages/habitat/Dockerfile .
  docker build -t twitter-habitat -f packages/habitat/Dockerfile.twitter-habitat .   # BuildKit
  docker run -d --name t -v t-data:/data -e HABITAT_API_KEY=k -p 127.0.0.1:7438:8080 twitter-habitat
  docker exec t sh -c 'ls /data/tools/bookmarks /data/src && test -L /data/node_modules && echo SEEDED'
  ```
- [ ] **`deploy/gaia/docker-compose.yml` runs Gaia w/ docker socket + persistent data + bearer-authed child A2A** — follow `deploy/gaia/README.md` §0–§2; `curl -s localhost:7420/health` shows `"docker":true`.
- [ ] **Twitter habitat boots (under Gaia or standalone), serves the agent card + authenticated `/a2a`, bookmarks tool loaded**
  ```bash
  curl -s -H "Authorization: Bearer k" http://127.0.0.1:7438/.well-known/agent-card.json | jq .name   # "Twitter"
  docker logs t 2>&1 | grep -i "failed to load handler" && echo "BAD" || echo "tools loaded"
  ```
  Under Gaia: `curl -s localhost:7420/api/habitats/twitter/agent-card | jq .name` and ask in Gaia chat *"Ask twitter to show my recent bookmarks."*
- [ ] **Required secrets documented in a runbook; covers refresh-token volume persistence + reaching via Gaia's proxy** — `deploy/gaia/README.md` §3 (secrets), §5 (restart test), §6 (SaaS via `/api/habitats/twitter/a2a`).
- [ ] **Smoke script verifies boot + stop/start survival**
  ```bash
  scripts/smoke-twitter-habitat.sh            # cold: builds base + twitter, ~5 min
  SKIP_BUILD=1 scripts/smoke-twitter-habitat.sh   # reuse images
  ```
- [ ] **`pnpm test:run` passes** ✅ (1444 passed)

## Worth knowing / follow-ups
- **Build + smoke unverified in CI here** (no Docker) — needs a run on a Docker host before merge confidence. The node_modules-symlink import-resolution is the riskiest piece; the smoke script's step 6 is designed to catch it.
- **Containerized Gaia is Linux-only** (host networking). macOS/Docker Desktop should use the standalone path (runbook last section).
- **Neon feed reader (#153)** isn't merged yet; the image bakes whatever is in `examples/twitter-habitat/src` at build time, so bookmarks (private/X-OAuth) works today and public feed tools light up once #153 lands and `DATABASE_URL` is bound.
- **SaaS reachability** defaults to Gaia's proxy; direct child-port exposure is documented as an alternative. Putting TLS (Caddy/nginx) in front of Gaia is left to the operator.
