### PR TITLE
feat(gaia): verify per-user JWTs on Gaia's own A2A surface (ADR 0003)

### DIFF
--- a/deploy/gaia/.env.example
+++ b/deploy/gaia/.env.example
@@ -32,10 +32,16 @@ OPENROUTER_API_KEY=
 # on 80/443). The network must already exist.
 # GAIA_INGRESS_NETWORK=caddy
 #
-# Per-user identity (ADR 0003): SaaS JWKS so spawned habitats verify per-user
-# JWTs (audience = each habitat's public URL). With HABITAT_API_KEY still set,
-# children accept a per-user JWT OR the shared bearer (Gaia relay) — dual-auth.
+# Per-user identity (ADR 0003): SaaS JWKS so habitats verify per-user JWTs. With
+# HABITAT_API_KEY still set, this is dual-auth — a per-user JWT (identity) OR the
+# shared bearer (Gaia relay). Two scopes, both fed from GAIA_JWKS_URL:
+#   - spawned CHILDREN verify JWTs (audience = each child's public URL); and
+#   - GAIA ITSELF verifies JWTs on its own A2A surface (audience =
+#     GAIA_AUTH_AUDIENCE below) — this is what lets the SaaS attach Gaia with NO
+#     pasted bearer token (its card then advertises bearerFormat:"JWT").
+# Leave both unset ⇒ bearer-only (legacy). Set BOTH to turn JWT on for Gaia.
 # GAIA_JWKS_URL=https://habitats.thefocus.ai/.well-known/jwks.json
+# GAIA_AUTH_AUDIENCE=https://gaia.habitats.example.com   # Gaia's own HTTPS origin
 
 # NOTE: child-habitat secrets (X OAuth, DATABASE_URL, child provider keys) are
 # NOT set here — they go into Gaia's master vault after boot (see the runbook),

--- a/deploy/gaia/README.md
+++ b/deploy/gaia/README.md
@@ -244,8 +244,21 @@ docker run -d --name gaia --restart unless-stopped \
   -e GAIA_PROVIDER -e GAIA_MODEL -e OPENROUTER_API_KEY \
   -e GAIA_BASE_DOMAIN=habitats.example.com -e GAIA_INGRESS_NETWORK=caddy \
   -e HABITAT_API_KEY="$GAIA_API_KEY" \
