### PR TITLE
feat(gaia): deploy Gaia as a caddy-fronted, authenticated habitat (#170 follow-up)

### DIFF
--- a/deploy/gaia/.env.example
+++ b/deploy/gaia/.env.example
@@ -5,6 +5,15 @@ GAIA_PROVIDER=openrouter
 GAIA_MODEL=openai/gpt-4o-mini
 GAIA_PORT=7420
 
+# --- Gaia control-plane URL + auth (it's a caddy-fronted habitat) ---
+# Public hostname Gaia's control plane is served at (TLS via Caddy). The SaaS
+# hits https://$GAIA_HOSTNAME to create/start/stop habitats.
+# GAIA_HOSTNAME=gaia.habitats.example.com
+# Bearer token the SaaS must present to Gaia's API. REQUIRED on any reachable
+# deploy — empty means open auth (control of the host's docker + secret vault).
+# Generate: openssl rand -hex 32
+# GAIA_API_KEY=
+
 # Provider key Gaia uses for its own chat. Set the one matching GAIA_PROVIDER.
 OPENROUTER_API_KEY=
 # GOOGLE_GENERATIVE_AI_API_KEY=

--- a/deploy/gaia/README.md
+++ b/deploy/gaia/README.md
@@ -65,23 +65,26 @@ imports resolve), and merges `toolsDir`/`stimulusFile` into the Gaia-seeded
 
 ```bash
 cd deploy/gaia
-cp .env.example .env          # set OPENROUTER_API_KEY (or GOOGLE_…) + GAIA_*
+cp .env.example .env          # set OPENROUTER_API_KEY (or GOOGLE_…), GAIA_HOSTNAME,
+                              # GAIA_API_KEY (openssl rand -hex 32), GAIA_BASE_DOMAIN
 sudo mkdir -p /opt/gaia-data  # identity bind-mount target (see compose header)
 
-docker compose up -d
-docker compose logs -f gaia   # watch for "[gaia] Orchestrator at http://0.0.0.0:7420"
+docker compose up -d          # Gaia + bundled caddy on gaia-net (owns 80/443)
+docker compose logs -f gaia   # watch for the orchestrator boot line
 ```
 
-Gaia is now at `http://<host>:7420` (host networking → binds the host directly).
-The dashboard has Chat / Habitats / Secrets / Create tabs. Verify:
+Gaia is **not** published on the host — it's reached through caddy at
+`https://$GAIA_HOSTNAME`, gated by `GAIA_API_KEY`. Verify from the host (over the
+gaia-net, the control-plane API requires the bearer):
 
 ```bash
-curl -s http://localhost:7420/health
-# → {"status":"ok","role":"gaia-orchestrator",...,"docker":true,...}
+# health is open; /api/* requires the key
+curl -s https://$GAIA_HOSTNAME/health
+curl -s -H "Authorization: Bearer $GAIA_API_KEY" https://$GAIA_HOSTNAME/api/habitats
 ```
 
-`docker: true` confirms Gaia can reach the host daemon through the mounted
-socket.
+(For the **reuse-existing-caddy** shape — e.g. a host already serving other
+sites — don't run the bundled caddy; see §6.)
 
 ---
 
@@ -207,22 +210,41 @@ per agent) instead of Gaia's master key.
 
 Every habitat Gaia starts gets `caddy=<id>.<base-domain>` labels stamped on its
 container (`DockerManager.startContainer`), so Caddy publishes it at
