### PR TITLE
feat(twitter): per-user X tokens keyed by the verified A2A sub (#176)

### DIFF
--- a/examples/twitter-habitat/src/token-store.test.ts
+++ b/examples/twitter-habitat/src/token-store.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   XTokenStore,
   habitatSecretStore,
+  perUserTokenStores,
+  refreshTokenSecretKey,
   X_CLIENT_ID_SECRET,
   X_CLIENT_SECRET_SECRET,
   X_REFRESH_TOKEN_SECRET,
@@ -219,5 +221,67 @@ describe('habitatSecretStore', () => {
     expect(store.get('FOO')).toBe('bar');
     await store.set('FOO', 'baz');
     expect(data.FOO).toBe('baz');
+  });
+});
+
+// ── Per-user tokens (ADR 0003 / #176) ─────────────────────────────────
+
+describe('refreshTokenSecretKey', () => {
+  it('uses the shared key with no subject, a per-user key with one', () => {
+    expect(refreshTokenSecretKey()).toBe(X_REFRESH_TOKEN_SECRET);
+    expect(refreshTokenSecretKey('user-42')).toBe(`${X_REFRESH_TOKEN_SECRET}:user-42`);
+  });
+});
+
+describe('XTokenStore — per-subject', () => {
+  it('reads/writes the per-user refresh-token secret when a subject is set', async () => {
+    const secrets = fakeSecrets({
+      [X_CLIENT_ID_SECRET]: 'cid',
+      [X_CLIENT_SECRET_SECRET]: 'csecret',
+      [`${X_REFRESH_TOKEN_SECRET}:alice`]: 'alice-refresh-0',
+    });
+    const { fn, calls } = fakeFetch([tokenPayload('alice-access', 'alice-refresh-1')]);
+    const store = new XTokenStore({ secrets, fetchFn: fn, subject: 'alice' });
+
+    expect(await store.getValidToken()).toBe('alice-access');
+    // presented alice's refresh token, rotated it back under alice's key only
+    expect(calls[0].body).toContain('refresh_token=alice-refresh-0');
+    expect(secrets.data[`${X_REFRESH_TOKEN_SECRET}:alice`]).toBe('alice-refresh-1');
+    expect(secrets.data[X_REFRESH_TOKEN_SECRET]).toBeUndefined();
+  });
+
+  it("needs_reauth when the speaker's own token is absent", async () => {
+    const secrets = fakeSecrets({
+      [X_CLIENT_ID_SECRET]: 'cid',
+      [X_CLIENT_SECRET_SECRET]: 'csecret',
+      // no per-user key for bob
+    });
+    const { fn } = fakeFetch([]);
+    const store = new XTokenStore({ secrets, fetchFn: fn, subject: 'bob' });
+    await expect(store.getValidToken()).rejects.toMatchObject({ kind: 'needs_reauth' });
+  });
+});
+
+describe('perUserTokenStores', () => {
+  function habitat(initial: Record<string, string>, currentUser?: string) {
+    const secrets = fakeSecrets(initial);
+    return {
+      getSecret: (n: string) => secrets.get(n),
+      setSecret: (n: string, v: string) => secrets.set(n, v),
+      getCurrentUserId: () => currentUser,
+    };
+  }
+
+  it('returns a subject-scoped store for the current speaker', async () => {
+    const reg = perUserTokenStores(habitat({}, 'carol'));
+    expect(reg.currentSubject()).toBe('carol');
+    // same speaker → same (cached) store instance
+    expect(reg.current()).toBe(reg.current());
+  });
+
+  it('falls back to the shared operator store when there is no speaker', () => {
+    const reg = perUserTokenStores(habitat({}, undefined));
+    expect(reg.currentSubject()).toBeUndefined();
+    expect(reg.current()).toBe(reg.current());
   });
 });

