### PR TITLE
feat(habitat): consume verified A2A user end-to-end (ADR 0003 step 2) (#164)

### DIFF
--- a/packages/habitat/src/a2a-handler.ts
+++ b/packages/habitat/src/a2a-handler.ts
@@ -33,6 +33,7 @@ import {
 import type { AgentHost } from "./types.js";
 import type { ChannelBridge } from "./bridge/channel-bridge.js";
 import { listArtifacts, type ArtifactMeta } from "./tools/artifact-tools.js";
+import { getSpeaker } from "./identity/agent-speaker-context.js";
 
 // ── Agent card builder ────────────────────────────────────────────
 
@@ -166,8 +167,13 @@ export class HabitatAgentExecutor implements AgentExecutor {
       } satisfies A2ATask);
     }
 
-    // Use contextId as channel key for session continuity
+    // contextId = the thread (session continuity); the verified speaker =
+    // who is talking *this* turn (ADR 0003 step 2). One thread, many speakers.
     const channelKey = `a2a:${contextId}`;
+    const speaker = getSpeaker();
+    // Fall back to the thread id as identity only when unauthenticated
+    // (dev/open or legacy bearer) — there is no per-user `sub` to use.
+    const userId = speaker?.userId ?? `a2a:${contextId}`;
 
     let fullText = "";
 