-`https://<id>.<base-domain>` and reaches it over `gaia-net` (the loopback `-p`
-binding is untouched — Gaia's internal proxy still uses it). Override the host per
-habitat with the `hostname` field on `create_habitat`. Auth is **pass-through**:
-Caddy forwards `Authorization` and the habitat verifies its own token, so attach
-the SaaS to `https://<id>.<base-domain>/a2a` with **that child's**
-`HABITAT_API_KEY`. Leave `GAIA_BASE_DOMAIN` unset for local dev — no labels are
-emitted and Caddy routes nothing.
+`https://<id>.<base-domain>` and reaches it by container DNS over the ingress
+network. Override the host per habitat with the `hostname` field on
+`create_habitat`. Auth is **pass-through**: Caddy forwards `Authorization` and the
+habitat verifies its own token, so attach the SaaS to
+`https://<id>.<base-domain>/a2a` with **that child's** `HABITAT_API_KEY`. Leave
+`GAIA_BASE_DOMAIN` unset for local dev — no labels are emitted and Caddy routes
+nothing.
+
+**Gaia is itself caddy-fronted + authenticated.** Gaia no longer uses host
+networking — it joins the ingress network and addresses children by Docker DNS
+(`gaia-<id>:8080`). Its control plane is served over TLS at `GAIA_HOSTNAME`
+(`{{upstreams 7420}}`) and gated by `GAIA_API_KEY` (→ `HABITAT_API_KEY` inside the
+container). The SaaS provisions habitats by calling
+`https://<GAIA_HOSTNAME>/api/habitats…` with `Authorization: Bearer $GAIA_API_KEY`.
+**Never** leave `7420` open — with the docker socket mounted it's host-root +
+the master secret vault.
 
 **Reusing an existing caddy.** If the host already runs caddy-docker-proxy (it
-owns 80/443 on its own network), don't start the bundled one. Set
-`GAIA_INGRESS_NETWORK=<that network>` (e.g. `caddy`) so spawned habitats join it
-and the existing proxy picks up their labels, then bring up **only** Gaia:
+owns 80/443 on its own network, say `caddy`), don't start the bundled one. Point
+Gaia at that network and attach Gaia to it too (so Gaia↔child DNS + the existing
+proxy both work), set the hostname + key, and bring up **only** Gaia:
 
 ```bash
-GAIA_INGRESS_NETWORK=caddy GAIA_BASE_DOMAIN=habitats.example.com \
-  docker compose up -d gaia      # not the bundled caddy
+# deploy/gaia/.env: GAIA_INGRESS_NETWORK=caddy, GAIA_BASE_DOMAIN=habitats.example.com,
+#                   GAIA_HOSTNAME=gaia.habitats.example.com, GAIA_API_KEY=$(openssl rand -hex 32)
+docker network connect caddy gaia 2>/dev/null || true   # if not already attached
+docker run -d --name gaia --restart unless-stopped \
+  --network caddy \
+  -l caddy=gaia.habitats.example.com -l 'caddy.reverse_proxy={{upstreams 7420}}' \
+  -v /var/run/docker.sock:/var/run/docker.sock -v /opt/gaia-data:/opt/gaia-data \
+  -e GAIA_PORT=7420 -e HABITAT_WORK_DIR=/opt/gaia-data \
+  -e GAIA_PROVIDER -e GAIA_MODEL -e OPENROUTER_API_KEY \
+  -e GAIA_BASE_DOMAIN=habitats.example.com -e GAIA_INGRESS_NETWORK=caddy \
+  -e HABITAT_API_KEY="$GAIA_API_KEY" \
+  habitat sh -c 'pnpm exec tsx packages/cli/src/entry.ts habitat gaia --port 7420 --data-dir /opt/gaia-data --provider "$GAIA_PROVIDER" --model "$GAIA_MODEL"'
 ```
 
 ---
@@ -232,7 +254,7 @@ GAIA_INGRESS_NETWORK=caddy GAIA_BASE_DOMAIN=habitats.example.com \
 | Symptom | Fix |
 |---|---|
 | `health` shows `"docker": false` | Socket not mounted / no daemon access. Check `/var/run/docker.sock` mount + the host user is in the `docker` group. |
-| Gaia can't reach a started child (proxy 502) | Not on Linux host networking. Containerized Gaia requires `network_mode: host` (this compose) on a Linux host. |
+| Gaia can't reach a started child (proxy 502) | Gaia and the child must share a user-defined network for embedded DNS. Ensure Gaia is attached to the same network as `GAIA_INGRESS_NETWORK` (children join it; Gaia must too). |
 | `Image "twitter-habitat" not found` | Build it on this host (§1). Gaia only auto-builds the default `habitat` image. |
 | Child session dirs empty on host | Data dir not identity-mounted. Keep `/opt/gaia-data:/opt/gaia-data` (same path in/out). |
 | Bookmarks tool: `needs_reauth` | `TWITTER_REFRESH_TOKEN` missing/expired — re-run the OAuth bootstrap and re-set the secret, then `rebuild` the habitat. |

--- a/deploy/gaia/docker-compose.yml
+++ b/deploy/gaia/docker-compose.yml
@@ -1,32 +1,36 @@
 # Gaia orchestrator — containerized deploy (Docker-out-of-Docker).
 #
 # Gaia spawns sibling habitat containers by driving the HOST docker daemon via
