### PR TITLE
feat(gaia): forward GAIA_BASE_DOMAIN/GAIA_INGRESS_NETWORK through compose (#170)

### DIFF
--- a/deploy/gaia/docker-compose.yml
+++ b/deploy/gaia/docker-compose.yml
@@ -34,6 +34,12 @@ services:
       GAIA_MODEL: ${GAIA_MODEL:-openai/gpt-4o-mini}
       GAIA_PORT: ${GAIA_PORT:-7420}
       HABITAT_WORK_DIR: /opt/gaia-data
+      # Per-habitat public URLs via Caddy (#170). When set, spawned children join
+      # GAIA_INGRESS_NETWORK and get caddy=<id>.$GAIA_BASE_DOMAIN labels. Empty ⇒
+      # no labels / default gaia-net (local dev). Set GAIA_INGRESS_NETWORK to an
+      # existing caddy network to reuse that proxy instead of the bundled one.
+      GAIA_BASE_DOMAIN: ${GAIA_BASE_DOMAIN:-}
+      GAIA_INGRESS_NETWORK: ${GAIA_INGRESS_NETWORK:-}
       # The provider key Gaia uses for its own chat. Child habitats get their
       # own keys via the master vault + secret bindings, not from here.
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}


### PR DESCRIPTION
Closes the last gap in #170's deploy path. The compose `gaia` service didn't pass `GAIA_BASE_DOMAIN` / `GAIA_INGRESS_NETWORK` into the Gaia container, so `DockerManager` never saw them — the per-habitat Caddy URL feature was unreachable via the documented `docker compose up`. Forward both (empty defaults ⇒ no labels / default `gaia-net`, unchanged for local dev).

## Verified live (arm64 host, reusing the existing caddy-docker-proxy)
With `GAIA_BASE_DOMAIN=habitats.thefocus.ai` + `GAIA_INGRESS_NETWORK=caddy`:
- spawned habitat joined the existing `caddy` network with `caddy=<id>.habitats.thefocus.ai` labels
- the existing caddy solved ACME `tls-alpn-01` and obtained a **real Let's Encrypt cert** for the host
- `https://<id>.habitats.thefocus.ai/.well-known/agent-card.json` → **200**, card self-URL correctly `https://…/a2a` (the #170 X-Forwarded fix)

This is the end-to-end direct-attach path the habitats SaaS uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)