--- a/examples/twitter-habitat/src/token-store.ts
+++ b/examples/twitter-habitat/src/token-store.ts
@@ -56,6 +56,8 @@ export interface SecretStore {
 interface HabitatLike {
   getSecret(name: string): string | undefined;
   setSecret(name: string, value: string): Promise<void>;
+  /** The verified speaking user (ADR 0003) when present — keys per-user tokens. */
+  getCurrentUserId?(): string | undefined;
 }
 
 /** Adapt a `Habitat` (or anything with getSecret/setSecret) into a {@link SecretStore}. */
@@ -74,6 +76,19 @@ export interface XTokenStoreOptions {
   now?: () => number;
   /** Refresh this many ms before expiry. Defaults to 5 minutes. */
   refreshSkewMs?: number;
+  /**
+   * The speaking user (verified A2A `sub`, ADR 0003). When set, the refresh
+   * token is read/written under a per-user secret key
+   * (`TWITTER_REFRESH_TOKEN:<subject>`) so each user has their own X account.
+   * Omitted ⇒ the single shared operator token (`TWITTER_REFRESH_TOKEN`) — the
+   * original single-tenant behavior.
+   */
+  subject?: string;
+}
+
+/** Per-user refresh-token secret key, or the shared operator key when no subject. */
+export function refreshTokenSecretKey(subject?: string): string {
+  return subject ? `${X_REFRESH_TOKEN_SECRET}:${subject}` : X_REFRESH_TOKEN_SECRET;
 }
 
 export class XTokenStore {
@@ -81,6 +96,8 @@ export class XTokenStore {
   private readonly fetchFn: FetchLike;
   private readonly now: () => number;
   private readonly skewMs: number;
+  /** Secret key holding this store's (rotating) refresh token — per-user or shared. */
+  private readonly refreshKey: string;
 
   private cachedAccessToken: string | undefined;
   private expiresAtMs = 0;
@@ -92,6 +109,7 @@ export class XTokenStore {
     this.fetchFn = opts.fetchFn ?? fetch;
     this.now = opts.now ?? Date.now;
     this.skewMs = opts.refreshSkewMs ?? DEFAULT_REFRESH_SKEW_MS;
+    this.refreshKey = refreshTokenSecretKey(opts.subject);
   }
 
   /**
@@ -128,11 +146,12 @@ export class XTokenStore {
   }
 
   private async refresh(): Promise<string> {
-    const refreshToken = this.secrets.get(X_REFRESH_TOKEN_SECRET);
+    const refreshToken = this.secrets.get(this.refreshKey);
     if (!refreshToken) {
       throw new XAuthError(
-        `No X refresh token found. Run the OAuth bootstrap script and store the result ` +
-          `as the ${X_REFRESH_TOKEN_SECRET} habitat secret before using the Twitter tools.`,
+        `No X refresh token found (secret ${this.refreshKey}). Connect this user's ` +
+          `X account (or run the OAuth bootstrap) so the token is stored before using ` +
+          `the Twitter tools.`,
         'needs_reauth',
       );
     }
@@ -142,10 +161,41 @@ export class XTokenStore {
     // Persist the rotated refresh token BEFORE returning (transaction): X has already
     // consumed the old one server-side, so the new one must reach durable storage or
     // the next refresh is dead. Do this before updating the cache or releasing the lock.
-    await this.secrets.set(X_REFRESH_TOKEN_SECRET, tokens.refresh_token);
+    await this.secrets.set(this.refreshKey, tokens.refresh_token);
 
     this.cachedAccessToken = tokens.access_token;
     this.expiresAtMs = this.now() + (tokens.expires_in ?? DEFAULT_EXPIRES_IN_S) * 1000;
     return tokens.access_token;
   }
+}
+
+/**
+ * Per-user token-store registry for the private read tools (ADR 0003 / #176).
+ *
+ * Resolves the current speaker via `habitat.getCurrentUserId()` and hands back a
+ * subject-scoped {@link XTokenStore} (cached per subject so the access-token
+ * cache + single-flight refresh are shared across calls for that user). When
+ * there is no speaker (off the A2A path, or no per-user grant) it falls back to
+ * the shared operator store — preserving single-tenant behavior.
+ */
+export function perUserTokenStores(habitat: HabitatLike) {
+  const secrets = habitatSecretStore(habitat);
+  const bySubject = new Map<string, XTokenStore>();
+  return {
+    /** The current speaker's `sub`, or undefined (operator/shared mode). */
+    currentSubject(): string | undefined {
+      return habitat.getCurrentUserId?.();
+    },
+    /** Token store for the current speaker (or the shared operator token). */
+    current(): XTokenStore {
+      const subject = habitat.getCurrentUserId?.();
+      const key = subject ?? "";
+      let store = bySubject.get(key);
+      if (!store) {
+        store = new XTokenStore({ secrets, subject });
+        bySubject.set(key, store);
+      }
+      return store;
+    },
+  };
 }

--- a/examples/twitter-habitat/tools/bookmarks/handler.ts
+++ b/examples/twitter-habitat/tools/bookmarks/handler.ts
@@ -12,19 +12,22 @@
 
 import { tool } from 'ai';
 import { z } from 'zod';
-import { XTokenStore, habitatSecretStore } from '../../src/token-store.js';
+import { perUserTokenStores } from '../../src/token-store.js';
 import { XReadClient } from '../../src/x-read-client.js';
 import { XAuthError } from '../../src/x-oauth.js';
 
 interface HabitatLike {
   getSecret(name: string): string | undefined;
   setSecret(name: string, value: string): Promise<void>;
+  /** Verified speaking user (ADR 0003) — keys this user's own X token. */
+  getCurrentUserId?(): string | undefined;
 }
 
 export default (habitat: unknown) => {
-  const secrets = habitatSecretStore(habitat as HabitatLike);
-  const tokens = new XTokenStore({ secrets });
-  const client = new XReadClient(tokens);
+  // Per-user tokens (ADR 0003 / #176): resolve the speaker each call and read
+  // their own X account; falls back to the shared operator token off the
+  // per-user path.
+  const userTokens = perUserTokenStores(habitat as HabitatLike);
 
   return tool({
     description:
@@ -40,16 +43,18 @@ export default (habitat: unknown) => {
         .describe('How many bookmarks to return (default 20, max 100).'),
     }),
     async execute({ limit }) {
+      const client = new XReadClient(userTokens.current());
       try {
         const bookmarks = await client.getBookmarks({ maxResults: limit ?? 20 });
         return { count: bookmarks.length, bookmarks };
       } catch (err) {
         if (err instanceof XAuthError && err.kind === 'needs_reauth') {
+          const sub = userTokens.currentSubject();
           return {
-            error:
-              'Twitter is not authenticated yet. Run the OAuth bootstrap and store the ' +
-              'TWITTER_REFRESH_TOKEN secret on this habitat.',
-            kind: err.kind,
+            error: sub
+              ? "Your X account isn't connected yet. Connect it in the habitats app to see your bookmarks."
+              : 'Twitter is not authenticated. Connect an X account (or run the OAuth bootstrap) for this habitat.',
+            kind: 'needs_x_connect',
           };
         }
         return { error: err instanceof Error ? err.message : String(err) };

--- a/examples/twitter-habitat/tools/mentions/handler.ts
+++ b/examples/twitter-habitat/tools/mentions/handler.ts
@@ -11,19 +11,19 @@
 
 import { tool } from 'ai';
 import { z } from 'zod';
-import { XTokenStore, habitatSecretStore } from '../../src/token-store.js';
+import { perUserTokenStores } from '../../src/token-store.js';
 import { XReadClient } from '../../src/x-read-client.js';
 import { XAuthError } from '../../src/x-oauth.js';
 
 interface HabitatLike {
   getSecret(name: string): string | undefined;
   setSecret(name: string, value: string): Promise<void>;
+  /** Verified speaking user (ADR 0003) — keys this user's own X token. */
+  getCurrentUserId?(): string | undefined;
 }
 
 export default (habitat: unknown) => {
-  const secrets = habitatSecretStore(habitat as HabitatLike);
-  const tokens = new XTokenStore({ secrets });
-  const client = new XReadClient(tokens);
+  const userTokens = perUserTokenStores(habitat as HabitatLike);
 
   return tool({
     description:
@@ -39,12 +39,19 @@ export default (habitat: unknown) => {
         .describe('How many mentions to return (default 20, min 5, max 100).'),
     }),
     async execute({ limit }) {
+      const client = new XReadClient(userTokens.current());
       try {
         const mentions = await client.getMentions({ maxResults: limit ?? 20 });
         return { count: mentions.length, mentions };
       } catch (err) {
         if (err instanceof XAuthError && err.kind === 'needs_reauth') {
-          return { error: err.message, kind: err.kind };
+          const sub = userTokens.currentSubject();
+          return {
+            error: sub
+              ? "Your X account isn't connected yet. Connect it in the habitats app to see your mentions."
+              : 'Twitter is not authenticated. Connect an X account (or run the OAuth bootstrap) for this habitat.',
+            kind: 'needs_x_connect',
+          };
         }
         return { error: err instanceof Error ? err.message : String(err) };
       }

--- a/examples/twitter-habitat/tools/my_timeline/handler.ts
+++ b/examples/twitter-habitat/tools/my_timeline/handler.ts
@@ -13,19 +13,19 @@
 
 import { tool } from 'ai';
 import { z } from 'zod';
-import { XTokenStore, habitatSecretStore } from '../../src/token-store.js';
+import { perUserTokenStores } from '../../src/token-store.js';
 import { XReadClient } from '../../src/x-read-client.js';
 import { XAuthError } from '../../src/x-oauth.js';
 
 interface HabitatLike {
   getSecret(name: string): string | undefined;
   setSecret(name: string, value: string): Promise<void>;
+  /** Verified speaking user (ADR 0003) — keys this user's own X token. */
+  getCurrentUserId?(): string | undefined;
 }
 
 export default (habitat: unknown) => {
-  const secrets = habitatSecretStore(habitat as HabitatLike);
-  const tokens = new XTokenStore({ secrets });
-  const client = new XReadClient(tokens);
+  const userTokens = perUserTokenStores(habitat as HabitatLike);
 
   return tool({
     description:
@@ -42,12 +42,19 @@ export default (habitat: unknown) => {
         .describe('How many timeline posts to return (default 20, max 100).'),
     }),
     async execute({ limit }) {
+      const client = new XReadClient(userTokens.current());
       try {
         const posts = await client.getHomeTimeline({ maxResults: limit ?? 20 });
         return { count: posts.length, posts };
       } catch (err) {
         if (err instanceof XAuthError && err.kind === 'needs_reauth') {
-          return { error: err.message, kind: err.kind };
+          const sub = userTokens.currentSubject();
+          return {
+            error: sub
+              ? "Your X account isn't connected yet. Connect it in the habitats app to see your timeline."
+              : 'Twitter is not authenticated. Connect an X account (or run the OAuth bootstrap) for this habitat.',
+            kind: 'needs_x_connect',
+          };
         }
         return { error: err instanceof Error ? err.message : String(err) };
       }


### PR DESCRIPTION
Closes #176 (slice 2 of multi-tenant Twitter; needs slice 1 #186 for `getCurrentUserId` at runtime).

Each speaker reads their **own** X account instead of one shared operator token.

- **token-store**: `XTokenStore({ subject })` keys the refresh token per-user (`TWITTER_REFRESH_TOKEN:<sub>`); no subject ⇒ shared operator key (unchanged). `perUserTokenStores(habitat)` resolves the speaker via `habitat.getCurrentUserId()` and returns a cached per-subject store; falls back to operator off the per-user path.
- **bookmarks / mentions / my_timeline**: resolve the current speaker each call; unlinked speaker → `needs_x_connect` ("connect your X account") rather than leaking another user's data.

Tests: per-subject keying, needs_reauth-when-absent, resolve/cache/fallback — **48 standalone tests pass, `tsc` clean**.

**Seeding contract for habitats #56:** the SaaS writes a user's refresh token to the habitat secret `TWITTER_REFRESH_TOKEN:<sub>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)