### PR TITLE
feat(habitat): dual-auth (per-user JWT OR shared bearer) + Gaia JWKS injection (ADR 0003)

### DIFF
--- a/deploy/gaia/.env.example
+++ b/deploy/gaia/.env.example
@@ -31,6 +31,11 @@ OPENROUTER_API_KEY=
 # (`docker compose up -d gaia`) — don't start the bundled caddy (it would clash
 # on 80/443). The network must already exist.
 # GAIA_INGRESS_NETWORK=caddy
+#
+# Per-user identity (ADR 0003): SaaS JWKS so spawned habitats verify per-user
+# JWTs (audience = each habitat's public URL). With HABITAT_API_KEY still set,
+# children accept a per-user JWT OR the shared bearer (Gaia relay) — dual-auth.
+# GAIA_JWKS_URL=https://habitats.thefocus.ai/.well-known/jwks.json
 
 # NOTE: child-habitat secrets (X OAuth, DATABASE_URL, child provider keys) are
 # NOT set here — they go into Gaia's master vault after boot (see the runbook),

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -42,6 +42,7 @@ import { WebAdapter } from "./web/WebAdapter.js";
 import { devAuth } from "./web/auth/dev-auth.js";
 import { bearerAuth } from "./web/auth/bearer-auth.js";
 import { jwtAuth } from "./web/auth/jwt-auth.js";
+import { compositeAuth } from "./web/auth/composite-auth.js";
 import { defaultRoutes } from "./web/routes/index.js";
 import type {
 	AuthProvider,
@@ -69,31 +70,40 @@ export interface StartedContainerServer {
 	close: () => void;
 }
 
-type AuthMode = "jwt" | "bearer" | "open";
+type AuthMode = "jwt" | "jwt+bearer" | "bearer" | "open";
 
 /**
  * Select the request AuthProvider from the environment. See the precedence note
  * at the call site and docs/adr/0003-per-user-a2a-identity.md.
  *
  * - `HABITAT_AUTH_AUDIENCE` + (`HABITAT_AUTH_JWKS_URL` | `HABITAT_AUTH_PUBLIC_KEY`)
- *   → per-user JWT verification (production).
- * - `HABITAT_API_KEY` → legacy shared bearer (retiring).
+ *   → per-user JWT verification (production). If `HABITAT_API_KEY` is ALSO set,
+ *   the habitat accepts a valid per-user JWT (identity) OR the shared bearer
+ *   (service trust, e.g. Gaia's relay) — the additive ADR-0003 transition.
+ * - `HABITAT_API_KEY` alone → legacy shared bearer (retiring).
  * - nothing → open dev auth (local only).
  */
 function resolveAuthProvider(): { auth: AuthProvider; authMode: AuthMode } {
 	const audience = process.env.HABITAT_AUTH_AUDIENCE;
 	const jwksUrl = process.env.HABITAT_AUTH_JWKS_URL;
 	const publicKeyPem = process.env.HABITAT_AUTH_PUBLIC_KEY;
+	const apiKey = process.env.HABITAT_API_KEY;
 	if (audience && (jwksUrl || publicKeyPem)) {
-		return {
-			auth: jwtAuth({
-				audience,
-				issuer: process.env.HABITAT_AUTH_ISSUER,
-				jwksUrl,
-				publicKeyPem,
-			}),
-			authMode: "jwt",
-		};
+		const jwt = jwtAuth({
+			audience,
+			issuer: process.env.HABITAT_AUTH_ISSUER,
+			jwksUrl,
+			publicKeyPem,
+		});
+		// Dual-auth during the transition: JWT (identity) OR shared bearer
+		// (service trust) so enabling JWT doesn't lock out Gaia's relay.
+		if (apiKey) {
+			return {
+				auth: compositeAuth("jwt+bearer", [jwt, bearerAuth(apiKey)]),
+				authMode: "jwt+bearer",
+			};
+		}
+		return { auth: jwt, authMode: "jwt" };
 	}
 	// Misconfiguration guard: a key without an audience (or vice-versa) almost
 	// certainly means the operator intended JWT auth — fail loud rather than
@@ -104,7 +114,6 @@ function resolveAuthProvider(): { auth: AuthProvider; authMode: AuthMode } {
 				"HABITAT_AUTH_JWKS_URL or HABITAT_AUTH_PUBLIC_KEY (see ADR 0003).",
 		);
 	}
-	const apiKey = process.env.HABITAT_API_KEY;
 	if (apiKey) return { auth: bearerAuth(apiKey), authMode: "bearer" };
 	return { auth: devAuth(), authMode: "open" };
 }

