### PR TITLE
feat(habitat): POST /api/secrets receiver for per-user token delivery (habitats #56)

### DIFF
--- a/deploy/gaia/.env.example
+++ b/deploy/gaia/.env.example
@@ -46,3 +46,7 @@ OPENROUTER_API_KEY=
 # NOTE: child-habitat secrets (X OAuth, DATABASE_URL, child provider keys) are
 # NOT set here — they go into Gaia's master vault after boot (see the runbook),
 # and Gaia binds only the named subset each habitat needs.
+#
+# Per-user token delivery (#56): enable the narrow POST /api/secrets receiver on
+# spawned habitats so the SaaS can push per-user X tokens (TWITTER_REFRESH_TOKEN:<sub>).
+# GAIA_SECRET_WRITE_PREFIXES=TWITTER_REFRESH_TOKEN:

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -43,6 +43,10 @@ import { devAuth } from "./web/auth/dev-auth.js";
 import { bearerAuth } from "./web/auth/bearer-auth.js";
 import { jwtAuth } from "./web/auth/jwt-auth.js";
 import { compositeAuth } from "./web/auth/composite-auth.js";
+import {
+	parseSecretWritePrefixes,
+	isSecretWriteAllowed,
+} from "./web/secret-write.js";
 import { defaultRoutes } from "./web/routes/index.js";
 import type {
 	AuthProvider,
@@ -493,6 +497,58 @@ export async function startContainerServer(
 							);
 						}
 					}
+					return;
+				}
+
+				// ── Secret write (per-user token delivery, #56) ───────
+				// Narrow, opt-in receiver: the habitats SaaS pushes a user's
+				// upstream token (e.g. their X refresh token) here as
+				// TWITTER_REFRESH_TOKEN:<sub>. Disabled unless
+				// HABITAT_SECRET_WRITE_PREFIXES is set; restricted to those
+				// prefixes; auth-gated like every /api route.
+				if (path === "/api/secrets" && req.method === "POST") {
+					const prefixes = parseSecretWritePrefixes(
+						process.env.HABITAT_SECRET_WRITE_PREFIXES,
+					);
+					if (prefixes.length === 0) {
+						sendJson(res, { error: "Not found" }, 404);
+						return;
+					}
+					if (authRequired) {
+						const user = await auth.authenticate(req);
+						if (!user) {
+							sendJson(res, { error: "Unauthorized" }, 401);
+							return;
+						}
+					}
+					let body: { name?: unknown; value?: unknown };
+					try {
+						body = JSON.parse((await readBodyRaw(req)) || "{}");
+					} catch {
+						sendJson(res, { error: "Parse error" }, 400);
+						return;
+					}
+					const { name, value } = body;
+					if (
+						typeof name !== "string" ||
+						typeof value !== "string" ||
+						value.length === 0
+					) {
+						sendJson(res, { error: "name and non-empty value required" }, 400);
+						return;
+					}
+					if (!isSecretWriteAllowed(name, prefixes)) {
+						sendJson(
+							res,
+							{
+								error: `secret name not allowed (must match one of: ${prefixes.join(", ")})`,
+							},
+							403,
+						);
+						return;
+					}
+					await habitat.setSecret(name, value);
+					sendJson(res, { ok: true, name });
 					return;
 				}
 

