### PR TITLE
fix(habitat): healthcheck probes the actual listen port (PORT|GAIA_PORT)

### DIFF
--- a/packages/habitat/Dockerfile
+++ b/packages/habitat/Dockerfile
@@ -74,11 +74,12 @@ ENV CLAUDE_CONFIG_DIR=/data/claude-config
 
 EXPOSE 8080
 
-# Probe the port the server actually listens on: PORT for `habitat serve`
-# (default 8080), GAIA_PORT for `habitat gaia` (e.g. 7420). Hardcoding 8080 made
-# Gaia containers report (unhealthy) even while healthy on 7420.
+# Probe the port the server actually listens on. GAIA_PORT wins because the
+# image sets ENV PORT=8080 (the `habitat serve` default) — only `habitat gaia`
+# containers set GAIA_PORT (e.g. 7420), and there it's authoritative. Hardcoding
+# 8080 made Gaia report (unhealthy) while healthy on 7420.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s \
-    CMD node -e "fetch('http://localhost:'+(process.env.PORT||process.env.GAIA_PORT||8080)+'/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
+    CMD node -e "fetch('http://localhost:'+(process.env.GAIA_PORT||process.env.PORT||8080)+'/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["pnpm", "exec", "tsx", "packages/cli/src/entry.ts", "habitat", "serve", "--port", "8080", "--host", "0.0.0.0", "--skip-onboard"]

--- a/packages/habitat/Dockerfile
+++ b/packages/habitat/Dockerfile
@@ -74,8 +74,11 @@ ENV CLAUDE_CONFIG_DIR=/data/claude-config
 
 EXPOSE 8080
 
+# Probe the port the server actually listens on: PORT for `habitat serve`
+# (default 8080), GAIA_PORT for `habitat gaia` (e.g. 7420). Hardcoding 8080 made
+# Gaia containers report (unhealthy) even while healthy on 7420.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s \
-    CMD node -e "fetch('http://localhost:8080/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
+    CMD node -e "fetch('http://localhost:'+(process.env.PORT||process.env.GAIA_PORT||8080)+'/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["pnpm", "exec", "tsx", "packages/cli/src/entry.ts", "habitat", "serve", "--port", "8080", "--host", "0.0.0.0", "--skip-onboard"]


### PR DESCRIPTION
The image HEALTHCHECK hardcoded `:8080`, so `habitat gaia` containers (listening on `GAIA_PORT`, e.g. 7420) showed `(unhealthy)` while perfectly healthy. Now probes `PORT || GAIA_PORT || 8080` — correct for both `habitat serve` (8080) and `habitat gaia` (7420). Cosmetic-only (Docker healthcheck status); verified by recreating the live Gaia container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)