### PR TITLE
fix(habitat): install the Docker CLI for the build host's arch (arm64 + amd64)

### DIFF
--- a/packages/habitat/Dockerfile
+++ b/packages/habitat/Dockerfile
@@ -24,8 +24,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git ripgrep ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Docker CLI (for Gaia to manage child containers via mounted socket)
-RUN curl -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-27.3.1.tgz | \
+# Install Docker CLI (for Gaia to manage child containers via mounted socket).
+# Use the build host's arch ($(uname -m) → x86_64 | aarch64) — the static
+# download paths use those names — so the image runs on amd64 AND arm64 hosts.
+RUN curl -fsSL "https://download.docker.com/linux/static/stable/$(uname -m)/docker-27.3.1.tgz" | \
     tar xz -C /usr/local/bin --strip-components=1 docker/docker
 
 # Install mise (universal runtime/package manager)


### PR DESCRIPTION
The habitat Dockerfile hardcoded the **x86_64** static Docker CLI:

```
https://download.docker.com/linux/static/stable/x86_64/docker-27.3.1.tgz
```

On an **arm64** host that installs an unrunnable binary, so Gaia's `docker` calls fail with `docker: ELF... not found` and it cannot spawn any child container — the orchestrator is dead on arm64. (Gaia needs the CLI to drive the host daemon via the mounted socket.)

## Fix
Derive the arch from `$(uname -m)` (→ `x86_64` | `aarch64`, which are exactly the names the static download paths use), so the image builds and runs on both amd64 and arm64 hosts.

## How found / verified
Booting Gaia for real on an arm64 host (pancake). Before: `create_habitat` → `docker: ELF... not found`. After rebuild: `docker --version` runs inside the image, and Gaia spawns a child end-to-end (`gaia-smoke` healthy, agent-card served through the proxy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)