--- a/packages/habitat/src/tools/gaia/caddy-labels.test.ts
+++ b/packages/habitat/src/tools/gaia/caddy-labels.test.ts
@@ -82,12 +82,14 @@ describe('Gaia Caddy label emission (#170)', () => {
   const prevBaseDomain = process.env.GAIA_BASE_DOMAIN;
   const prevIngress = process.env.GAIA_INGRESS_NETWORK;
   const prevJwks = process.env.GAIA_JWKS_URL;
+  const prevSecretPrefixes = process.env.GAIA_SECRET_WRITE_PREFIXES;
 
   beforeEach(async () => {
     recordedCalls = [];
     delete process.env.GAIA_BASE_DOMAIN;
     delete process.env.GAIA_INGRESS_NETWORK;
     delete process.env.GAIA_JWKS_URL;
+    delete process.env.GAIA_SECRET_WRITE_PREFIXES;
     dataDir = await mkdtemp(join(tmpdir(), 'umwl-gaia-caddy-'));
     docker = new DockerManager(dataDir, '/tmp/project');
   });
@@ -99,7 +101,22 @@ describe('Gaia Caddy label emission (#170)', () => {
     else process.env.GAIA_INGRESS_NETWORK = prevIngress;
     if (prevJwks === undefined) delete process.env.GAIA_JWKS_URL;
     else process.env.GAIA_JWKS_URL = prevJwks;
+    if (prevSecretPrefixes === undefined) delete process.env.GAIA_SECRET_WRITE_PREFIXES;
+    else process.env.GAIA_SECRET_WRITE_PREFIXES = prevSecretPrefixes;
     await rm(dataDir, { recursive: true, force: true });
+  });
+
+  it('injects HABITAT_SECRET_WRITE_PREFIXES when GAIA_SECRET_WRITE_PREFIXES is set (#56)', async () => {
+    process.env.GAIA_SECRET_WRITE_PREFIXES = 'TWITTER_REFRESH_TOKEN:';
+    await docker.startContainer(makeEntry(), '', []);
+    const e = runArgs().filter((_, i) => runArgs()[i - 1] === '--env');
+    expect(e).toContain('HABITAT_SECRET_WRITE_PREFIXES=TWITTER_REFRESH_TOKEN:');
+  });
+
+  it('omits HABITAT_SECRET_WRITE_PREFIXES when unset (endpoint stays disabled)', async () => {
+    await docker.startContainer(makeEntry(), '', []);
+    const e = runArgs().filter((_, i) => runArgs()[i - 1] === '--env');
+    expect(e.some((v) => v.startsWith('HABITAT_SECRET_WRITE_PREFIXES='))).toBe(false);
   });
 
   /** Values that follow each `--env` flag in the recorded docker run args. */

--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -228,6 +228,15 @@ export class DockerManager {
       );
     }
 
+    // Per-user token delivery (#56): enable the narrow POST /api/secrets receiver
+    // on spawned habitats when GAIA_SECRET_WRITE_PREFIXES is set (e.g.
+    // "TWITTER_REFRESH_TOKEN:"), so the SaaS can push per-user X tokens. Unset ⇒
+    // the endpoint stays disabled (404).
+    const secretWritePrefixes = process.env.GAIA_SECRET_WRITE_PREFIXES?.trim();
+    if (secretWritePrefixes) {
+      args.push("--env", `HABITAT_SECRET_WRITE_PREFIXES=${secretWritePrefixes}`);
+    }
+
     args.push(image);
 
     await execFile("docker", args);

--- a/packages/habitat/src/web/secret-write.test.ts
+++ b/packages/habitat/src/web/secret-write.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSecretWritePrefixes,
+  isSecretWriteAllowed,
+} from "./secret-write.js";
+
+describe("parseSecretWritePrefixes", () => {
+  it("returns [] when unset/empty (endpoint disabled)", () => {
+    expect(parseSecretWritePrefixes(undefined)).toEqual([]);
+    expect(parseSecretWritePrefixes("")).toEqual([]);
+    expect(parseSecretWritePrefixes("  ,  ")).toEqual([]);
+  });
+  it("splits + trims a comma list", () => {
+    expect(parseSecretWritePrefixes("TWITTER_REFRESH_TOKEN:, FOO:")).toEqual([
+      "TWITTER_REFRESH_TOKEN:",
+      "FOO:",
+    ]);
+  });
+});
+
+describe("isSecretWriteAllowed", () => {
+  const prefixes = ["TWITTER_REFRESH_TOKEN:"];
+
+  it("allows a per-user key (prefix + sub suffix)", () => {
+    expect(isSecretWriteAllowed("TWITTER_REFRESH_TOKEN:user-123", prefixes)).toBe(true);
+  });
+  it("rejects the bare prefix with no suffix", () => {
+    expect(isSecretWriteAllowed("TWITTER_REFRESH_TOKEN:", prefixes)).toBe(false);
+  });
+  it("rejects an unrelated/global secret name", () => {
+    expect(isSecretWriteAllowed("TWITTER_REFRESH_TOKEN", prefixes)).toBe(false);
+    expect(isSecretWriteAllowed("OPENROUTER_API_KEY", prefixes)).toBe(false);
+    expect(isSecretWriteAllowed("HABITAT_API_KEY", prefixes)).toBe(false);
+  });
+  it("rejects everything when no prefixes are configured (disabled)", () => {
+    expect(isSecretWriteAllowed("TWITTER_REFRESH_TOKEN:user-123", [])).toBe(false);
+  });
+  it("supports multiple prefixes", () => {
+    expect(isSecretWriteAllowed("FOO:bar", ["TWITTER_REFRESH_TOKEN:", "FOO:"])).toBe(true);
+  });
+});