@@ -176,7 +182,7 @@ export class HabitatAgentExecutor implements AgentExecutor {
 
     try {
       await this.bridge.handleMessage(
-        { channelKey, text, userId: `a2a:${contextId}` },
+        { channelKey, text, userId, displayName: speaker?.displayName },
         {
           onText: (delta) => {
             // Emit working status with incremental text

--- a/packages/habitat/src/bridge/channel-bridge-identity.test.ts
+++ b/packages/habitat/src/bridge/channel-bridge-identity.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for per-user identity in ChannelBridge (ADR 0003 step 2):
+ * - userId is set on EVERY message (the current speaker), not just at
+ *   entry creation, so multi-speaker threads attribute per turn;
+ * - a thread with >1 speaker labels each user turn;
+ * - a single-speaker thread is unchanged (no label);
+ * - the participant set is persisted to session metadata.
+ *
+ * Interaction is mocked so the default path doesn't hit a real LLM.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Shape we assert against (the real class is defined inside the mock factory).
+interface FakeInteractionShape {
+  userId: string;
+  messages: Array<{ role: string; content: unknown }>;
+  userIdAtGeneration: string[];
+}
+
+// Capture every Interaction the bridge constructs, plus the userId observed
+// at each streamText (i.e. at generation time, per turn). Declared via
+// vi.hoisted so it's available inside the hoisted vi.mock factory.
+const { instances } = vi.hoisted(() => ({
+  instances: [] as FakeInteractionShape[],
+}));
+
+vi.mock("@umwelten/core/interaction/core/interaction.js", () => {
+  class FakeInteraction {
+    userId = "default";
+    modelDetails: unknown;
+    messages: Array<{ role: string; content: unknown }> = [];
+    onTranscriptUpdate: ((m: unknown) => void) | undefined;
+    userIdAtGeneration: string[] = [];
+    constructor(modelDetails: unknown, _stimulus: unknown) {
+      this.modelDetails = modelDetails;
+      instances.push(this);
+    }
+    addMessage(m: { role: string; content: unknown }) {
+      this.messages.push(m);
+    }
+    getMessages() {
+      return this.messages;
+    }
+    setOnTranscriptUpdate(cb: (m: unknown) => void) {
+      this.onTranscriptUpdate = cb;
+    }
+    async streamText() {
+      this.userIdAtGeneration.push(this.userId);
+      return { content: "reply", metadata: undefined };
+    }
+  }
+  return { Interaction: FakeInteraction };
+});
+
+import { ChannelBridge } from "./channel-bridge.js";
+import { Stimulus } from "@umwelten/core/stimulus/stimulus.js";
+import type { AgentHost } from "../types.js";
+
+async function makeFixture() {
+  const workDir = await mkdtemp(join(tmpdir(), "bridge-identity-"));
+  const sessionDir = join(workDir, "sessions", "sess-1");
+  await mkdir(sessionDir, { recursive: true });
+  // Empty routing → resolves to the main persona on the default runtime.
+  await writeFile(join(workDir, "routing.json"), JSON.stringify({ channels: {} }));
+
+  const updateSessionMetadata = vi.fn(async () => {});
+  const host = {
+    workDir,
+    getDefaultModelDetails: () => ({ name: "test-model", provider: "test" }),
+    getStimulus: async () => new Stimulus({ role: "test assistant" }),
+    getAgents: () => [],
+    getAgent: () => undefined,
+    getOrCreateSession: async () => ({ sessionId: "sess-1", sessionDir }),
+    updateSessionMetadata,
+  } as unknown as AgentHost;
+
+  return { host, sessionDir, updateSessionMetadata };
+}
+
+describe("ChannelBridge per-user identity (ADR 0003 step 2)", () => {
+  it("single-speaker thread: userId set, no labeling", async () => {
+    instances.length = 0;
+    const { host } = await makeFixture();
+    const bridge = new ChannelBridge(host, {});
+
+    await bridge.handleMessage(
+      { channelKey: "a2a:ctx-1", text: "hello", userId: "u1" },
+      { onDone: () => {} },
+    );
+    await bridge.handleMessage(
+      { channelKey: "a2a:ctx-1", text: "again", userId: "u1" },
+      { onDone: () => {} },
+    );
+
+    // Same channelKey → one cached interaction.
+    expect(instances).toHaveLength(1);
+    const i = instances[0];
+    expect(i.userId).toBe("u1");
+    // No labels for a single speaker.
+    expect(i.messages.map((m) => m.content)).toEqual(["hello", "again"]);
+  });
+
+  it("multi-speaker thread: per-turn userId + labeled turns", async () => {
+    instances.length = 0;
+    const { host, updateSessionMetadata } = await makeFixture();
+    const bridge = new ChannelBridge(host, {});
+
+    await bridge.handleMessage(
+      { channelKey: "a2a:ctx-2", text: "hi", userId: "u1" },
+      { onDone: () => {} },
+    );
+    await bridge.handleMessage(
+      {
+        channelKey: "a2a:ctx-2",
+        text: "my turn",
+        userId: "u2",
+        displayName: "Bob",
+      },
+      { onDone: () => {} },
+    );
+
+    expect(instances).toHaveLength(1);
+    const i = instances[0];
+
+    // userId reflects the CURRENT speaker at each generation, not the creator.
+    expect(i.userIdAtGeneration).toEqual(["u1", "u2"]);
+    expect(i.userId).toBe("u2");
+
+    // Second speaker's turn is labeled (by displayName); first stays bare.
+    expect(i.messages.map((m) => m.content)).toEqual(["hi", "[Bob]: my turn"]);
+
+    // Participant set persisted to session metadata.
+    expect(updateSessionMetadata).toHaveBeenCalledWith("sess-1", {
+      metadata: { participants: ["u1", "u2"] },
+    });
+  });
+
+  it("labels by userId when no displayName is given", async () => {
+    instances.length = 0;
+    const { host } = await makeFixture();
+    const bridge = new ChannelBridge(host, {});
+
+    await bridge.handleMessage(
+      { channelKey: "a2a:ctx-3", text: "one", userId: "alice" },
+      { onDone: () => {} },
+    );
+    await bridge.handleMessage(
+      { channelKey: "a2a:ctx-3", text: "two", userId: "bob" },
+      { onDone: () => {} },
+    );
+
+    const i = instances[0];
+    expect(i.messages.map((m) => m.content)).toEqual(["one", "[bob]: two"]);
+  });
+});

--- a/packages/habitat/src/bridge/channel-bridge.ts
+++ b/packages/habitat/src/bridge/channel-bridge.ts
@@ -37,6 +37,12 @@ interface InteractionEntry {
   sessionId: string;
   sessionDir: string;
   routeSig: string;
+  /**
+   * Distinct speakers seen on this thread (ADR 0003 step 2). One contextId
+   * can carry many speakers; once there is more than one, user turns are
+   * labeled so the agent can disambiguate "my" and address people by name.
+   */
+  participants: Set<string>;
 }
 
 // ── ChannelBridge ────────────────────────────────────────────────────
@@ -138,6 +144,25 @@ export class ChannelBridge {
       const entry = await this.getOrCreateEntry(msg);
       const { interaction, sessionId, sessionDir } = entry;
 
+      // Per-turn speaker (ADR 0003 step 2): set userId on EVERY message, not
+      // just at entry creation, so the *current* speaker — not just the thread
+      // creator — is attributed, forwarded to providers, and seen by per-user
+      // tools. Track distinct speakers; a newly-seen one is persisted to
+      // session metadata (best-effort) for host-side attribution.
+      if (msg.userId) {
+        interaction.userId = msg.userId;
+        if (!entry.participants.has(msg.userId)) {
+          entry.participants.add(msg.userId);
+          void this.host
+            .updateSessionMetadata(sessionId, {
+              metadata: { participants: [...entry.participants] },
+            })
+            .catch(() => {
+              /* non-fatal — session dir may not exist in some test scenarios */
+            });
+        }
+      }
+
       // Wire transcript persistence (no more event extraction here — the
       // StreamObserver below receives events directly from the runner).
       const originalCallback = interaction.onTranscriptUpdate;
@@ -165,8 +190,15 @@ export class ChannelBridge {
         },
       };
 
-      // Add the user message
-      interaction.addMessage({ role: 'user', content: msg.text });
+      // Add the user message. In a multi-speaker thread, label the turn with
+      // the speaker so the agent can attribute it; single-speaker threads are
+      // unchanged (no label).
+      const multiSpeaker = entry.participants.size > 1;
+      const userContent =
+        multiSpeaker && msg.userId
+          ? `[${msg.displayName ?? msg.userId}]: ${msg.text}`
+          : msg.text;
+      interaction.addMessage({ role: 'user', content: userContent });
 
       // Stream the response
       let response;
@@ -437,6 +469,9 @@ export class ChannelBridge {
       sessionId: session.sessionId,
       sessionDir: session.sessionDir,
       routeSig: sig,
+      // Populated per-turn by handleMessage (the single owner of speaker
+      // tracking), so the first speaker is persisted uniformly with the rest.
+      participants: new Set<string>(),
     };
     this.cache.set(channelKey, entry);
     return entry;

--- a/packages/habitat/src/bridge/types.ts
+++ b/packages/habitat/src/bridge/types.ts
@@ -37,6 +37,11 @@ export interface ChannelMessage {
   /** Stable user identifier (for provider analytics, not PII). */
   userId?: string;
   /**
+   * Display name of the speaker, when known (e.g. from a verified A2A grant).
+   * Used to label turns in multi-speaker threads.
+   */
+  displayName?: string;
+  /**
    * Parent channel key — used for thread-based routing inheritance.
    * e.g. a Discord thread inherits its parent channel's agent binding.
    */

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -31,6 +31,7 @@ import type { AgentHost } from "./types.js";
 import { resolveProjectDir, saveConfig, fileExists } from "./config.js";
 import { listArtifacts } from "./tools/artifact-tools.js";
 import { createA2AHandler, type A2AHandler } from "./a2a-handler.js";
+import { runWithSpeaker } from "./identity/agent-speaker-context.js";
 import { createAgentSurface } from "./agent-surface.js";
 import { buildAgentStimulus } from "./habitat-agent.js";
 import { createClaudeSdkRuntimeRunner } from "./claude-sdk-runner.js";
@@ -381,13 +382,27 @@ export async function startContainerServer(
 
 				// ── A2A endpoint ─────────────────────────────────────
 				if (path === "/a2a" && req.method === "POST") {
+					let user: UserContext | null = null;
 					if (authRequired) {
-						const user = await auth.authenticate(req);
+						user = await auth.authenticate(req);
 						if (!user) {
 							sendJson(res, { error: "Unauthorized" }, 401);
 							return;
 						}
 					}
+					// Per-user identity (ADR 0003 step 2): only the JWT path carries a
+					// real end-user `sub`. Bind it as the speaker so the executor uses
+					// it as interaction.userId. Bearer/dev have no per-user identity —
+					// leave the speaker unbound so the executor keeps its thread-scoped
+					// `a2a:${contextId}` fallback (no regression off the JWT path).
+					const speaker =
+						authMode === "jwt" && user
+							? {
+									userId: user.userId,
+									displayName: user.displayName,
+									email: user.email,
+								}
+							: undefined;
 					const addr = httpServer.address();
 					const actualPort =
 						typeof addr === "object" && addr ? addr.port : port;
@@ -409,7 +424,9 @@ export async function startContainerServer(
 					}
 
 					try {
-						const result = await handler.transportHandler.handle(parsedBody);
+						const result = await runWithSpeaker(speaker, () =>
+							handler.transportHandler.handle(parsedBody),
+						);
 						if (
 							result &&
 							typeof (result as any)[Symbol.asyncIterator] === "function"

--- a/packages/habitat/src/identity/agent-speaker-context.test.ts
+++ b/packages/habitat/src/identity/agent-speaker-context.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { runWithSpeaker, getSpeaker } from "./agent-speaker-context.js";
+
+describe("agent-speaker-context", () => {
+  it("getSpeaker is undefined at the top level", () => {
+    expect(getSpeaker()).toBeUndefined();
+  });
+
+  it("runWithSpeaker binds the speaker for the duration of fn", () => {
+    let observed: string | undefined;
+    runWithSpeaker({ userId: "user-123", displayName: "Alice" }, () => {
+      observed = getSpeaker()?.userId;
+    });
+    expect(observed).toBe("user-123");
+    // Cleared once fn returns.
+    expect(getSpeaker()).toBeUndefined();
+  });
+
+  it("carries displayName and email", () => {
+    runWithSpeaker(
+      { userId: "u1", displayName: "Bob", email: "bob@example.com" },
+      () => {
+        const s = getSpeaker();
+        expect(s?.displayName).toBe("Bob");
+        expect(s?.email).toBe("bob@example.com");
+      },
+    );
+  });
+
+  it("undefined speaker runs fn with no speaker bound (dev fallback)", () => {
+    let bound = true;
+    const result = runWithSpeaker(undefined, () => {
+      bound = getSpeaker() !== undefined;
+      return 42;
+    });
+    expect(bound).toBe(false);
+    expect(result).toBe(42);
+  });
+
+  it("follows the async call tree", async () => {
+    let inner: string | undefined;
+    await runWithSpeaker({ userId: "async-user" }, async () => {
+      await Promise.resolve();
+      inner = getSpeaker()?.userId;
+    });
+    expect(inner).toBe("async-user");
+  });
+
+  it("isolates concurrent speakers", async () => {
+    const seen: Record<string, string | undefined> = {};
+    await Promise.all([
+      runWithSpeaker({ userId: "a" }, async () => {
+        await Promise.resolve();
+        seen.a = getSpeaker()?.userId;
+      }),
+      runWithSpeaker({ userId: "b" }, async () => {
+        await Promise.resolve();
+        seen.b = getSpeaker()?.userId;
+      }),
+    ]);
+    expect(seen.a).toBe("a");
+    expect(seen.b).toBe("b");
+  });
+});

--- a/packages/habitat/src/identity/agent-speaker-context.ts
+++ b/packages/habitat/src/identity/agent-speaker-context.ts
@@ -1,0 +1,50 @@
+/**
+ * Speaker context — the verified end-user on whose behalf the current A2A
+ * request runs (ADR 0003 step 2).
+ *
+ * The habitat A2A surface authenticates a per-user signed grant (`jwtAuth`,
+ * `sub` = the speaking user) but the A2A SDK's request handler does not carry
+ * that identity into the executor. Rather than thread it through every
+ * `execute()` / `handleMessage()` signature, we stash it in an
+ * AsyncLocalStorage so it follows the async call tree — the same pattern as
+ * {@link ../identity/agent-call-context.ts} (the agent_ask recursion guard).
+ *
+ * The container server wraps `transportHandler.handle()` in
+ * {@link runWithSpeaker}; the executor reads it with {@link getSpeaker}.
+ *
+ * `contextId` (the thread) and `sub` (the speaker) are deliberately separate:
+ * one thread can carry many speakers, so the speaker is per-request, not
+ * per-session.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/** The verified speaker for the current request. */
+export interface Speaker {
+  /** Stable user id — the verified JWT `sub`. Used as `interaction.userId`. */
+  userId: string;
+  /** Display name, if the grant carried one (for speaker labeling). */
+  displayName?: string;
+  /** Email, if the grant carried one. */
+  email?: string;
+}
+
+const storage = new AsyncLocalStorage<Speaker>();
+
+/**
+ * Run `fn` with `speaker` as the current speaker. A `undefined` speaker runs
+ * `fn` with no speaker bound — preserving the unauthenticated / dev fallback
+ * (the executor then keeps its `a2a:${contextId}` identity).
+ */
+export function runWithSpeaker<T>(
+  speaker: Speaker | undefined,
+  fn: () => T,
+): T {
+  if (!speaker) return fn();
+  return storage.run(speaker, fn);
+}
+
+/** Get the current speaker, or undefined when none is bound. */
+export function getSpeaker(): Speaker | undefined {
+  return storage.getStore();
+}


### PR DESCRIPTION
Closes #164. Implements **ADR 0003 step 2** — thread the verified A2A speaker (`sub`) through the runtime instead of discarding it.

## Problem
The A2A surface verifies a per-user JWT (#163, `sub` = the speaking user), but the identity was thrown away: `container-server.ts` used the authenticated user only for the 401 check, and `HabitatAgentExecutor` derived `userId` from the caller-chosen `contextId` (`a2a:${contextId}`). Net effect: every speaker in a thread collapsed into one identity and one conversation — the structural flaw the ADR targets.

## Change
Separate **`sub` (who, per message)** from **`contextId` (which thread)**:

- **`identity/agent-speaker-context.ts`** (new) — `AsyncLocalStorage` carrying the per-request speaker `{ userId, displayName?, email? }`, mirroring the existing `agent-call-context.ts` pattern (house style for request-scoped threading).
- **`container-server.ts`** — `/a2a` wraps `transportHandler.handle()` in `runWithSpeaker(...)` using the already-authenticated user, **JWT path only**; bearer/dev keep the existing thread-scoped fallback (no regression).
- **`a2a-handler.ts`** — `HabitatAgentExecutor` reads `getSpeaker()` and uses the verified `sub` as `interaction.userId` (drops the `a2a:${contextId}`-as-identity hack), passing `displayName` through.
- **`channel-bridge.ts` / `bridge/types.ts`** — set `interaction.userId` on **every** message (per-turn speaker, fixing stale userId on cached threads), track participants as a set persisted to session metadata, and speaker-label user turns once a thread has >1 participant. Single-speaker threads are byte-for-byte unchanged.

## Acceptance criteria (#164)
- [x] JWT request → `interaction.userId === sub` (not `a2a:${contextId}`, not `bearer-user`)
- [x] Two speakers in one `contextId` attributed distinctly per message
- [x] Private/per-user tools resolve the current speaker (per-turn `userId`; runner already forwards it to providers)
- [x] Multi-speaker thread history is speaker-labeled
- [x] `pnpm test:run` passes

## Tests
9 new tests (ALS speaker-context; ChannelBridge per-turn userId + multi-speaker labeling). **`pnpm test:run` green: 1467/1467.**

> Note: the workspace `tsc` build is broken pre-existingly on `main` (an `@ai-sdk/provider` 2.0.0-vs-3.0.10 version skew across `core/`/`protocols/`); none of the files in this PR are involved. Not fixed here — out of scope.

## Follow-ups
- #165 (umwelten) — require JWT, remove the shared `HABITAT_API_KEY` path (ADR step 4)
- The-Focus-AI/habitats#54 — SaaS mints per-user JWTs + JWKS (ADR step 1, SaaS side)
- The-Focus-AI/habitats#55 — SaaS moves contextId onto a thread record (ADR step 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)