-# the mounted socket. Two non-obvious requirements make that work:
+# the mounted socket, and is itself a normal caddy-fronted, authenticated
+# habitat — its control-plane API is served over TLS at GAIA_HOSTNAME, not raw
+# on 0.0.0.0:7420. Two things to know:
 #
-#   1. network_mode: host
-#      Gaia reaches its children at 127.0.0.1:<port> (DockerManager publishes
-#      each child on 127.0.0.1:7440-7499). Inside a bridged container that
-#      loopback is the container's own — not the host's. Host networking puts
-#      Gaia in the host network namespace so 127.0.0.1:<port> hits the
-#      published child ports. (Linux only — see the runbook. On macOS/Docker
-#      Desktop use the standalone single-container path instead.)
+#   1. No host networking. Gaia addresses its children by Docker embedded DNS
+#      (gaia-<id>:8080) over the shared ingress network, so it just joins that
+#      network like any container. Caddy reaches Gaia the same way
+#      ({{upstreams 7420}}).
 #
-#   2. Identity bind mount for the data dir (/opt/gaia-data:/opt/gaia-data)
-#      Gaia bind-mounts each child's sessions dir at <dataDir>/sessions/<id>.
-#      That path is resolved by the HOST daemon, so the data dir must live at
-#      the SAME path inside the Gaia container and on the host. Mounting it at
-#      an identical path makes child bind mounts line up.
+#   2. Identity bind mount for the data dir (/opt/gaia-data:/opt/gaia-data).
+#      Gaia bind-mounts each child's sessions dir at <dataDir>/sessions/<id>,
+#      resolved by the HOST daemon — so the data dir must live at the SAME path
+#      inside the Gaia container and on the host for child bind mounts to line up.
 #
-# Prereqs: `docker build -t habitat -f packages/habitat/Dockerfile .` and
-# `docker build -t twitter-habitat -f packages/habitat/Dockerfile.twitter-habitat .`
-# have been run on this host. See deploy/gaia/README.md for the full runbook.
+# Two deploy shapes:
+#   - Bundled caddy (fresh host): `docker compose up -d` brings up Gaia + a
+#     caddy-docker-proxy on gaia-net that owns 80/443.
+#   - Reuse an existing caddy: set GAIA_INGRESS_NETWORK to that proxy's network
+#     and attach Gaia to it; bring up only Gaia (see deploy/gaia/README.md).
+#
+# Prereqs: `docker build -t habitat -f packages/habitat/Dockerfile .` (and any
+# specialized images) on this host. Full runbook: deploy/gaia/README.md.
 
 services:
   gaia:
     image: habitat
     container_name: gaia
     restart: unless-stopped
-    network_mode: host
+    networks:
+      - gaia-net
     environment:
       # Gaia's own chat model. openrouter avoids the fresh-install
       # @ai-sdk/google v3 vs ai@5 break (PRD #149 "Further Notes").
@@ -34,16 +38,25 @@ services:
       GAIA_MODEL: ${GAIA_MODEL:-openai/gpt-4o-mini}
       GAIA_PORT: ${GAIA_PORT:-7420}
       HABITAT_WORK_DIR: /opt/gaia-data
-      # Per-habitat public URLs via Caddy (#170). When set, spawned children join
+      # Per-habitat public URLs via Caddy (#170). Spawned children join
       # GAIA_INGRESS_NETWORK and get caddy=<id>.$GAIA_BASE_DOMAIN labels. Empty ⇒
       # no labels / default gaia-net (local dev). Set GAIA_INGRESS_NETWORK to an
-      # existing caddy network to reuse that proxy instead of the bundled one.
+      # existing caddy network to reuse that proxy (and attach Gaia to it too).
       GAIA_BASE_DOMAIN: ${GAIA_BASE_DOMAIN:-}
       GAIA_INGRESS_NETWORK: ${GAIA_INGRESS_NETWORK:-}
