### PR TITLE
feat(a2a): advertise per-user JWT capability in the agent card (#184)

### DIFF
--- a/packages/habitat/src/a2a-handler.test.ts
+++ b/packages/habitat/src/a2a-handler.test.ts
@@ -110,6 +110,31 @@ describe("buildAgentCard — securitySchemes", () => {
 		});
 		expect(card.security).toEqual([{ bearer: [] }]);
 	});
+
+	it("advertises bearerFormat JWT in jwt mode (per-user grants, ADR 0003)", async () => {
+		const card = await buildAgentCard({
+			baseUrl: "http://localhost:7430",
+			habitat: await makeHost(),
+			requiresApiKey: true,
+			jwtMode: true,
+		});
+		expect(
+			(card.securitySchemes as Record<string, { bearerFormat?: string }>).bearer
+				.bearerFormat,
+		).toBe("JWT");
+	});
+
+	it("omits bearerFormat for a plain shared bearer (no jwt mode)", async () => {
+		const card = await buildAgentCard({
+			baseUrl: "http://localhost:7430",
+			habitat: await makeHost(),
+			requiresApiKey: true,
+		});
+		expect(
+			(card.securitySchemes as Record<string, { bearerFormat?: string }>).bearer
+				.bearerFormat,
+		).toBeUndefined();
+	});
 });
 
 // ── 2 + 3. executor: task tracking, usage metadata, cancel ──────

--- a/packages/habitat/src/a2a-handler.ts
+++ b/packages/habitat/src/a2a-handler.ts
@@ -52,6 +52,13 @@ export interface AgentCardOptions {
    * on 401. Set iff the host enforces an API key on /a2a.
    */
   requiresApiKey?: boolean;
+  /**
+   * When true, the bearer the habitat accepts is a per-user JWT (jwt /
+   * jwt+bearer mode, ADR 0003). Advertised as `bearerFormat: "JWT"` so the
+   * habitats SaaS knows to mint a per-user grant (aud = this habitat) instead
+   * of sending a static shared bearer.
+   */
+  jwtMode?: boolean;
 }
 
 export async function buildAgentCard(
@@ -95,8 +102,10 @@ export async function buildAgentCard(
             bearer: {
               type: "http" as const,
               scheme: "bearer",
-              description:
-                "API key as a bearer token (Authorization: Bearer <HABITAT_API_KEY>).",
+              ...(options.jwtMode ? { bearerFormat: "JWT" as const } : {}),
+              description: options.jwtMode
+                ? "Per-user JWT (ADR 0003): Authorization: Bearer <JWT>, minted by the habitats SaaS and verified via its JWKS. The shared HABITAT_API_KEY is also accepted during the transition."
+                : "API key as a bearer token (Authorization: Bearer <HABITAT_API_KEY>).",
             },
           },
           security: [{ bearer: [] }],
@@ -336,6 +345,8 @@ export interface A2AHandlerOptions {
   description?: string;
   /** Declare bearer auth in the agent card (set iff /a2a enforces an API key). */
   requiresApiKey?: boolean;
+  /** Advertise per-user JWT capability (bearerFormat: JWT) — jwt/jwt+bearer mode. */
+  jwtMode?: boolean;
 }
 
 /**
@@ -354,6 +365,7 @@ export async function createA2AHandler(
     name: options.name,
     description: options.description,
     requiresApiKey: options.requiresApiKey,
+    jwtMode: options.jwtMode,
   });
 
   const executor = new HabitatAgentExecutor(options.habitat, options.bridge);

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -308,6 +308,7 @@ export async function startContainerServer(
 				baseUrl,
 				name: serverName,
 				requiresApiKey: authRequired,
+				jwtMode: authMode === "jwt" || authMode === "jwt+bearer",
 			});
 		}
 		return a2aHandler;


### PR DESCRIPTION
Closes #184. The habitat's agent card now advertises JWT capability via the standard `securitySchemes.bearer.bearerFormat = "JWT"` when in `jwt`/`jwt+bearer` mode, so the habitats SaaS can detect it on attach and mint a per-user grant instead of sending the static bearer. Bearer-only mode unchanged; `container-server` threads the auth mode to `buildAgentCard`.

Pairs with habitats #60 (the keystone: attach reads this → sets `config.audience` → dispatch mints). Test added; `pnpm test:run` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)