### PR TITLE
feat(gaia): per-habitat public URLs via label-driven Caddy (#170)

### DIFF
--- a/deploy/gaia/.env.example
+++ b/deploy/gaia/.env.example
@@ -9,6 +9,13 @@ GAIA_PORT=7420
 OPENROUTER_API_KEY=
 # GOOGLE_GENERATIVE_AI_API_KEY=
 
+# --- Per-habitat public URLs via Caddy (#170) ---
+# When set, each spawned habitat is published at <id>.$GAIA_BASE_DOMAIN over
+# HTTPS (Caddy label proxy). Requires DNS `*.<domain>` → this host + ports
+# 80/443 open. Unset ⇒ no Caddy labels, no public URLs (children stay internal).
+# GAIA_BASE_DOMAIN=habitats.example.com
+# CADDY_EMAIL=ops@example.com   # Let's Encrypt account email (optional)
+
 # NOTE: child-habitat secrets (X OAuth, DATABASE_URL, child provider keys) are
 # NOT set here — they go into Gaia's master vault after boot (see the runbook),
 # and Gaia binds only the named subset each habitat needs.

--- a/deploy/gaia/README.md
+++ b/deploy/gaia/README.md
@@ -194,6 +194,27 @@ on attach; a rotated token shows the SaaS's "needs reconnect" state.
 > `https://<host>:<childport>/a2a` with that child's `HABITAT_API_KEY`. The
 > proxy path above is the default because children bind to `127.0.0.1`.
 
+### Per-habitat public URLs via Caddy (#170)
+
+The compose file ships a `caddy` service (`lucaslorentz/caddy-docker-proxy`) that
+gives **each spawned habitat its own HTTPS URL** for direct SaaS attach — the
+recommended path, since the SaaS then holds a per-habitat credential (revocable
+per agent) instead of Gaia's master key.
+
+1. Point DNS `*.<base-domain>` at this host and open ports 80/443.
+2. Set `GAIA_BASE_DOMAIN` (and optionally `CADDY_EMAIL`) in `deploy/gaia/.env`.
+3. `docker compose up -d` — Caddy now watches the docker socket.
+
+Every habitat Gaia starts gets `caddy=<id>.<base-domain>` labels stamped on its
+container (`DockerManager.startContainer`), so Caddy publishes it at
+`https://<id>.<base-domain>` and reaches it over `gaia-net` (the loopback `-p`
+binding is untouched — Gaia's internal proxy still uses it). Override the host per
+habitat with the `hostname` field on `create_habitat`. Auth is **pass-through**:
+Caddy forwards `Authorization` and the habitat verifies its own token, so attach
+the SaaS to `https://<id>.<base-domain>/a2a` with **that child's**
+`HABITAT_API_KEY`. Leave `GAIA_BASE_DOMAIN` unset for local dev — no labels are
+emitted and Caddy routes nothing.
+
 ---
 
 ## Troubleshooting

--- a/deploy/gaia/docker-compose.yml
+++ b/deploy/gaia/docker-compose.yml
@@ -53,3 +53,52 @@ services:
         --data-dir /opt/gaia-data
         --provider "$$GAIA_PROVIDER"
         --model "$$GAIA_MODEL"
+
+  # Label-driven reverse proxy (#170). Gives every spawned habitat its own
+  # public HTTPS URL so the habitats SaaS can attach to it DIRECTLY (per-habitat
+  # URL + per-habitat credential) — Gaia is the orchestrator, not the request
+  # path. Caddy watches the docker socket and builds routes from the
+  # `caddy=<host>` / `caddy.reverse_proxy={{upstreams 8080}}` labels that
+  # DockerManager.startContainer stamps on each child (driven by GAIA_BASE_DOMAIN
+  # or a per-habitat hostname). It reaches each child by container DNS over
+  # gaia-net, so the children's loopback -p binding is untouched.
+  #
+  # Requires: DNS `*.${GAIA_BASE_DOMAIN}` → this host, and ports 80/443 open
+  # (Caddy auto-provisions Let's Encrypt certs). Auth is pass-through — Caddy
+  # forwards Authorization untouched and each habitat verifies its own token.
+  caddy:
+    image: lucaslorentz/caddy-docker-proxy:2.9-alpine
+    container_name: gaia-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      # Only build routes from containers on this network (the children).
+      CADDY_INGRESS_NETWORKS: gaia-net
+      # Email for Let's Encrypt account / expiry notices (optional).
+      CADDY_DOCKER_CADDYFILE_EMAIL: ${CADDY_EMAIL:-}
+    networks:
+      - gaia-net
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - caddy-data:/data     # certificates — persist across restarts
+      - caddy-config:/config
+
+  # To also expose the Gaia dashboard itself over Caddy, add labels here routing
+  # to the host-networked Gaia (e.g. caddy=${GAIA_HOSTNAME} +
+  # caddy.reverse_proxy=host.docker.internal:${GAIA_PORT} with
+  # extra_hosts: ["host.docker.internal:host-gateway"]). Off by default — the
+  # runbook recommends not exposing 7420 publicly unauthenticated.
+
+networks:
+  # Shared with the children DockerManager spawns (--network gaia-net). Declared
+  # here so `docker compose up` creates it before Caddy attaches; ensureNetwork()
+  # is idempotent when it already exists. `name:` pins the literal name (no
+  # compose project prefix) so it matches what DockerManager looks for.
+  gaia-net:
+    name: gaia-net
+
+volumes:
+  caddy-data:
+  caddy-config:

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -32,6 +32,7 @@ import { resolveProjectDir, saveConfig, fileExists } from "./config.js";
 import { listArtifacts } from "./tools/artifact-tools.js";
 import { createA2AHandler, type A2AHandler } from "./a2a-handler.js";
 import { runWithSpeaker } from "./identity/agent-speaker-context.js";
+import { getPublicBaseUrl } from "@umwelten/protocols";
 import { createAgentSurface } from "./agent-surface.js";
 import { buildAgentStimulus } from "./habitat-agent.js";
 import { createClaudeSdkRuntimeRunner } from "./claude-sdk-runner.js";
@@ -376,7 +377,15 @@ export async function startContainerServer(
 					const actualPort =
 						typeof addr === "object" && addr ? addr.port : port;
 					const handler = await getA2AHandler(actualPort);
-					sendJson(res, handler.agentCard);
+					// Self-describe with the PUBLIC url, not the cached host:port one
+					// (#170): behind a reverse proxy (Caddy/Gaia) the card must point
+					// callers at the externally reachable origin via X-Forwarded-*.
+					// Mirrors the MCP/OAuth surface (agent-surface.ts). Falls back to
+					// the Host header / BASE_URL when no forwarding headers are present.
+					sendJson(res, {
+						...handler.agentCard,
+						url: `${getPublicBaseUrl(req)}/a2a`,
+					});
 					return;
 				}
 

--- a/packages/habitat/src/tools/gaia/caddy-labels.test.ts
+++ b/packages/habitat/src/tools/gaia/caddy-labels.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Caddy label emission (#170) — DockerManager.startContainer stamps
+ * `caddy=<host>` + `caddy.reverse_proxy={{upstreams 8080}}` labels so
+ * caddy-docker-proxy publishes each habitat at its own public URL. Labels are
+ * emitted only when a hostname is resolvable (explicit entry.hostname, or
+ * <id>.$GAIA_BASE_DOMAIN); local dev with neither stays label-free. Exec layer
+ * mocked; host sessions dir creation is real (tmp data dir).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+type CallbackFn = (
+  error: Error | null,
+  result: { stdout: string; stderr: string },
+) => void;
+
+interface RecordedCall {
+  cmd: string;
+  args: string[];
+}
+
+let recordedCalls: RecordedCall[] = [];
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual('node:child_process');
+  return {
+    ...actual,
+    execFile: vi
+      .fn()
+      .mockImplementation(
+        (
+          cmd: string,
+          args?: string[] | CallbackFn,
+          options?: Record<string, unknown> | CallbackFn,
+          cb?: CallbackFn,
+        ) => {
+          let callback: CallbackFn | undefined;
+          if (typeof args === 'function') callback = args;
+          else if (typeof options === 'function') callback = options;
+          else callback = cb;
+          recordedCalls.push({ cmd, args: Array.isArray(args) ? args : [] });
+          if (callback) callback(null, { stdout: '', stderr: '' });
+          return {} as never;
+        },
+      ),
+  };
+});
+
+import { DockerManager, resolveHabitatHostname } from './docker.js';
+import type { GaiaHabitatEntry } from './types.js';
+
+function makeEntry(over: Partial<GaiaHabitatEntry> = {}): GaiaHabitatEntry {
+  return {
+    id: 'twitter',
+    name: 'Twitter',
+    config: { name: 'Twitter', agents: [] },
+    secretBindings: [],
+    apiKey: 'gaia_testkey',
+    createdAt: '2026-06-18T00:00:00.000Z',
+    ...over,
+  };
+}
+
+function runArgs(): string[] {
+  return (
+    recordedCalls.find((c) => c.cmd === 'docker' && c.args[0] === 'run')?.args ??
+    []
+  );
+}
+
+/** Values that follow each `--label` flag in the recorded docker run args. */
+function labels(args: string[]): string[] {
+  return args.filter((_, i) => args[i - 1] === '--label');
+}
+
+describe('Gaia Caddy label emission (#170)', () => {
+  let dataDir: string;
+  let docker: DockerManager;
+  const prevBaseDomain = process.env.GAIA_BASE_DOMAIN;
+
+  beforeEach(async () => {
+    recordedCalls = [];
+    delete process.env.GAIA_BASE_DOMAIN;
+    dataDir = await mkdtemp(join(tmpdir(), 'umwl-gaia-caddy-'));
+    docker = new DockerManager(dataDir, '/tmp/project');
+  });
+
+  afterEach(async () => {
+    if (prevBaseDomain === undefined) delete process.env.GAIA_BASE_DOMAIN;
+    else process.env.GAIA_BASE_DOMAIN = prevBaseDomain;
+    await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it('emits no caddy labels when no hostname is resolvable (local dev)', async () => {
+    await docker.startContainer(makeEntry(), '', []);
+    const args = runArgs();
+    expect(labels(args)).toEqual([]);
+    // Image still last, core wiring intact.
+    expect(args[args.length - 1]).toBe('habitat');
+  });
+
+  it('derives <id>.$GAIA_BASE_DOMAIN and stamps both labels', async () => {
+    process.env.GAIA_BASE_DOMAIN = 'habitats.example.com';
+    await docker.startContainer(makeEntry(), '', []);
+    const args = runArgs();
+    expect(labels(args)).toEqual([
+      'caddy=twitter.habitats.example.com',
+      'caddy.reverse_proxy={{upstreams 8080}}',
+    ]);
+    // Labels precede the image (which must remain the final arg).
+    expect(args[args.length - 1]).toBe('habitat');
+  });
+
+  it('prefers an explicit entry.hostname over the base domain', async () => {
+    process.env.GAIA_BASE_DOMAIN = 'habitats.example.com';
+    await docker.startContainer(
+      makeEntry({ hostname: 'bird.custom.dev' }),
+      '',
+      [],
+    );
+    expect(labels(runArgs())).toEqual([
+      'caddy=bird.custom.dev',
+      'caddy.reverse_proxy={{upstreams 8080}}',
+    ]);
+  });
+
+  it('does not disturb image/port/network/api-key wiring', async () => {
+    process.env.GAIA_BASE_DOMAIN = 'habitats.example.com';
+    await docker.startContainer(makeEntry(), '', []);
+    const args = runArgs();
+    expect(args[args.length - 1]).toBe('habitat');
+    expect(args).toContain('HABITAT_API_KEY=gaia_testkey');
+    expect(args.join(' ')).toMatch(/-p 127\.0\.0\.1:\d+:8080/);
+    expect(args).toContain('gaia-net');
+  });
+
+  describe('resolveHabitatHostname', () => {
+    it('returns undefined with no hostname and no base domain', () => {
+      delete process.env.GAIA_BASE_DOMAIN;
+      expect(resolveHabitatHostname({ id: 'x' })).toBeUndefined();
+    });
+    it('derives from the base domain', () => {
+      process.env.GAIA_BASE_DOMAIN = 'h.example.com';
+      expect(resolveHabitatHostname({ id: 'x' })).toBe('x.h.example.com');
+    });
+    it('explicit hostname wins', () => {
+      process.env.GAIA_BASE_DOMAIN = 'h.example.com';
+      expect(resolveHabitatHostname({ id: 'x', hostname: 'y.dev' })).toBe(
+        'y.dev',
+      );
+    });
+  });
+});

--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -63,6 +63,19 @@ function volumeName(id: string): string {
   return `${CONTAINER_PREFIX}${id}-data`;
 }
 
+/**
+ * Public hostname a habitat is served at via the Caddy label proxy (#170).
+ * Explicit `entry.hostname` wins; otherwise derive `<id>.$GAIA_BASE_DOMAIN`.
+ * Returns undefined when neither is set — no Caddy label is emitted (local dev).
+ */
+export function resolveHabitatHostname(
+  entry: Pick<GaiaHabitatEntry, "id" | "hostname">,
+): string | undefined {
+  if (entry.hostname) return entry.hostname;
+  const base = process.env.GAIA_BASE_DOMAIN?.trim();
+  return base ? `${entry.id}.${base}` : undefined;
+}
+
 export class DockerManager {
   constructor(
     private readonly dataDir: string,
@@ -159,8 +172,23 @@ export class DockerManager {
       "-v", `${sessionsHostDir}:/data/sessions`,
       "--env", `HABITAT_API_KEY=${entry.apiKey}`,
       "-p", `127.0.0.1:${hostPort}:8080`,
-      image,
     ];
+
+    // Caddy label-driven routing (#170): when a public hostname is configured,
+    // stamp labels so caddy-docker-proxy publishes https://<hostname> → this
+    // container's :8080 over gaia-net (the loopback -p binding above stays for
+    // Gaia's own proxy; Caddy reaches the container by network DNS instead).
+    // Identity is per-container, set at run time — never baked into the image.
+    // No hostname / GAIA_BASE_DOMAIN ⇒ no labels (local dev is unaffected).
+    const hostname = resolveHabitatHostname(entry);
+    if (hostname) {
+      args.push(
+        "--label", `caddy=${hostname}`,
+        "--label", "caddy.reverse_proxy={{upstreams 8080}}",
+      );
+    }
+
+    args.push(image);
 
     await execFile("docker", args);
     return hostPort;

--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -100,6 +100,12 @@ export function createHabitatLifecycleTools(
 					.describe(
 						"Docker image for this habitat's container (default: the standard habitat image). Must exist locally — specialized images are built out of band.",
 					),
+				hostname: z
+					.string()
+					.optional()
+					.describe(
+						"Public hostname for Caddy routing (e.g. 'twitter.example.com'). Default: '<id>.$GAIA_BASE_DOMAIN' when that env var is set; otherwise no public URL.",
+					),
 			}),
 			execute: async (params) => {
 				// Validate capability bindings before creating

--- a/packages/habitat/src/tools/gaia/registry.ts
+++ b/packages/habitat/src/tools/gaia/registry.ts
@@ -101,6 +101,7 @@ export class GaiaRegistryManager {
 			secretBindings: options.secretBindings ?? [],
 			apiKey: generateApiKey(),
 			...(options.image ? { image: options.image } : {}),
+			...(options.hostname ? { hostname: options.hostname } : {}),
 			createdAt: new Date().toISOString(),
 		};
 

--- a/packages/habitat/src/tools/gaia/types.ts
+++ b/packages/habitat/src/tools/gaia/types.ts
@@ -24,6 +24,13 @@ export interface GaiaHabitatEntry {
 	image?: string;
 	/** Assigned host port (127.0.0.1 only) — set after container starts */
 	containerPort?: number;
+	/**
+	 * Public hostname this habitat is served at via the label-driven Caddy
+	 * proxy (#170), e.g. "twitter.example.com". Omitted ⇒ derived from
+	 * `<id>.$GAIA_BASE_DOMAIN` at start time, or no Caddy label when neither
+	 * is set (local dev).
+	 */
+	hostname?: string;
 	/** ISO timestamp */
 	createdAt: string;
 }
@@ -62,6 +69,8 @@ export interface CreateHabitatOptions {
 	capabilities?: CapabilityBinding[];
 	/** Docker image for the container (default: the standard habitat image). */
 	image?: string;
+	/** Public hostname for Caddy routing (#170), e.g. "twitter.example.com". */
+	hostname?: string;
 }
 
 /** Status of a credential (whether it's known to be working). */


### PR DESCRIPTION
Closes #170.

Gives every Gaia-spawned habitat its **own public HTTPS URL** via a label-driven Caddy proxy, so the habitats SaaS attaches **directly** (per-habitat URL + per-habitat credential) instead of routing A2A through Gaia's proxy with Gaia's master key. Gaia stays an orchestrator — never in the request path.

## How
- **`gaia/docker.ts`** — `startContainer` stamps `caddy=<host>` + `caddy.reverse_proxy={{upstreams 8080}}` labels when a hostname is resolvable. New `resolveHabitatHostname()` derives `<id>.$GAIA_BASE_DOMAIN` or uses an explicit `entry.hostname`. The loopback `-p 127.0.0.1:<744x>:8080` binding is **untouched** — Caddy reaches the child over `gaia-net` by container DNS; Gaia's internal proxy keeps using the host port. No hostname / `GAIA_BASE_DOMAIN` ⇒ no labels (local dev unaffected).
- **`gaia/types.ts` + `registry.ts` + `create_habitat`** — optional per-habitat `hostname`.
- **`deploy/gaia/docker-compose.yml`** — adds a `caddy-docker-proxy` service on `gaia-net` (publishes 80/443, mounts `docker.sock:ro`, persists certs). Declares `gaia-net` with a pinned `name:` so compose creates it before Caddy attaches and it matches what `DockerManager.ensureNetwork` expects. `.env.example` + runbook document `GAIA_BASE_DOMAIN` and the direct-attach flow.
- **`container-server.ts`** — the `/.well-known/agent-card.json` card now self-describes its `url` from `getPublicBaseUrl(req)` (X-Forwarded-aware) instead of the cached `host:port` baseUrl, so behind Caddy it advertises `https://<host>/a2a`. Mirrors the MCP/OAuth surface.

Auth stays **pass-through** — Caddy forwards `Authorization`, the habitat verifies its own token; **no bearer ever goes in a label**.

## Tests
`caddy-labels.test.ts`: label emission (no base domain → no labels; derived `<id>.$domain`; explicit hostname wins; image/port/network/api-key wiring intact) + `resolveHabitatHostname`. **`pnpm test:run` green: 1474/1474.** Compose YAML validated (services/networks/volumes parse).

## Not verified here (needs a Linux docker host)
The label→route→TLS path can't be exercised in this environment (no docker daemon, no DNS/domain). The deterministic label emission is unit-tested; the live `docker compose up` + cert issuance + `https://<id>.<domain>/a2a` round-trip needs an operator smoke test on the Gaia host. Flagging for a reviewer with the box.

## Pairs with
- ADR 0003 direct-attach: once the SaaS mints JWTs (The-Focus-AI/habitats#54), Gaia should also inject `HABITAT_AUTH_JWKS_URL` + `HABITAT_AUTH_AUDIENCE=https://<id>.<domain>` at spawn so the audience matches the public URL (noted as a follow-up in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)