+      # Auth for Gaia's own control-plane API. The SaaS sends this as
+      # `Authorization: Bearer` to create/start/stop habitats. Empty ⇒ open auth
+      # (local dev only — NEVER leave open on a reachable deploy).
+      HABITAT_API_KEY: ${GAIA_API_KEY:-}
       # The provider key Gaia uses for its own chat. Child habitats get their
       # own keys via the master vault + secret bindings, not from here.
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
+    labels:
+      # Gaia is itself a caddy-fronted habitat: control plane over TLS + auth at
+      # GAIA_HOSTNAME, reached by caddy over the network ({{upstreams 7420}}).
+      caddy: ${GAIA_HOSTNAME:-gaia.localhost}
+      caddy.reverse_proxy: "{{upstreams 7420}}"
     volumes:
       # Drive the host docker daemon (spawn/seed/stop child habitats).
       - /var/run/docker.sock:/var/run/docker.sock
@@ -60,18 +73,17 @@ services:
         --provider "$$GAIA_PROVIDER"
         --model "$$GAIA_MODEL"
 
-  # Label-driven reverse proxy (#170). Gives every spawned habitat its own
-  # public HTTPS URL so the habitats SaaS can attach to it DIRECTLY (per-habitat
-  # URL + per-habitat credential) — Gaia is the orchestrator, not the request
-  # path. Caddy watches the docker socket and builds routes from the
-  # `caddy=<host>` / `caddy.reverse_proxy={{upstreams 8080}}` labels that
-  # DockerManager.startContainer stamps on each child (driven by GAIA_BASE_DOMAIN
-  # or a per-habitat hostname). It reaches each child by container DNS over
-  # gaia-net, so the children's loopback -p binding is untouched.
+  # Bundled label-driven reverse proxy (#170) for the fresh-host shape. Gives
+  # Gaia and every spawned habitat its own public HTTPS URL. Caddy watches the
+  # docker socket and builds routes from the `caddy=<host>` /
+  # `caddy.reverse_proxy={{upstreams ...}}` labels on each container, reaching
+  # them by container DNS over gaia-net.
   #
-  # Requires: DNS `*.${GAIA_BASE_DOMAIN}` → this host, and ports 80/443 open
-  # (Caddy auto-provisions Let's Encrypt certs). Auth is pass-through — Caddy
-  # forwards Authorization untouched and each habitat verifies its own token.
+  # Reusing an existing caddy instead? Don't start this service — set
+  # GAIA_INGRESS_NETWORK to that proxy's network and attach Gaia to it
+  # (see README). Requires DNS `*.${GAIA_BASE_DOMAIN}` → this host + 80/443 open;
+  # Caddy auto-provisions Let's Encrypt certs. Auth is pass-through for children
+  # (each verifies its own token); Gaia enforces HABITAT_API_KEY itself.
   caddy:
     image: lucaslorentz/caddy-docker-proxy:2.9-alpine
     container_name: gaia-caddy
@@ -80,9 +92,7 @@ services:
       - "80:80"
       - "443:443"
     environment:
-      # Only build routes from containers on this network (the children).
       CADDY_INGRESS_NETWORKS: gaia-net
-      # Email for Let's Encrypt account / expiry notices (optional).
       CADDY_DOCKER_CADDYFILE_EMAIL: ${CADDY_EMAIL:-}
     networks:
       - gaia-net
@@ -91,17 +101,11 @@ services:
       - caddy-data:/data     # certificates — persist across restarts
       - caddy-config:/config
 
-  # To also expose the Gaia dashboard itself over Caddy, add labels here routing
-  # to the host-networked Gaia (e.g. caddy=${GAIA_HOSTNAME} +
-  # caddy.reverse_proxy=host.docker.internal:${GAIA_PORT} with
-  # extra_hosts: ["host.docker.internal:host-gateway"]). Off by default — the
-  # runbook recommends not exposing 7420 publicly unauthenticated.
-
 networks:
-  # Shared with the children DockerManager spawns (--network gaia-net). Declared
-  # here so `docker compose up` creates it before Caddy attaches; ensureNetwork()
-  # is idempotent when it already exists. `name:` pins the literal name (no
-  # compose project prefix) so it matches what DockerManager looks for.
+  # Shared with the children DockerManager spawns. Declared here so
+  # `docker compose up` creates it before Caddy/Gaia attach; ensureNetwork() is
+  # idempotent when it already exists. `name:` pins the literal name (no compose
+  # project prefix) so it matches what DockerManager looks for.
   gaia-net:
     name: gaia-net
 

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -366,7 +366,19 @@ export async function startContainerServer(
 				}
 
 				// ── Extra raw handler (e.g. Gaia orchestrator routes) ──