--- a/packages/habitat/src/tools/gaia/caddy-labels.test.ts
+++ b/packages/habitat/src/tools/gaia/caddy-labels.test.ts
@@ -81,11 +81,13 @@ describe('Gaia Caddy label emission (#170)', () => {
   let docker: DockerManager;
   const prevBaseDomain = process.env.GAIA_BASE_DOMAIN;
   const prevIngress = process.env.GAIA_INGRESS_NETWORK;
+  const prevJwks = process.env.GAIA_JWKS_URL;
 
   beforeEach(async () => {
     recordedCalls = [];
     delete process.env.GAIA_BASE_DOMAIN;
     delete process.env.GAIA_INGRESS_NETWORK;
+    delete process.env.GAIA_JWKS_URL;
     dataDir = await mkdtemp(join(tmpdir(), 'umwl-gaia-caddy-'));
     docker = new DockerManager(dataDir, '/tmp/project');
   });
@@ -95,7 +97,39 @@ describe('Gaia Caddy label emission (#170)', () => {
     else process.env.GAIA_BASE_DOMAIN = prevBaseDomain;
     if (prevIngress === undefined) delete process.env.GAIA_INGRESS_NETWORK;
     else process.env.GAIA_INGRESS_NETWORK = prevIngress;
+    if (prevJwks === undefined) delete process.env.GAIA_JWKS_URL;
+    else process.env.GAIA_JWKS_URL = prevJwks;
     await rm(dataDir, { recursive: true, force: true });
+  });
+
+  /** Values that follow each `--env` flag in the recorded docker run args. */
+  function envs(args: string[]): string[] {
+    return args.filter((_, i) => args[i - 1] === '--env');
+  }
+
+  it('injects HABITAT_AUTH_* (JWT-verify) when GAIA_JWKS_URL + hostname are set', async () => {
+    process.env.GAIA_BASE_DOMAIN = 'habitats.example.com';
+    process.env.GAIA_JWKS_URL = 'https://habitats.example.com/.well-known/jwks.json';
+    await docker.startContainer(makeEntry(), '', []);
+    const e = envs(runArgs());
+    expect(e).toContain('HABITAT_AUTH_AUDIENCE=https://twitter.habitats.example.com');
+    expect(e).toContain('HABITAT_AUTH_JWKS_URL=https://habitats.example.com/.well-known/jwks.json');
+    // shared bearer stays → dual-auth
+    expect(e).toContain('HABITAT_API_KEY=gaia_testkey');
+  });
+
+  it('omits HABITAT_AUTH_* when GAIA_JWKS_URL is unset (bearer-only)', async () => {
+    process.env.GAIA_BASE_DOMAIN = 'habitats.example.com';
+    await docker.startContainer(makeEntry(), '', []);
+    const e = envs(runArgs());
+    expect(e.some((v) => v.startsWith('HABITAT_AUTH_'))).toBe(false);
+    expect(e).toContain('HABITAT_API_KEY=gaia_testkey');
+  });
+
+  it('omits HABITAT_AUTH_* when there is no hostname even if GAIA_JWKS_URL is set', async () => {
+    process.env.GAIA_JWKS_URL = 'https://habitats.example.com/.well-known/jwks.json';
+    await docker.startContainer(makeEntry(), '', []);
+    expect(envs(runArgs()).some((v) => v.startsWith('HABITAT_AUTH_'))).toBe(false);
   });
 
   it('emits no caddy labels when no hostname is resolvable (local dev)', async () => {

--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -215,6 +215,19 @@ export class DockerManager {
       );
     }
 
+    // Per-user identity (ADR 0003): when a JWKS is configured, spawn the child
+    // in JWT-verify mode (audience = its own public URL, keys from the SaaS
+    // JWKS). HABITAT_API_KEY above stays, so the habitat accepts a per-user JWT
+    // (from the SaaS) OR the shared bearer (Gaia's relay) — dual-auth. Needs a
+    // public hostname to form the audience; unset GAIA_JWKS_URL ⇒ bearer-only.
+    const jwksUrl = process.env.GAIA_JWKS_URL?.trim();
+    if (hostname && jwksUrl) {
+      args.push(
+        "--env", `HABITAT_AUTH_AUDIENCE=https://${hostname}`,
+        "--env", `HABITAT_AUTH_JWKS_URL=${jwksUrl}`,
+      );
+    }
+
     args.push(image);
 
     await execFile("docker", args);

--- a/packages/habitat/src/web/auth/composite-auth.test.ts
+++ b/packages/habitat/src/web/auth/composite-auth.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import type { IncomingMessage } from "node:http";
+import type { AuthProvider, UserContext } from "../types.js";
+import { compositeAuth } from "./composite-auth.js";
+
+function provider(name: string, user: UserContext | null): AuthProvider {
+  return { name, authenticate: vi.fn(async () => user) };
+}
+const req = {} as IncomingMessage;
+
+describe("compositeAuth", () => {
+  it("returns the first provider's user when it authenticates", async () => {
+    const jwtUser = { userId: "sub-1", provider: "oauth" as const };
+    const auth = compositeAuth("jwt+bearer", [
+      provider("jwt", jwtUser),
+      provider("bearer", { userId: "bearer-user" }),
+    ]);
+    expect(await auth.authenticate(req)).toEqual(jwtUser);
+  });
+
+  it("falls through to the next provider when the first declines", async () => {
+    const bearerUser = { userId: "bearer-user", provider: "oauth" as const };
+    const second = provider("bearer", bearerUser);
+    const auth = compositeAuth("jwt+bearer", [provider("jwt", null), second]);
+    expect(await auth.authenticate(req)).toEqual(bearerUser);
+    expect(second.authenticate).toHaveBeenCalled();
+  });
+
+  it("returns null when every provider declines", async () => {
+    const auth = compositeAuth("x", [provider("a", null), provider("b", null)]);
+    expect(await auth.authenticate(req)).toBeNull();
+  });
+
+  it("does not call later providers once one succeeds", async () => {
+    const second = provider("bearer", { userId: "bearer-user" });
+    const auth = compositeAuth("x", [
+      provider("jwt", { userId: "sub-1" }),
+      second,
+    ]);
+    await auth.authenticate(req);
+    expect(second.authenticate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/habitat/src/web/auth/composite-auth.ts
+++ b/packages/habitat/src/web/auth/composite-auth.ts
@@ -1,0 +1,37 @@
+/**
+ * Composite auth — try each provider in order; the first to return a
+ * UserContext wins (ADR 0003 transition).
+ *
+ * Lets a habitat accept a per-user JWT (identity — from the SaaS) AND the
+ * legacy shared bearer (service trust — e.g. Gaia's dashboard/relay, which
+ * dials children with the shared HABITAT_API_KEY) at the same time. Without
+ * this, turning on JWT verification would lock out Gaia's own relay.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { AuthProvider, UserContext } from "../types.js";
+
+export function compositeAuth(
+  name: string,
+  providers: AuthProvider[],
+): AuthProvider {
+  return {
+    name,
+    async authenticate(req: IncomingMessage): Promise<UserContext | null> {
+      for (const p of providers) {
+        const user = await p.authenticate(req);
+        if (user) return user;
+      }
+      return null;
+    },
+    async handleAuthRoute(
+      req: IncomingMessage,
+      res: ServerResponse,
+    ): Promise<boolean> {
+      for (const p of providers) {
+        if (p.handleAuthRoute && (await p.handleAuthRoute(req, res))) return true;
+      }
+      return false;
+    },
+  };
+}


### PR DESCRIPTION
Closes the per-user-JWT loop for **Gaia-managed** habitats. The blocker: Gaia's own relay dials children with the shared bearer, so flipping a child to JWT-only would lock Gaia out. Fix: let a habitat accept **either** auth during the additive transition.

## Change
- **`web/auth/composite-auth.ts`** — `compositeAuth()` tries providers in order; first non-null `UserContext` wins.
- **`container-server` `resolveAuthProvider`** — when `HABITAT_AUTH_*` **and** `HABITAT_API_KEY` are both set → `compositeAuth([jwtAuth, bearerAuth])` (authMode `jwt+bearer`): a per-user JWT (identity, from the SaaS) **or** the shared bearer (service trust, Gaia's relay). JWT-only and bearer-only modes unchanged.
- **`gaia/docker.ts`** — when `GAIA_JWKS_URL` is set, inject `HABITAT_AUTH_AUDIENCE=https://<hostname>` + `HABITAT_AUTH_JWKS_URL` into spawned children (keeps `HABITAT_API_KEY` → dual-auth). Unset ⇒ bearer-only (unchanged).
- `.env.example`: `GAIA_JWKS_URL`.

## Proven live on pancake
- mint (merged #54 SaaS code) → verify (#163/#164): valid per-user JWT → **200**, wrong-audience/garbage/no-token → **401**.
- dual-auth habitat (`auth: jwt+bearer`): per-user JWT → **200**, shared bearer → **200**, bad → **401**.

## Tests
`composite-auth` matrix + `docker` `HABITAT_AUTH_*` emission. `pnpm test:run` green (**1490**).

## Note on #165
Deleting the shared key (#165) stays **queued**: Gaia's *control plane* still authenticates with `HABITAT_API_KEY`, and habitats need the SaaS minting in **prod** (JWKS live) before requiring JWT. This PR is the additive enabler; the flip comes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)