+  -e GAIA_JWKS_URL=https://habitats.thefocus.ai/.well-known/jwks.json \
+  -e HABITAT_AUTH_AUDIENCE=https://gaia.habitats.example.com \
+  -e HABITAT_AUTH_JWKS_URL=https://habitats.thefocus.ai/.well-known/jwks.json \
   habitat sh -c 'pnpm exec tsx packages/cli/src/entry.ts habitat gaia --port 7420 --data-dir /opt/gaia-data --provider "$GAIA_PROVIDER" --model "$GAIA_MODEL"'
 ```
+
+> **Per-user identity (ADR 0003).** The last three `-e` flags turn on per-user
+> JWT verification. `GAIA_JWKS_URL` makes spawned **children** verify JWTs;
+> `HABITAT_AUTH_AUDIENCE` (Gaia's own HTTPS origin) + `HABITAT_AUTH_JWKS_URL`
+> make **Gaia itself** verify them on its `/a2a` surface. Because `HABITAT_API_KEY`
+> stays set, Gaia runs dual-auth (`jwt+bearer`): the SaaS can attach it with **no
+> pasted bearer token** (its card advertises `bearerFormat:"JWT"` and the SaaS
+> mints a per-user grant), while the legacy shared bearer still works. Omit all
+> three for legacy bearer-only. To migrate an already-running Gaia in place, use
+> `deploy/gaia/recreate-gaia-jwt.sh` (reversible, derives current env).
 
 ---
 

--- a/deploy/gaia/docker-compose.yml
+++ b/deploy/gaia/docker-compose.yml
@@ -48,6 +48,17 @@ services:
       # `Authorization: Bearer` to create/start/stop habitats. Empty ⇒ open auth
       # (local dev only — NEVER leave open on a reachable deploy).
       HABITAT_API_KEY: ${GAIA_API_KEY:-}
+      # Per-user identity (ADR 0003). GAIA_JWKS_URL = the SaaS public keys; it is
+      # passed through so spawned CHILDREN verify per-user JWTs, AND reused below
+      # so GAIA ITSELF verifies them on its own A2A surface. With HABITAT_API_KEY
+      # still set, Gaia runs dual-auth (jwt+bearer): it accepts a per-user JWT
+      # (identity, so the SaaS attach flow needs no pasted token) OR the shared
+      # bearer (service trust / relay). Audience = Gaia's own public URL. All
+      # empty ⇒ bearer-only (unchanged). Set GAIA_AUTH_AUDIENCE to Gaia's HTTPS
+      # origin (e.g. https://gaia.habitats.example.com) to turn JWT on.
+      GAIA_JWKS_URL: ${GAIA_JWKS_URL:-}
+      HABITAT_AUTH_AUDIENCE: ${GAIA_AUTH_AUDIENCE:-}
+      HABITAT_AUTH_JWKS_URL: ${GAIA_JWKS_URL:-}
       # The provider key Gaia uses for its own chat. Child habitats get their
       # own keys via the master vault + secret bindings, not from here.
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}

--- a/deploy/gaia/recreate-gaia-jwt.sh
+++ b/deploy/gaia/recreate-gaia-jwt.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Recreate the live Gaia container with per-user JWT verification on its OWN
+# A2A surface (ADR 0003). The running container already sets GAIA_JWKS_URL (so
+# spawned CHILDREN verify JWTs) but not HABITAT_AUTH_AUDIENCE/JWKS_URL for Gaia
+# itself — so Gaia stays bearer-only and the SaaS attach flow can only ask for a
+# pasted bearer token. This adds those two vars (keeping HABITAT_API_KEY ⇒ dual
+# jwt+bearer) so Gaia's card advertises bearerFormat:"JWT" and the SaaS mints a
+# per-user grant on attach instead of demanding a token.
+#
+# Safe + reversible: derives all current runtime env + the /data volume from the
+# running container (no hardcoded secrets), keeps the old container as a stopped
+# `gaia-prev` backup, verifies the new card, and rolls back automatically if the
+# new container doesn't come up.
+#
+# Usage (on the pancake host):  sudo bash deploy/gaia/recreate-gaia-jwt.sh
+set -euo pipefail
+
+NAME=gaia
+HOSTNAME_FQDN=gaia.habitats.thefocus.ai
+AUD="https://${HOSTNAME_FQDN}"
+JWKS="https://habitats.thefocus.ai/.well-known/jwks.json"
+
+command -v docker >/dev/null || { echo "docker not found"; exit 1; }
+docker inspect "$NAME" >/dev/null 2>&1 || { echo "container '$NAME' not found — nothing to recreate"; exit 1; }
+
+# Capture current runtime env (skip image-baked vars like PATH/NODE_VERSION).
+# Existing HABITAT_AUTH_* are carried over as-is; we only add them if missing, so
+# this is safe to re-run after an image rebuild to pick up new container code.
+mapfile -t ENVS < <(docker inspect "$NAME" --format '{{range .Config.Env}}{{println .}}{{end}}' \
+  | grep -E '^(GAIA_|HABITAT_API_KEY=|HABITAT_AUTH_|HABITAT_WORK_DIR=|OPENROUTER_API_KEY=|GOOGLE_GENERATIVE_AI_API_KEY=)')
+DATA_VOL=$(docker inspect "$NAME" --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}')
+
+EARGS=(); for e in "${ENVS[@]}"; do EARGS+=(-e "$e"); done
+# Add the JWT-verify vars only if the running container didn't already have them.
+printf '%s\n' "${ENVS[@]}" | grep -q '^HABITAT_AUTH_AUDIENCE=' || EARGS+=(-e "HABITAT_AUTH_AUDIENCE=${AUD}")
+printf '%s\n' "${ENVS[@]}" | grep -q '^HABITAT_AUTH_JWKS_URL=' || EARGS+=(-e "HABITAT_AUTH_JWKS_URL=${JWKS}")
+
+echo "Backing up current container as gaia-prev (stopped)…"
+docker rename "$NAME" gaia-prev
+docker stop gaia-prev >/dev/null
+
+echo "Starting new gaia with JWT verification…"
+if ! docker run -d --name "$NAME" --restart unless-stopped \
+  --network caddy \
+  -l "caddy=${HOSTNAME_FQDN}" -l 'caddy.reverse_proxy={{upstreams 7420}}' \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /opt/gaia-data:/opt/gaia-data \
+  ${DATA_VOL:+-v "${DATA_VOL}:/data"} \
+  "${EARGS[@]}" \
+  habitat sh -c 'pnpm exec tsx packages/cli/src/entry.ts habitat gaia --port 7420 --data-dir /opt/gaia-data --provider "$GAIA_PROVIDER" --model "$GAIA_MODEL"'; then
+  echo "docker run failed — rolling back to gaia-prev"
+  docker rm -f "$NAME" 2>/dev/null || true
+  docker rename gaia-prev "$NAME"
+  docker start "$NAME"
+  exit 1
+fi
+
+echo "Waiting ~10s for caddy to re-route + Gaia to boot…"
+sleep 10
+
+if curl -fsS -m 10 "${AUD}/.well-known/agent-card.json" | grep -q '"bearerFormat":"JWT"'; then
+  echo "✅ Gaia now advertises per-user JWT. Removing backup gaia-prev."
+  docker rm gaia-prev >/dev/null
+  echo "Done. Re-attach Gaia in the SaaS — no bearer token needed."
+else
+  echo "⚠️  New card did not show bearerFormat:JWT. Check: docker logs gaia"
+  echo "Backup retained. Roll back with:"
+  echo "    docker rm -f gaia && docker rename gaia-prev gaia && docker start gaia"
+  exit 1
+fi

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -1062,6 +1062,10 @@ export async function startContainerServer(
 				console.log(
 					`[container]   Auth: per-user JWT grants required (verified, sub = user id)`,
 				);
+			} else if (authMode === "jwt+bearer") {
+				console.log(
+					`[container]   Auth: per-user JWT (verified, sub = user id) OR shared HABITAT_API_KEY — dual-auth transition (ADR 0003)`,
+				);
 			} else if (authMode === "bearer") {
 				console.log(
 					`[container]   Auth: legacy shared HABITAT_API_KEY (no per-user identity — see ADR 0003)`,


### PR DESCRIPTION
## What

Make Gaia verify per-user JWTs on **its own** `/a2a` surface, so the habitats SaaS can attach Gaia with **no pasted bearer token**.

## Why

Gaia already spawned *children* in JWT-verify mode (`GAIA_JWKS_URL`), but never set `HABITAT_AUTH_AUDIENCE`/`HABITAT_AUTH_JWKS_URL` for **itself**. So Gaia's own front door stayed `bearer`-only and its agent card couldn't advertise `bearerFormat:"JWT"` — which is exactly what the SaaS attach flow keys off. Result: the attach form could only ask the operator to paste a shared bearer token.

With this change Gaia runs dual-auth (`jwt+bearer`): a per-user grant (identity) **or** the shared relay bearer (service trust) during the transition. Its card advertises JWT and the SaaS mints a per-user grant per request.

## Changes

- **docker-compose.yml** — pass `GAIA_JWKS_URL` + `HABITAT_AUTH_AUDIENCE` (from new `GAIA_AUTH_AUDIENCE`) + `HABITAT_AUTH_JWKS_URL` to the `gaia` service.
- **.env.example / README.md** — document `GAIA_AUTH_AUDIENCE` + the equivalent `docker run` flags.
- **recreate-gaia-jwt.sh** (new) — reversible in-place migration for a running Gaia (derives current env, auto-rollback if the new card lacks JWT; safe to re-run after an image rebuild).
- **container-server.ts** — add the missing `jwt+bearer` branch to the startup auth log (it printed a misleading `"open dev mode"` while actually enforcing auth — this caused real confusion during rollout).

## Deployed

Already applied to the live Gaia on **pancake**: rebuilt the `habitat` image (needs umwelten #184 for the card advertisement), recreated the container `jwt+bearer`, verified the card now shows `bearerFormat:"JWT"` and `/a2a` 401s unauthenticated. The companion SaaS change (token optional on attach) is shipped to prod (habitats `6311267`).

## Test

`pnpm test:run` — 1492 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)