+				// This runs BEFORE the per-route auth checks below, so any control
+				// plane it serves under /api/* would otherwise bypass auth entirely
+				// (Gaia's create/start/stop + secret-vault routes). Gate /api/* here.
+				// Static UI + /health stay open (health handled above; UI is served
+				// after this block), matching bearer-auth's "exclude static/health".
 				if (extraRawHandler) {
+					if (authRequired && path.startsWith("/api/")) {
+						const user = await auth.authenticate(req);
+						if (!user) {
+							sendJson(res, { error: "Unauthorized" }, 401);
+							return;
+						}
+					}
 					const handled = await extraRawHandler(req, res);
 					if (handled) return;
 				}

--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -67,8 +67,22 @@ const HABITAT_PORT_BASE = 7440;
 /** Last port in the habitat container range (inclusive). */
 const HABITAT_PORT_MAX = 7499;
 
-function containerName(id: string): string {
+/** Internal port every habitat container listens on (never published publicly). */
+export const CHILD_INTERNAL_PORT = 8080;
+
+/** Container (and embedded-DNS) name for a habitat: `gaia-<id>`. */
+export function containerName(id: string): string {
   return `${CONTAINER_PREFIX}${id}`;
+}
+
+/**
+ * In-network base URL for reaching a habitat from Gaia (or any container on the
+ * shared ingress network): `http://gaia-<id>:8080`. Gaia addresses children by
+ * Docker embedded DNS over the shared network rather than via host loopback
+ * ports, so Gaia no longer needs host networking (#170 follow-up).
+ */
+export function childBaseUrl(id: string): string {
+  return `http://${containerName(id)}:${CHILD_INTERNAL_PORT}`;
 }
 
 function volumeName(id: string): string {

--- a/packages/habitat/src/tools/gaia/gaia-tools/context.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/context.ts
@@ -19,7 +19,12 @@ import {
 import type { GaiaHabitatEntry } from "../types.js";
 import type { GaiaRegistryManager } from "../registry.js";
 import type { GaiaSecretVault } from "../secrets.js";
-import type { DockerManager } from "../docker.js";
+import {
+	type DockerManager,
+	containerName,
+	CHILD_INTERNAL_PORT,
+	resolveHabitatHostname,
+} from "../docker.js";
 import type { CredentialCatalog } from "../credential-catalog.js";
 import type { CredentialAuditLogger } from "../credential-audit.js";
 
@@ -44,15 +49,33 @@ export interface GaiaToolsContext {
 
 /** Adapt a Gaia registry entry to a generic A2A endpoint. */
 export function entryToEndpoint(entry: GaiaHabitatEntry): A2AEndpoint {
+	// containerPort is the "running" marker (set when the container is up);
+	// the address itself is the container's embedded-DNS name on the shared
+	// network, so Gaia no longer needs host networking (#170 follow-up).
 	if (!entry.containerPort) {
 		throw new Error(`Container ${entry.id} not running`);
 	}
 	return {
-		host: "127.0.0.1",
-		port: entry.containerPort,
+		host: containerName(entry.id),
+		port: CHILD_INTERNAL_PORT,
 		apiKey: entry.apiKey,
 		label: entry.id,
 	};
+}
+
+/**
+ * "Open in browser" URL for a habitat: prefer its public Caddy hostname
+ * (reachable from anywhere, valid TLS), falling back to the host loopback port
+ * (only useful on the Gaia host itself). Null when neither is available.
+ */
+export function entryOpenUrl(
+	entry: GaiaHabitatEntry,
+	port: number | undefined = entry.containerPort,
+): string | null {
+	const host = resolveHabitatHostname(entry);
+	if (host) return `https://${host}/?token=${entry.apiKey}`;
+	if (port) return `http://localhost:${port}/?token=${entry.apiKey}`;
+	return null;
 }
 
 /** Fetch agent cards from all running habitats; failures are reported per-entry. */

--- a/packages/habitat/src/tools/gaia/gaia-tools/endpoint.test.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/endpoint.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Gaia addresses children by Docker embedded DNS, not host loopback ports
+ * (#170 follow-up). entryToEndpoint → gaia-<id>:8080; entryOpenUrl prefers the
+ * public Caddy hostname.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { entryToEndpoint, entryOpenUrl } from "./context.js";
+import type { GaiaHabitatEntry } from "../types.js";
+
+function entry(over: Partial<GaiaHabitatEntry> = {}): GaiaHabitatEntry {
+  return {
+    id: "twitter",
+    name: "Twitter",
+    config: { name: "Twitter", agents: [] },
+    secretBindings: [],
+    apiKey: "gaia_k",
+    createdAt: "2026-06-19T00:00:00.000Z",
+    containerPort: 7440,
+    ...over,
+  };
+}
+
+const prevBaseDomain = process.env.GAIA_BASE_DOMAIN;
+afterEach(() => {
+  if (prevBaseDomain === undefined) delete process.env.GAIA_BASE_DOMAIN;
+  else process.env.GAIA_BASE_DOMAIN = prevBaseDomain;
+});
+
+describe("entryToEndpoint (children by DNS)", () => {
+  it("addresses the container by name on the internal port, not 127.0.0.1", () => {
+    const ep = entryToEndpoint(entry());
+    expect(ep.host).toBe("gaia-twitter");
+    expect(ep.port).toBe(8080);
+    expect(ep.apiKey).toBe("gaia_k");
+  });
+
+  it("still requires the container to be running (containerPort set)", () => {
+    expect(() => entryToEndpoint(entry({ containerPort: undefined }))).toThrow(
+      /not running/,
+    );
+  });
+});
+
+describe("entryOpenUrl", () => {
+  it("prefers the public Caddy hostname when GAIA_BASE_DOMAIN is set", () => {
+    process.env.GAIA_BASE_DOMAIN = "habitats.example.com";
+    expect(entryOpenUrl(entry())).toBe(
+      "https://twitter.habitats.example.com/?token=gaia_k",
+    );
+  });
+
+  it("prefers an explicit per-habitat hostname", () => {
+    expect(entryOpenUrl(entry({ hostname: "bird.dev" }))).toBe(
+      "https://bird.dev/?token=gaia_k",
+    );
+  });
+
+  it("falls back to the loopback port when no hostname", () => {
+    delete process.env.GAIA_BASE_DOMAIN;
+    expect(entryOpenUrl(entry())).toBe("http://localhost:7440/?token=gaia_k");
+  });
+
+  it("uses an explicit port override (fresh start, registry not yet updated)", () => {
+    delete process.env.GAIA_BASE_DOMAIN;
+    expect(entryOpenUrl(entry({ containerPort: undefined }), 7441)).toBe(
+      "http://localhost:7441/?token=gaia_k",
+    );
+  });
+
+  it("returns null when neither hostname nor port is available", () => {
+    delete process.env.GAIA_BASE_DOMAIN;
+    expect(entryOpenUrl(entry({ containerPort: undefined }))).toBeNull();
+  });
+});

--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -11,7 +11,7 @@ import type { Tool } from "ai";
 import { sendA2AMessage } from "@umwelten/protocols";
 import { CapabilityResolver } from "../capability-resolver.js";
 import { seedOrgReadonly, seedStandardsAgent } from "../gaia-seed.js";
-import { type GaiaToolsContext, entryToEndpoint, discoverHabitats } from "./context.js";
+import { type GaiaToolsContext, entryToEndpoint, discoverHabitats, entryOpenUrl } from "./context.js";
 import { buildSeedFiles } from "./seed-files.js";
 
 export function createHabitatLifecycleTools(
@@ -44,9 +44,7 @@ export function createHabitatLifecycleTools(
 							model: entry.config.defaultModel ?? "not set",
 							status,
 							port: entry.containerPort ?? null,
-							url: entry.containerPort
-								? `http://localhost:${entry.containerPort}/?token=${entry.apiKey}`
-								: null,
+							url: entryOpenUrl(entry),
 							secretBindings: entry.secretBindings,
 							createdAt: entry.createdAt,
 						};
@@ -199,7 +197,7 @@ export function createHabitatLifecycleTools(
 						"WARNING: No API keys available — the habitat cannot call LLM providers.",
 					);
 				}
-				const url = `http://localhost:${port}/?token=${entry.apiKey}`;
+				const url = entryOpenUrl(entry, port);
 				const msg = `Started habitat "${id}" on port ${port}\nWeb UI: ${url}`;
 				return warnings.length > 0 ? `${msg}\n\n${warnings.join("\n")}` : msg;
 			},
@@ -235,9 +233,7 @@ export function createHabitatLifecycleTools(
 					name: entry.name,
 					containerStatus,
 					port: entry.containerPort ?? null,
-					url: entry.containerPort
-						? `http://localhost:${entry.containerPort}/?token=${entry.apiKey}`
-						: null,
+					url: entryOpenUrl(entry),
 					config: entry.config,
 					secretBindings: entry.secretBindings,
 				};
@@ -400,7 +396,7 @@ export function createHabitatLifecycleTools(
 				await docker.seedVolume(id, buildSeedFiles(entry, vault, catalog));
 				const port = await docker.startContainer(entry, "", registry.list());
 				await registry.update(id, { containerPort: port });
-				const url = `http://localhost:${port}/?token=${entry.apiKey}`;
+				const url = entryOpenUrl(entry, port);
 				return `Rebuilt habitat "${id}" on port ${port}\nWeb UI: ${url}`;
 			},
 		}),

--- a/packages/habitat/src/tools/gaia/proxy.ts
+++ b/packages/habitat/src/tools/gaia/proxy.ts
@@ -6,6 +6,7 @@
 import http from "node:http";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { GaiaHabitatEntry } from "./types.js";
+import { containerName, CHILD_INTERNAL_PORT } from "./docker.js";
 
 /**
  * Proxy a request to a running habitat container.
@@ -30,15 +31,16 @@ export async function proxyRequest(
     req.on("end", () => {
       const body = Buffer.concat(chunks);
 
+      const childHost = containerName(entry.id);
       const proxyReq = http.request(
         {
-          hostname: "127.0.0.1",
-          port: entry.containerPort,
+          hostname: childHost,
+          port: CHILD_INTERNAL_PORT,
           path: targetPath,
           method: req.method,
           headers: {
             ...req.headers,
-            host: `127.0.0.1:${entry.containerPort}`,
+            host: `${childHost}:${CHILD_INTERNAL_PORT}`,
             authorization: `Bearer ${entry.apiKey}`,
           },
         },
@@ -80,8 +82,8 @@ export async function fetchFromContainer<T = unknown>(
   return new Promise<T>((resolve, reject) => {
     const req = http.request(
       {
-        hostname: "127.0.0.1",
-        port: entry.containerPort,
+        hostname: containerName(entry.id),
+        port: CHILD_INTERNAL_PORT,
         path,
         method: "GET",
         headers: {


### PR DESCRIPTION
Makes Gaia a first-class, caddy-fronted, authenticated habitat — so the SaaS provisions habitats over TLS + auth (`https://$GAIA_HOSTNAME`) instead of Gaia running raw on `0.0.0.0:7420` with open auth.

## Why
The SaaS **does** talk to Gaia — it's the control plane for create/start/stop. But Gaia was host-networked (to reach children at `127.0.0.1:<744x>`), so it couldn't sit behind caddy, and its API was exposed unauthenticated with the docker socket mounted (host-root + master secret vault). Fix: deploy Gaia like any other habitat.

## Change
- **Children by DNS, not loopback** — Gaia addresses children at `gaia-<id>:8080` over the shared ingress network (Docker embedded DNS), so it no longer needs host networking. New helpers `childBaseUrl`/`containerName`/`CHILD_INTERNAL_PORT`; `entryToEndpoint` + `proxy.ts` use them. `containerPort` stays purely as the running-marker.
- **Dashboard URLs** — `entryOpenUrl` prefers the habitat's public Caddy hostname over the on-host loopback port.
- **compose** — drop `network_mode: host`; Gaia joins the ingress network and is labeled `caddy=$GAIA_HOSTNAME` / `{{upstreams 7420}}`; control-plane auth via `GAIA_API_KEY` (→ `HABITAT_API_KEY`); no host port publish. `.env.example` + runbook document `GAIA_HOSTNAME`/`GAIA_API_KEY` and the reuse-existing-caddy shape.

Net: control plane (SaaS→Gaia) and data plane (SaaS→habitat) are both TLS + authenticated; nothing on raw 7420.

## Tests
`endpoint.test.ts` (DNS addressing + `entryOpenUrl` hostname/port/fallback). **`pnpm test:run` green: 1483/1483.**

## Live validation
Redeploying on pancake (reuse-existing-caddy shape) as part of this — will confirm `https://gaia.habitats.thefocus.ai` is authed, Gaia reaches children by DNS, raw `7420` goes dark, and existing habitat URLs still serve. (Will note results before merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)