### PR TITLE
feat(gaia): configurable ingress network to reuse an existing caddy (#170 follow-up)

### DIFF
--- a/deploy/gaia/.env.example
+++ b/deploy/gaia/.env.example
@@ -15,6 +15,13 @@ OPENROUTER_API_KEY=
 # 80/443 open. Unset ⇒ no Caddy labels, no public URLs (children stay internal).
 # GAIA_BASE_DOMAIN=habitats.example.com
 # CADDY_EMAIL=ops@example.com   # Let's Encrypt account email (optional)
+#
+# Reuse an EXISTING caddy-docker-proxy instead of the bundled one: set this to
+# the network that proxy ingresses (e.g. `caddy`) so spawned habitats join it and
+# get routed automatically. When set, run only the gaia service
+# (`docker compose up -d gaia`) — don't start the bundled caddy (it would clash
+# on 80/443). The network must already exist.
+# GAIA_INGRESS_NETWORK=caddy
 
 # NOTE: child-habitat secrets (X OAuth, DATABASE_URL, child provider keys) are
 # NOT set here — they go into Gaia's master vault after boot (see the runbook),

--- a/deploy/gaia/README.md
+++ b/deploy/gaia/README.md
@@ -215,6 +215,16 @@ the SaaS to `https://<id>.<base-domain>/a2a` with **that child's**
 `HABITAT_API_KEY`. Leave `GAIA_BASE_DOMAIN` unset for local dev — no labels are
 emitted and Caddy routes nothing.
 
+**Reusing an existing caddy.** If the host already runs caddy-docker-proxy (it
+owns 80/443 on its own network), don't start the bundled one. Set
+`GAIA_INGRESS_NETWORK=<that network>` (e.g. `caddy`) so spawned habitats join it
+and the existing proxy picks up their labels, then bring up **only** Gaia:
+
+```bash
+GAIA_INGRESS_NETWORK=caddy GAIA_BASE_DOMAIN=habitats.example.com \
+  docker compose up -d gaia      # not the bundled caddy
+```
+
 ---
 
 ## Troubleshooting

--- a/packages/habitat/src/tools/gaia/caddy-labels.test.ts
+++ b/packages/habitat/src/tools/gaia/caddy-labels.test.ts
@@ -80,10 +80,12 @@ describe('Gaia Caddy label emission (#170)', () => {
   let dataDir: string;
   let docker: DockerManager;
   const prevBaseDomain = process.env.GAIA_BASE_DOMAIN;
+  const prevIngress = process.env.GAIA_INGRESS_NETWORK;
 
   beforeEach(async () => {
     recordedCalls = [];
     delete process.env.GAIA_BASE_DOMAIN;
+    delete process.env.GAIA_INGRESS_NETWORK;
     dataDir = await mkdtemp(join(tmpdir(), 'umwl-gaia-caddy-'));
     docker = new DockerManager(dataDir, '/tmp/project');
   });
@@ -91,6 +93,8 @@ describe('Gaia Caddy label emission (#170)', () => {
   afterEach(async () => {
     if (prevBaseDomain === undefined) delete process.env.GAIA_BASE_DOMAIN;
     else process.env.GAIA_BASE_DOMAIN = prevBaseDomain;
+    if (prevIngress === undefined) delete process.env.GAIA_INGRESS_NETWORK;
+    else process.env.GAIA_INGRESS_NETWORK = prevIngress;
     await rm(dataDir, { recursive: true, force: true });
   });
 
@@ -135,6 +139,19 @@ describe('Gaia Caddy label emission (#170)', () => {
     expect(args).toContain('HABITAT_API_KEY=gaia_testkey');
     expect(args.join(' ')).toMatch(/-p 127\.0\.0\.1:\d+:8080/);
     expect(args).toContain('gaia-net');
+  });
+
+  it('defaults the ingress network to gaia-net', async () => {
+    await docker.startContainer(makeEntry(), '', []);
+    const args = runArgs();
+    expect(args[args.indexOf('--network') + 1]).toBe('gaia-net');
+  });
+
+  it('honors GAIA_INGRESS_NETWORK to reuse an existing caddy network (#170)', async () => {
+    process.env.GAIA_INGRESS_NETWORK = 'caddy';
+    await docker.startContainer(makeEntry(), '', []);
+    const args = runArgs();
+    expect(args[args.indexOf('--network') + 1]).toBe('caddy');
   });
 
   describe('resolveHabitatHostname', () => {

--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -45,7 +45,19 @@ function spawnWithStdin(
   });
 }
 
-const NETWORK_NAME = "gaia-net";
+/** Default Docker network children attach to when none is configured. */
+const DEFAULT_NETWORK_NAME = "gaia-net";
+/**
+ * Which Docker network spawned habitats join for reverse-proxy ingress.
+ * Override with `GAIA_INGRESS_NETWORK` to reuse an existing caddy-docker-proxy
+ * network (e.g. a host that already runs caddy on a network named `caddy` —
+ * #170): set it to that network's name so the existing proxy sees the children
+ * and routes their `caddy=` labels. The network must already exist (ensureNetwork
+ * no-ops when it does); a missing default network is created.
+ */
+function resolveNetworkName(): string {
+  return process.env.GAIA_INGRESS_NETWORK?.trim() || DEFAULT_NETWORK_NAME;
+}
 /** Default image every habitat runs unless its registry entry says otherwise. */
 export const DEFAULT_IMAGE_NAME = "habitat";
 const CONTAINER_PREFIX = "gaia-";
@@ -85,9 +97,10 @@ export class DockerManager {
   /** Create the Docker network (idempotent). */
   async ensureNetwork(): Promise<void> {
     try {
-      await execFile("docker", ["network", "create", NETWORK_NAME]);
+      await execFile("docker", ["network", "create", resolveNetworkName()]);
     } catch (err: any) {
-      // Network already exists — that's fine
+      // Network already exists — that's fine (also the expected case when
+      // reusing an externally-managed network via GAIA_INGRESS_NETWORK).
       if (!err.stderr?.includes("already exists")) throw err;
     }
   }
@@ -167,7 +180,7 @@ export class DockerManager {
     const args = [
       "run", "-d",
       "--name", name,
-      "--network", NETWORK_NAME,
+      "--network", resolveNetworkName(),
       "-v", `${volume}:/data`,
       "-v", `${sessionsHostDir}:/data/sessions`,
       "--env", `HABITAT_API_KEY=${entry.apiKey}`,


### PR DESCRIPTION
Follow-up to #170, found while wiring Gaia onto a real host (pancake) that already runs caddy-docker-proxy.

## Why
#170 assumed a dedicated bundled caddy on `gaia-net`. A host that already runs caddy-docker-proxy ingresses **its own** network (e.g. `caddy`) and owns 80/443 — the bundled caddy would clash, and DockerManager's hardcoded `gaia-net` means the existing proxy never sees the children.

## Change
- **`gaia/docker.ts`** — `resolveNetworkName()` reads `GAIA_INGRESS_NETWORK` (default `gaia-net`), used by `ensureNetwork` + `startContainer`. `ensureNetwork` already no-ops on an existing (externally-managed) network.
- **`.env.example` + runbook** — document the reuse path: set `GAIA_INGRESS_NETWORK=caddy`, bring up **only** the gaia service (`docker compose up -d gaia`), skip the bundled caddy.
- **`caddy-labels.test.ts`** — assert default `gaia-net` and the `GAIA_INGRESS_NETWORK` override.

`pnpm test:run` green (1476).

🤖 Generated with [Claude Code](https://claude.com/claude-code)