--- a/packages/habitat/src/web/secret-write.ts
+++ b/packages/habitat/src/web/secret-write.ts
@@ -1,0 +1,33 @@
+/**
+ * Habitat secret-write allowlist — narrow surface for per-user token delivery
+ * (ADR 0003 / habitats #56).
+ *
+ * The habitats SaaS pushes a user's upstream token (e.g. their X refresh token)
+ * to a running habitat as the secret `TWITTER_REFRESH_TOKEN:<sub>` so the
+ * twitter habitat can read it per-speaker (umwelten #176). `POST /api/secrets`
+ * is the receiver — but a generic "set any secret" endpoint is dangerous, so it
+ * is:
+ *   - OFF by default — only enabled when `HABITAT_SECRET_WRITE_PREFIXES` is set
+ *     (comma-separated list of allowed name prefixes);
+ *   - restricted to names that match one of those prefixes AND carry a suffix
+ *     (so the bare prefix alone can't be written).
+ *
+ * It is still auth-gated by the server (jwt/bearer) on top of this.
+ */
+
+/** Parse the comma-separated `HABITAT_SECRET_WRITE_PREFIXES` env into a list. */
+export function parseSecretWritePrefixes(raw: string | undefined): string[] {
+  return (raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * True when `name` may be written: at least one prefix is configured, and the
+ * name starts with a configured prefix and has a non-empty suffix after it.
+ */
+export function isSecretWriteAllowed(name: string, prefixes: string[]): boolean {
+  if (prefixes.length === 0) return false;
+  return prefixes.some((p) => name.startsWith(p) && name.length > p.length);
+}


### PR DESCRIPTION
The umwelten paired dependency for habitats #56 (per-user X). The SaaS must push a user's X refresh token to a running habitat as `TWITTER_REFRESH_TOKEN:<sub>` (umwelten #176 reads it per-speaker) — but there was **no live secret-set path** on a habitat. This adds a narrow, opt-in receiver.

## Change
- **`web/secret-write.ts`** — `parseSecretWritePrefixes()` + `isSecretWriteAllowed()` (name must match a configured prefix *and* carry a suffix).
- **`container-server` `POST /api/secrets`** — **disabled unless `HABITAT_SECRET_WRITE_PREFIXES` is set** (404); **auth-gated** like every `/api` route (401); **403** for non-allowlisted names; else `habitat.setSecret(name, value)` → `{ok:true}`.
- **`gaia/docker.ts`** — injects `HABITAT_SECRET_WRITE_PREFIXES` into spawned habitats from `GAIA_SECRET_WRITE_PREFIXES` (unset ⇒ off). `.env.example` documents it.

Defense in depth: **off by default · prefix-restricted · auth-gated · suffix-required.**

## Success criteria + how to verify
- [x] **Disabled by default** — without `HABITAT_SECRET_WRITE_PREFIXES`, `POST /api/secrets` → **404**. *(unit: `parseSecretWritePrefixes`/`isSecretWriteAllowed`)*
- [x] **Allowlist enforced** — `TWITTER_REFRESH_TOKEN:user-1` allowed; bare prefix / `OPENROUTER_API_KEY` / `HABITAT_API_KEY` rejected. *(unit tests, 7)*
- [x] **Auth required** — no/invalid token → 401. *(server gate, mirrors other `/api` routes)*
- [x] **Gaia injection** — `GAIA_SECRET_WRITE_PREFIXES` set ⇒ child gets `HABITAT_SECRET_WRITE_PREFIXES`; unset ⇒ omitted. *(unit, 2)*
- **Live check (after deploy):** on a habitat with `HABITAT_SECRET_WRITE_PREFIXES=TWITTER_REFRESH_TOKEN:` —
  ```bash
  curl -s -o/dev/null -w '%{http_code}\n' -X POST -H 'content-type: application/json' \
    -d '{"name":"TWITTER_REFRESH_TOKEN:u1","value":"x"}' https://<id>.habitats.thefocus.ai/api/secrets   # 401 (no auth)
  curl -s -X POST -H "authorization: Bearer <token>" -H 'content-type: application/json' \
    -d '{"name":"OPENROUTER_API_KEY","value":"x"}' https://<id>.habitats.thefocus.ai/api/secrets          # 403
  curl -s -X POST -H "authorization: Bearer <token>" -H 'content-type: application/json' \
    -d '{"name":"TWITTER_REFRESH_TOKEN:u1","value":"<rt>"}' https://<id>.habitats.thefocus.ai/api/secrets  # {"ok":true}
  ```

## Notes / further work
- Enable per-deploy via `GAIA_SECRET_WRITE_PREFIXES=TWITTER_REFRESH_TOKEN:` (off elsewhere).
- The SaaS side (habitats #56) POSTs here after a user connects X. Report: worktree `reports/2026-06-22-saas-per-user-x-oauth.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)