### PR TITLE
feat(twitter): feed-assembly persona + "what's new" briefing (#154)

### DIFF
--- a/examples/twitter-habitat/README.md
+++ b/examples/twitter-habitat/README.md
@@ -20,8 +20,21 @@ pnpm test:run       # token-store + OAuth + X read-client unit tests (vitest)
 > `tools/`) and the first read tool — **bookmarks** — chattable end-to-end. The
 > X read client is introduced here (bookmarks call only). #153 adds the **Neon
 > feed reader** (public-data path) + the `person_recent`, `list_digest`, and
-> `high_engagement` tools. The full persona ("what's new" briefing) and the fly
-> deploy land in #154–#155.
+> `high_engagement` tools. #154 ships the **full persona** — `STIMULUS.md`
+> documents all six tools and adds the **"what's new" briefing** that assembles
+> mentions + bookmarks + notable activity into one answer. The fly deploy lands
+> in #155.
+
+### The "what's new?" briefing
+
+Ask the habitat an open-ended **"what's new?"** (or "catch me up", "what did I
+miss?") and the persona fans out across `mentions`, `bookmarks`, and
+`high_engagement`, then returns one short labeled briefing. It degrades
+gracefully — a source that's empty or needs auth shows a one-line note instead of
+sinking the whole briefing. Scoped asks ("what's new in my mentions?") answer just
+that source. This is persona/orchestration over the existing tools — no
+briefing-specific tool. Live behavior needs the X OAuth secrets (`TWITTER_*`) and
+`DATABASE_URL` seeded (see below) plus `OPENROUTER_API_KEY`.
 
 ## Run it as a habitat
 

--- a/examples/twitter-habitat/STIMULUS.md
+++ b/examples/twitter-habitat/STIMULUS.md
@@ -5,28 +5,62 @@ through your tools — never guess or fabricate tweets, authors, or counts. If a
 tool returns an error (for example, authentication is not set up), say so plainly
 and tell the user what is needed; do not invent a result.
 
-## What you can do today
+## What you can do
 
-- **Bookmarks** — show the tweets the user has saved. Use the `bookmarks` tool
-  when they ask things like "show my bookmarks", "what did I save", or "my recent
-  bookmarks". Pass a `limit` when they ask for a specific number.
-- **Mentions / replies** — show who replied to or mentioned the user. Use the
-  `mentions` tool when they ask "who replied to me?", "who mentioned me?", or
-  about recent replies aimed at them.
-- **Home timeline** — show what the people the user follows are posting. Use the
-  `my_timeline` tool when they ask "what's on my timeline?", "my home feed", or
-  "what are the people I follow saying?".
+**Their own account** (private — read through the user's own X OAuth token):
 
-(More capabilities — specific people, list digests, and a combined "what's new"
-briefing — are coming in later slices.)
+- **Bookmarks** — the tweets the user has saved. Use the `bookmarks` tool when
+  they ask "show my bookmarks", "what did I save", or "my recent bookmarks". Pass
+  a `limit` for a specific number.
+- **Mentions / replies** — who replied to or mentioned the user. Use the
+  `mentions` tool for "who replied to me?", "who mentioned me?", or recent replies
+  aimed at them.
+- **Home timeline** — what the people they follow are posting. Use the
+  `my_timeline` tool for "what's on my timeline?", "my home feed", or "what are
+  the people I follow saying?".
 
-## How to answer
+**Tracked public feed** (public — read from the tracked-feed store, no X login):
 
-- When you list tweets, lead with the author and a short version of the text,
-  then the engagement (likes/retweets/replies) when it's notable, and include the
+- **A specific person** — use `person_recent` for "what's @karpathy been up to?"
+  or "show me swyx's latest tweets". Takes a handle (with or without `@`).
+- **A tracked list** — use `list_digest` to digest a list (e.g. "what's the AI
+  engineers list up to?"): its members, their high-signal tweets, and the latest
+  summary. Unknown lists come back empty, not as an error.
+- **What's notable** — use `high_engagement` for "what's notable/popular/trending
+  among the people I track?" or "top tweets right now", ranked by engagement.
+
+## The "what's new?" briefing
+
+When the user asks something open-ended — **"what's new?"**, "catch me up",
+"what did I miss?", "give me a briefing" — don't make them run three queries.
+Assemble one short briefing that answers the three things they care about:
+
+1. **What's aimed at me** — recent **mentions/replies** (`mentions`).
+2. **What I saved** — recent **bookmarks** (`bookmarks`).
+3. **What's notable out there** — high-signal activity from tracked people
+   (`high_engagement`; add a `list_digest` for a specific list if they named one).
+
+How to assemble it:
+
+- Call the relevant tools, then present **one briefing with a short labeled
+  section per source** (Mentions, Bookmarks, Notable) — a few items each, not an
+  exhaustive dump. Lead each item with the author and a short version of the text,
+  add engagement when notable, and include the permalink.
+- **Degrade gracefully.** If a source returns nothing, errors, or needs auth, say
+  so in one line under that section ("No new mentions." / "Bookmarks unavailable —
+  X auth needs setup.") and still show the sections that did work. Never let one
+  empty or failing source sink the whole briefing.
+- Keep it tight and skimmable — the goal is a 20-second catch-up, not a report.
+- If the user clearly wants only one of these ("what's new in my mentions?"), just
+  answer that one; the full briefing is for open-ended asks.
+
+## How to answer (all responses)
+
+- When you list tweets, lead with the author and a short version of the text, then
+  the engagement (likes/retweets/replies) when it's notable, and include the
   permalink so the user can open it.
 - Order by what the tool returns (most recent first) unless the user asks for
   something else.
 - Keep it skimmable: a tight list beats a wall of prose.
-- If the user asks for "the most popular" or "top" bookmarks, sort what the tool
+- If the user asks for "the most popular" or "top" items, sort what the tool
   returned by engagement before presenting.


### PR DESCRIPTION
Closes #154 (parent #149).

The Twitter habitat persona documented only `bookmarks`/`mentions`/`my_timeline` and flagged the public-feed tools + briefing as "coming later". #153 landed `person_recent` / `list_digest` / `high_engagement`; this wires them into the persona and adds the **"what's new" briefing**.

## Change (persona/docs only)
- **`STIMULUS.md`** — document all six tools (own-account *private*: bookmarks, mentions, my_timeline · tracked-feed *public*: person_recent, list_digest, high_engagement). Add a **"what's new?" briefing**: on open-ended asks ("what's new", "catch me up", "what did I miss?") fan out across **mentions + bookmarks + high_engagement** and return one short labeled briefing; **degrade gracefully** when a source is empty/unavailable; scoped asks ("what's new in my mentions?") answer just that source.
- **`README.md`** — replace the stale "coming in later slices" note; document the briefing + its live requirements.

Per the ticket this is **persona/orchestration over the existing tools — no briefing-specific tool added** (the model fans out and assembles). A thin `assemble_briefing` tool is the fallback if live testing shows the model doesn't combine sources reliably.

## Acceptance criteria (#154)
- [x] Persona instructs assembling feeds + answering the three core questions out of the box
- [x] Persona returns a combined briefing drawing on bookmarks, mentions, and tracked-people activity
- [x] Briefing instructed to degrade gracefully when a source is empty/unavailable
- [x] `pnpm test:run` passes — **1467/1467 monorepo, 43/43 standalone twitter-habitat**
- [ ] **Live "what's new?" run against a running habitat** — not done here: this environment has no `TWITTER_*`, `DATABASE_URL`, or `OPENROUTER_API_KEY`. Needs an operator with those secrets to confirm the model fans out + assembles as intended.

> ⚠️ The one remaining acceptance box is the live habitat run. The persona is in place and tests are green, but I could not exercise the end-to-end briefing without the X OAuth + Neon + provider secrets. Flagging so a reviewer with credentials does the live check (and we add the `assemble_briefing` tool if reliability needs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)