### PR TITLE
feat(habitat): per-user upstream connectors in the base server (X connect) — ADR 0004 §7

### DIFF
--- a/packages/habitat/src/connectors/connectors.test.ts
+++ b/packages/habitat/src/connectors/connectors.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { createPkcePair, base64url } from "./pkce.js";
+import { signState, verifyState } from "./state.js";
+import { createXConnector, X_AUTHORIZE_URL } from "./x.js";
+import { buildDefaultConnectors } from "./registry.js";
+
+describe("pkce", () => {
+	it("produces url-safe verifier + challenge", () => {
+		const { verifier, challenge } = createPkcePair();
+		expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+		expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+		expect(verifier).not.toEqual(challenge);
+	});
+	it("base64url strips padding and +/", () => {
+		expect(base64url(Buffer.from([255, 255, 255]))).toBe("____");
+	});
+});
+
+describe("signState / verifyState", () => {
+	const secret = "test-secret";
+	const claims = { sub: "user-1", provider: "x", verifier: "v123" };
+
+	it("round-trips valid claims", () => {
+		const tok = signState(claims, secret, 1000);
+		const out = verifyState(tok, secret, 1100);
+		expect(out).toMatchObject(claims);
+		expect(out?.exp).toBe(1000 + 600);
+	});
+	it("rejects a tampered body", () => {
+		const tok = signState(claims, secret, 1000);
+		const [body, mac] = tok.split(".");
+		const forged = `${body}x.${mac}`;
+		expect(verifyState(forged, secret, 1100)).toBeNull();
+	});
+	it("rejects a wrong secret (forged mac)", () => {
+		const tok = signState(claims, secret, 1000);
+		expect(verifyState(tok, "other-secret", 1100)).toBeNull();
+	});
+	it("rejects an expired token", () => {
+		const tok = signState(claims, secret, 1000); // exp = 1600
+		expect(verifyState(tok, secret, 1700)).toBeNull();
+	});
+	it("rejects malformed input", () => {
+		expect(verifyState("nope", secret, 1100)).toBeNull();
+		expect(verifyState("", secret, 1100)).toBeNull();
+	});
+});
+
+describe("x connector", () => {
+	const x = createXConnector({ clientId: "cid", clientSecret: "csecret" });
+
+	it("secretKey is the per-sub TWITTER_REFRESH_TOKEN convention (#176)", () => {
+		expect(x.secretKey("user-9")).toBe("TWITTER_REFRESH_TOKEN:user-9");
+	});
+
+	it("buildAuthorizeUrl carries PKCE S256 + state + scopes", () => {
+		const url = new URL(
+			x.buildAuthorizeUrl({
+				redirectUri: "https://h.example/connect/x/callback",
+				state: "STATE",
+				codeChallenge: "CHAL",
+			}),
+		);
+		expect(`${url.origin}${url.pathname}`).toBe(X_AUTHORIZE_URL);
+		expect(url.searchParams.get("response_type")).toBe("code");
+		expect(url.searchParams.get("client_id")).toBe("cid");
+		expect(url.searchParams.get("code_challenge")).toBe("CHAL");
+		expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+		expect(url.searchParams.get("state")).toBe("STATE");
+		expect(url.searchParams.get("scope")).toContain("offline.access");
+	});
+
+	it("exchangeCode uses Basic auth + code_verifier, no client_id in body", async () => {
+		let captured: { headers: Record<string, string>; body: string } | null =
+			null;
+		const fakeFetch = (async (_url: string, init: RequestInit) => {
+			captured = {
+				headers: init.headers as Record<string, string>,
+				body: String(init.body),
+			};
+			return new Response(JSON.stringify({ refresh_token: "rt-1" }), {
+				status: 200,
+			});
+		}) as unknown as typeof fetch;
+
+		const out = await x.exchangeCode({
+			code: "abc",
+			redirectUri: "https://h.example/connect/x/callback",
+			codeVerifier: "ver",
+			fetchImpl: fakeFetch,
+		});
+		expect(out.refreshToken).toBe("rt-1");
+		expect(captured!.headers.authorization).toBe(
+			`Basic ${Buffer.from("cid:csecret").toString("base64")}`,
+		);
+		expect(captured!.body).toContain("code_verifier=ver");
+		expect(captured!.body).toContain("grant_type=authorization_code");
+		expect(captured!.body).not.toContain("client_id=");
+	});
+
+	it("exchangeCode throws on non-2xx", async () => {
+		const fakeFetch = (async () =>
+			new Response("bad", { status: 400 })) as unknown as typeof fetch;
+		await expect(
+			x.exchangeCode({
+				code: "abc",
+				redirectUri: "r",
+				codeVerifier: "v",
+				fetchImpl: fakeFetch,
+			}),
+		).rejects.toThrow(/X token exchange failed: 400/);
+	});
+
+	it("exchangeCode throws when no refresh_token (missing offline.access)", async () => {
+		const fakeFetch = (async () =>
+			new Response(JSON.stringify({ access_token: "a" }), {
+				status: 200,
+			})) as unknown as typeof fetch;
+		await expect(
+			x.exchangeCode({
+				code: "abc",
+				redirectUri: "r",
+				codeVerifier: "v",
+				fetchImpl: fakeFetch,
+			}),
+		).rejects.toThrow(/no refresh_token/);
+	});
+});
+
+describe("buildDefaultConnectors", () => {
+	it("is empty without X creds (inert by default)", () => {
+		expect(buildDefaultConnectors({} as NodeJS.ProcessEnv).size).toBe(0);
+	});
+	it("registers x when both creds are present", () => {
+		const m = buildDefaultConnectors({
+			TWITTER_CLIENT_ID: "a",
+			TWITTER_CLIENT_SECRET: "b",
+		} as NodeJS.ProcessEnv);
+		expect(m.has("x")).toBe(true);
+		expect(m.get("x")!.name).toBe("x");
+	});
+	it("does not register x with only one cred", () => {
+		expect(
+			buildDefaultConnectors({
+				TWITTER_CLIENT_ID: "a",
+			} as NodeJS.ProcessEnv).size,
+		).toBe(0);
+	});
+});

--- a/packages/habitat/src/connectors/pkce.ts
+++ b/packages/habitat/src/connectors/pkce.ts
@@ -1,0 +1,18 @@
+// PKCE (RFC 7636) S256 helpers for the upstream connect flow.
+
+import { createHash, randomBytes } from "node:crypto";
+
+export function base64url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/** A fresh PKCE verifier + S256 challenge. */
+export function createPkcePair(): { verifier: string; challenge: string } {
+  const verifier = base64url(randomBytes(32));
+  const challenge = base64url(createHash("sha256").update(verifier).digest());
+  return { verifier, challenge };
+}

--- a/packages/habitat/src/connectors/registry.ts
+++ b/packages/habitat/src/connectors/registry.ts
@@ -1,0 +1,25 @@
+// Build the set of upstream connectors available on this habitat.
+//
+// Inert by default (mirrors the secret-write receiver, #189): a provider only
+// activates when its credentials are configured. X activates when
+// TWITTER_CLIENT_ID + TWITTER_CLIENT_SECRET are set.
+
+import type { UpstreamConnector } from "./types.js";
+import { createXConnector } from "./x.js";
+
+export function buildDefaultConnectors(
+  env: NodeJS.ProcessEnv = process.env,
+): Map<string, UpstreamConnector> {
+  const connectors = new Map<string, UpstreamConnector>();
+
+  const xId = env.TWITTER_CLIENT_ID?.trim();
+  const xSecret = env.TWITTER_CLIENT_SECRET?.trim();
+  if (xId && xSecret) {
+    connectors.set(
+      "x",
+      createXConnector({ clientId: xId, clientSecret: xSecret }),
+    );
+  }
+
+  return connectors;
+}

--- a/packages/habitat/src/connectors/state.ts
+++ b/packages/habitat/src/connectors/state.ts
@@ -1,0 +1,63 @@
+// Sign/verify the OAuth `state` round-trip for the connect flow.
+//
+// The state is stateless: it carries the claims (sub, provider, PKCE verifier)
+// HMAC-signed so the callback can recover them without server-side storage and
+// reject tampering/forgery/expiry. Used as the OAuth `state` parameter.
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { base64url } from "./pkce.js";
+import type { ConnectStateClaims } from "./types.js";
+
+const DEFAULT_TTL_SECONDS = 600; // 10 min to complete consent
+
+function sign(body: string, secret: string): string {
+  return base64url(createHmac("sha256", secret).update(body).digest());
+}
+
+/** Encode + sign connect claims into an opaque state token. */
+export function signState(
+  claims: Omit<ConnectStateClaims, "exp">,
+  secret: string,
+  nowSeconds: number,
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+): string {
+  const full: ConnectStateClaims = {
+    ...claims,
+    exp: nowSeconds + ttlSeconds,
+  };
+  const body = base64url(Buffer.from(JSON.stringify(full), "utf8"));
+  return `${body}.${sign(body, secret)}`;
+}
+
+/** Verify a state token; returns the claims or null (tampered/forged/expired). */
+export function verifyState(
+  token: string,
+  secret: string,
+  nowSeconds: number,
+): ConnectStateClaims | null {
+  const dot = token.lastIndexOf(".");
+  if (dot <= 0) return null;
+  const body = token.slice(0, dot);
+  const mac = token.slice(dot + 1);
+  const expected = sign(body, secret);
+  const a = Buffer.from(mac);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+  let claims: ConnectStateClaims;
+  try {
+    claims = JSON.parse(Buffer.from(body, "base64").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (
+    !claims ||
+    typeof claims.sub !== "string" ||
+    typeof claims.provider !== "string" ||
+    typeof claims.verifier !== "string" ||
+    typeof claims.exp !== "number"
+  ) {
+    return null;
+  }
+  if (claims.exp < nowSeconds) return null;
+  return claims;
+}

--- a/packages/habitat/src/connectors/types.ts
+++ b/packages/habitat/src/connectors/types.ts
@@ -1,0 +1,48 @@
+// Upstream connectors (ADR 0004 §7 — "the agent owns its upstream connections").
+//
+// A habitat exposes a generic per-user OAuth connect flow on its own surface so
+// a speaking user can link a third-party account (X, Google, …) to THEIR id.
+// The resulting refresh token is stored per-`sub` (`secretKey(sub)`) and read by
+// tools via the per-user token store (umwelten #176). The base server owns the
+// /connect routes; connectors are pluggable providers registered on the habitat.
+
+export interface ExchangeResult {
+  /** The long-lived refresh token to persist (per-sub). */
+  refreshToken: string;
+}
+
+export interface UpstreamConnector {
+  /** URL-safe provider id, e.g. "x". */
+  name: string;
+  /** Human label for the consent/success UI. */
+  label: string;
+  /** OAuth scopes requested. */
+  scopes: string[];
+  /** Build the provider's authorize URL (PKCE S256). */
+  buildAuthorizeUrl(args: {
+    redirectUri: string;
+    state: string;
+    codeChallenge: string;
+  }): string;
+  /** Exchange an authorization code for tokens (confidential client + PKCE). */
+  exchangeCode(args: {
+    code: string;
+    redirectUri: string;
+    codeVerifier: string;
+    fetchImpl?: typeof fetch;
+  }): Promise<ExchangeResult>;
+  /** Habitat secret name the refresh token is stored under, keyed by speaker. */
+  secretKey(sub: string): string;
+}
+
+/** Claims carried (HMAC-signed) through the OAuth `state` round-trip. */
+export interface ConnectStateClaims {
+  /** The speaking user this connection belongs to. */
+  sub: string;
+  /** Provider name (must match the callback path). */
+  provider: string;
+  /** PKCE verifier (recovered on callback to complete the exchange). */
+  verifier: string;
+  /** Expiry (epoch seconds) — short-lived. */
+  exp: number;
+}

--- a/packages/habitat/src/connectors/x.ts
+++ b/packages/habitat/src/connectors/x.ts
@@ -1,0 +1,91 @@
+// X (Twitter) upstream connector (ADR 0004 §7).
+//
+// Per-user OAuth 2.0 with PKCE + confidential client. Mirrors the proven flow in
+// examples/twitter-habitat/src/x-oauth.ts and the SaaS core (habitats #65), but
+// lives in the base server so any habitat with X creds gets the connect flow.
+// The refresh token is stored as `TWITTER_REFRESH_TOKEN:<sub>` — the exact key
+// the per-user token store reads (umwelten #176).
+
+import type { ExchangeResult, UpstreamConnector } from "./types.js";
+
+export const X_AUTHORIZE_URL = "https://x.com/i/oauth2/authorize";
+export const X_TOKEN_URL = "https://api.x.com/2/oauth2/token";
+
+// Read scopes + offline.access so X issues a (rotating) refresh token.
+export const X_DEFAULT_SCOPES = [
+  "tweet.read",
+  "users.read",
+  "bookmark.read",
+  "list.read",
+  "offline.access",
+];
+
+export interface XConnectorConfig {
+  clientId: string;
+  clientSecret: string;
+  scopes?: string[];
+}
+
+export function createXConnector(cfg: XConnectorConfig): UpstreamConnector {
+  const scopes = cfg.scopes ?? X_DEFAULT_SCOPES;
+  return {
+    name: "x",
+    label: "X (Twitter)",
+    scopes,
+    buildAuthorizeUrl({ redirectUri, state, codeChallenge }) {
+      const u = new URL(X_AUTHORIZE_URL);
+      u.searchParams.set("response_type", "code");
+      u.searchParams.set("client_id", cfg.clientId);
+      u.searchParams.set("redirect_uri", redirectUri);
+      u.searchParams.set("scope", scopes.join(" "));
+      u.searchParams.set("state", state);
+      u.searchParams.set("code_challenge", codeChallenge);
+      u.searchParams.set("code_challenge_method", "S256");
+      return u.toString();
+    },
+    async exchangeCode({
+      code,
+      redirectUri,
+      codeVerifier,
+      fetchImpl,
+    }): Promise<ExchangeResult> {
+      const f = fetchImpl ?? fetch;
+      // Confidential client: Basic auth header; client_id NOT in the body.
+      const basic = Buffer.from(
+        `${cfg.clientId}:${cfg.clientSecret}`,
+      ).toString("base64");
+      const body = new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+        code_verifier: codeVerifier,
+      });
+      const res = await f(X_TOKEN_URL, {
+        method: "POST",
+        headers: {
+          authorization: `Basic ${basic}`,
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body: body.toString(),
+      });
+      if (!res.ok) {
+        const detail = await res.text().catch(() => "");
+        throw new Error(
+          `X token exchange failed: ${res.status} ${res.statusText}${
+            detail ? ` — ${detail.slice(0, 300)}` : ""
+          }`,
+        );
+      }
+      const json = (await res.json()) as { refresh_token?: string };
+      if (!json.refresh_token) {
+        throw new Error(
+          "X token exchange returned no refresh_token (is offline.access in scope?)",
+        );
+      }
+      return { refreshToken: json.refresh_token };
+    },
+    secretKey(sub: string) {
+      return `TWITTER_REFRESH_TOKEN:${sub}`;
+    },
+  };
+}

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -20,6 +20,7 @@ import {
 	type IncomingMessage,
 	type ServerResponse,
 } from "node:http";
+import { randomBytes } from "node:crypto";
 import { readFile, stat } from "node:fs/promises";
 import { join, resolve, extname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -47,6 +48,8 @@ import {
 	parseSecretWritePrefixes,
 	isSecretWriteAllowed,
 } from "./web/secret-write.js";
+import { buildDefaultConnectors } from "./connectors/registry.js";
+import { startConnect, completeConnect } from "./web/connect.js";
 import { defaultRoutes } from "./web/routes/index.js";
 import type {
 	AuthProvider,
@@ -215,6 +218,14 @@ function sendJson(res: ServerResponse, data: unknown, status = 200): void {
 	res.end(JSON.stringify(data));
 }
 
+/** Escape text for safe interpolation into the small connect result pages. */
+function escapeHtmlText(s: string): string {
+	return s
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;");
+}
+
 // ── Main server ───────────────────────────────────────────────────
 
 export async function startContainerServer(
@@ -239,6 +250,14 @@ export async function startContainerServer(
 	// gates keyed off HABITAT_API_KEY directly, which would skip enforcement under
 	// JWT auth.)
 	const authRequired = authMode !== "open";
+
+	// Upstream connectors (ADR 0004 §7): per-user "connect your X / …" flows the
+	// habitat owns. Inert unless a provider's creds are configured. The signed
+	// state secret rides HABITAT_API_KEY when present (stable across restarts),
+	// else a per-process random (fine — a connect round-trip is short-lived).
+	const connectors = buildDefaultConnectors();
+	const connectSecret =
+		process.env.HABITAT_API_KEY?.trim() || randomBytes(32).toString("hex");
 
 	// Chat bridge + adapter, with logging wrapper
 	const bridge = new ChannelBridge(habitat, {
@@ -416,6 +435,76 @@ export async function startContainerServer(
 				}
 
 				// ── A2A endpoint ─────────────────────────────────────
+				// Upstream connect (ADR 0004 section 7):
+				// GET /connect/:provider          -> start (redirect to provider)
+				// GET /connect/:provider/callback -> finish (exchange + store)
+				// Inert (404) unless a connector for :provider is registered.
+				if (path.startsWith("/connect/") && req.method === "GET") {
+					const parts = path.split("/").filter(Boolean);
+					const provider = parts[1];
+					const isCallback = parts.length === 3 && parts[2] === "callback";
+					const connector = provider ? connectors.get(provider) : undefined;
+					if (!connector || (parts.length === 3 && !isCallback) || parts.length > 3) {
+						sendJson(res, { error: "Unknown connector" }, 404);
+						return;
+					}
+					const publicBaseUrl = getPublicBaseUrl(req);
+					const nowSeconds = Math.floor(Date.now() / 1000);
+					if (!isCallback) {
+						// A browser GET can't send an Authorization header, so the SaaS
+						// passes a per-user JWT as ?jwt= (or ?token=); fall back to the
+						// request's own auth otherwise.
+						const tok = query.jwt || query.token;
+						const authReq = tok
+							? ({ headers: { authorization: `Bearer ${tok}` } } as unknown as IncomingMessage)
+							: req;
+						const user = await auth.authenticate(authReq);
+						if (!user) {
+							sendJson(
+								res,
+								{ error: "Unauthorized — the connect link needs a valid per-user token" },
+								401,
+							);
+							return;
+						}
+						const { authorizeUrl } = startConnect({
+							connector,
+							sub: user.userId,
+							publicBaseUrl,
+							secret: connectSecret,
+							nowSeconds,
+						});
+						res.writeHead(302, { Location: authorizeUrl });
+						res.end();
+						return;
+					}
+					// Callback: identity rides the signed state, not auth headers.
+					const result = await completeConnect({
+						connector,
+						provider,
+						query,
+						publicBaseUrl,
+						secret: connectSecret,
+						nowSeconds,
+						setSecret: (name, value) => habitat.setSecret(name, value),
+					});
+					const page = (title: string, body: string) =>
+						`<!doctype html><meta charset="utf-8"><body style="font-family:system-ui;max-width:32rem;margin:3rem auto;padding:0 1rem"><h1>${title}</h1><p>${body}</p></body>`;
+					if (!result.ok) {
+						res.writeHead(result.status, { "content-type": "text/html; charset=utf-8" });
+						res.end(page("Connection failed", escapeHtmlText(result.message)));
+						return;
+					}
+					res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+					res.end(
+						page(
+							`Connected ${escapeHtmlText(connector.label)}`,
+							"You can close this window and return to your chat.",
+						),
+					);
+					return;
+				}
+
 				if (path === "/a2a" && req.method === "POST") {
 					let user: UserContext | null = null;
 					if (authRequired) {

--- a/packages/habitat/src/web/connect.test.ts
+++ b/packages/habitat/src/web/connect.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { startConnect, completeConnect, callbackUri } from "./connect.js";
+import { createXConnector } from "../connectors/x.js";
+import { signState } from "../connectors/state.js";
+
+const x = createXConnector({ clientId: "cid", clientSecret: "csecret" });
+const SECRET = "hmac-secret";
+const BASE = "https://h.example";
+
+describe("callbackUri", () => {
+	it("builds the exact provider callback path (trailing-slash safe)", () => {
+		expect(callbackUri("https://h.example/", "x")).toBe(
+			"https://h.example/connect/x/callback",
+		);
+	});
+});
+
+describe("startConnect", () => {
+	it("returns an authorize URL with a verifiable signed state", () => {
+		const { authorizeUrl } = startConnect({
+			connector: x,
+			sub: "user-1",
+			publicBaseUrl: BASE,
+			secret: SECRET,
+			nowSeconds: 1000,
+		});
+		const url = new URL(authorizeUrl);
+		expect(url.searchParams.get("redirect_uri")).toBe(
+			"https://h.example/connect/x/callback",
+		);
+		expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+		// state is our signed token and must verify back to the sub
+		const state = url.searchParams.get("state")!;
+		expect(state).toContain(".");
+	});
+});
+
+describe("completeConnect", () => {
+	const okFetch = (async () =>
+		new Response(JSON.stringify({ refresh_token: "rt-9" }), {
+			status: 200,
+		})) as unknown as typeof fetch;
+
+	function validState(sub = "user-1", provider = "x") {
+		return signState({ sub, provider, verifier: "ver" }, SECRET, 1000);
+	}
+
+	it("happy path: exchanges and stores the per-sub secret", async () => {
+		const stored: Record<string, string> = {};
+		const res = await completeConnect({
+			connector: x,
+			provider: "x",
+			query: { code: "auth-code", state: validState() },
+			publicBaseUrl: BASE,
+			secret: SECRET,
+			nowSeconds: 1100,
+			setSecret: (n, v) => {
+				stored[n] = v;
+			},
+			fetchImpl: okFetch,
+		});
+		expect(res).toEqual({ ok: true, provider: "x", sub: "user-1" });
+		expect(stored["TWITTER_REFRESH_TOKEN:user-1"]).toBe("rt-9");
+	});
+
+	it("rejects a provider error redirect", async () => {
+		const res = await completeConnect({
+			connector: x,
+			provider: "x",
+			query: { error: "access_denied" },
+			publicBaseUrl: BASE,
+			secret: SECRET,
+			nowSeconds: 1100,
+			setSecret: () => {},
+			fetchImpl: okFetch,
+		});
+		expect(res.ok).toBe(false);
+	});
+
+	it("rejects missing code/state", async () => {
+		const res = await completeConnect({
+			connector: x,
+			provider: "x",
+			query: { code: "only-code" },
+			publicBaseUrl: BASE,
+			secret: SECRET,
+			nowSeconds: 1100,
+			setSecret: () => {},
+			fetchImpl: okFetch,
+		});
+		expect(res).toMatchObject({ ok: false, status: 400 });
+	});
+
+	it("rejects an invalid/forged state", async () => {
+		const res = await completeConnect({
+			connector: x,
+			provider: "x",
+			query: { code: "c", state: validState("user-1", "x") + "x" },
+			publicBaseUrl: BASE,
+			secret: SECRET,
+			nowSeconds: 1100,
+			setSecret: () => {},
+			fetchImpl: okFetch,
+		});
+		expect(res).toMatchObject({ ok: false, status: 400 });
+	});
+
+	it("rejects a state minted for a different provider (no cross-provider replay)", async () => {
+		const res = await completeConnect({
+			connector: x,
+			provider: "x",
+			query: { code: "c", state: validState("user-1", "google") },
+			publicBaseUrl: BASE,
+			secret: SECRET,
+			nowSeconds: 1100,
+			setSecret: () => {},
+			fetchImpl: okFetch,
+		});
+		expect(res).toMatchObject({ ok: false, status: 400 });
+	});
+
+	it("surfaces an exchange failure as 502 and stores nothing", async () => {
+		const stored: Record<string, string> = {};
+		const badFetch = (async () =>
+			new Response("nope", { status: 400 })) as unknown as typeof fetch;
+		const res = await completeConnect({
+			connector: x,
+			provider: "x",
+			query: { code: "c", state: validState() },
+			publicBaseUrl: BASE,
+			secret: SECRET,
+			nowSeconds: 1100,
+			setSecret: (n, v) => {
+				stored[n] = v;
+			},
+			fetchImpl: badFetch,
+		});
+		expect(res).toMatchObject({ ok: false, status: 502 });
+		expect(Object.keys(stored)).toHaveLength(0);
+	});
+});

--- a/packages/habitat/src/web/connect.ts
+++ b/packages/habitat/src/web/connect.ts
@@ -1,0 +1,105 @@
+// Upstream-connect request logic (ADR 0004 §7), kept separate from the HTTP
+// plumbing in container-server so it's unit-testable. The base server owns the
+// routes:
+//   GET /connect/:provider          → start: verify the speaker, redirect to the
+//                                      provider's authorize URL (PKCE + signed state)
+//   GET /connect/:provider/callback → finish: verify state, exchange the code,
+//                                      store the refresh token as secretKey(sub)
+
+import { createPkcePair } from "../connectors/pkce.js";
+import { signState, verifyState } from "../connectors/state.js";
+import type { UpstreamConnector } from "../connectors/types.js";
+
+/** Build the exact redirect URI the provider must call back (and we registered). */
+export function callbackUri(publicBaseUrl: string, provider: string): string {
+  return `${publicBaseUrl.replace(/\/$/, "")}/connect/${provider}/callback`;
+}
+
+/** Start: produce the provider authorize URL for this speaker. */
+export function startConnect(args: {
+  connector: UpstreamConnector;
+  sub: string;
+  publicBaseUrl: string;
+  secret: string;
+  nowSeconds: number;
+}): { authorizeUrl: string } {
+  const { connector, sub, publicBaseUrl, secret, nowSeconds } = args;
+  const redirectUri = callbackUri(publicBaseUrl, connector.name);
+  const { verifier, challenge } = createPkcePair();
+  const state = signState(
+    { sub, provider: connector.name, verifier },
+    secret,
+    nowSeconds,
+  );
+  const authorizeUrl = connector.buildAuthorizeUrl({
+    redirectUri,
+    state,
+    codeChallenge: challenge,
+  });
+  return { authorizeUrl };
+}
+
+export type CompleteResult =
+  | { ok: true; provider: string; sub: string }
+  | { ok: false; status: number; message: string };
+
+/** Finish: verify state, exchange the code, persist the refresh token per-sub. */
+export async function completeConnect(args: {
+  connector: UpstreamConnector;
+  provider: string;
+  query: Record<string, string>;
+  publicBaseUrl: string;
+  secret: string;
+  nowSeconds: number;
+  setSecret: (name: string, value: string) => Promise<void> | void;
+  fetchImpl?: typeof fetch;
+}): Promise<CompleteResult> {
+  const {
+    connector,
+    provider,
+    query,
+    publicBaseUrl,
+    secret,
+    nowSeconds,
+    setSecret,
+    fetchImpl,
+  } = args;
+
+  if (query.error) {
+    return { ok: false, status: 400, message: `provider error: ${query.error}` };
+  }
+  const code = query.code;
+  const state = query.state;
+  if (!code || !state) {
+    return { ok: false, status: 400, message: "missing code or state" };
+  }
+  const claims = verifyState(state, secret, nowSeconds);
+  if (!claims) {
+    return { ok: false, status: 400, message: "invalid or expired state" };
+  }
+  // The state's provider must match the callback path — no cross-provider replay.
+  if (claims.provider !== provider) {
+    return { ok: false, status: 400, message: "state/provider mismatch" };
+  }
+
+  const redirectUri = callbackUri(publicBaseUrl, provider);
+  let refreshToken: string;
+  try {
+    const out = await connector.exchangeCode({
+      code,
+      redirectUri,
+      codeVerifier: claims.verifier,
+      fetchImpl,
+    });
+    refreshToken = out.refreshToken;
+  } catch (err) {
+    return {
+      ok: false,
+      status: 502,
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  await setSecret(connector.secretKey(claims.sub), refreshToken);
+  return { ok: true, provider, sub: claims.sub };
+}


### PR DESCRIPTION
Implements **ADR 0004 decision 7** ("the agent owns its upstream connections") as a **generic capability in the base container-server**, and uses it for the Twitter case (habitats **#56**, the ADR-aligned **Option A**: the habitat owns its X OAuth; the SaaS does nothing X-specific).

## Why this shape
The Twitter habitat runs on the generic image with no way to add its own HTTP routes, so "the agent owns its `/authorize`" has to live in the base server. It's a common need, so it's built in and provider-pluggable.

## What's built
- **`connectors/`** — `UpstreamConnector` interface; PKCE S256; **stateless HMAC-signed `state`** (carries sub/provider/verifier, rejects tamper/forge/expiry — no server-side session); an **X connector** (confidential client, `offline.access`, stores `TWITTER_REFRESH_TOKEN:<sub>` — the exact key #176 reads); a **registry inert by default** (activates only when `TWITTER_CLIENT_ID`/`TWITTER_CLIENT_SECRET` are set).
- **`web/connect.ts`** — start/complete logic (pure, fetch-injectable).
- **`container-server`** — `GET /connect/:provider` (identify the speaker via a per-user JWT passed as `?jwt=`, redirect to the provider) and `GET /connect/:provider/callback` (verify signed state, exchange code, `habitat.setSecret` per sub). **404 unless a connector is registered**; callback identity rides the signed state, not headers.

## Flow
User clicks "Connect X" (SaaS mints a per-user JWT, links to `…/connect/x?jwt=…`) → habitat verifies the JWT → redirect to X (PKCE) → X calls back → habitat exchanges + stores `TWITTER_REFRESH_TOKEN:<sub>` → the bookmarks tool (#176) resolves the speaker's token.

## Supersedes
The SaaS-push path — habitats **#65** (deliver) + umwelten **#189** (receiver) — per ADR 0004 §7. Those stay inert/harmless.

## Tests
PKCE; state sign/verify (tamper/forge/expiry); X authorize + exchange (Basic auth, **no `client_id` in body**, no-refresh-token guard); connect start/complete (happy path, provider error, missing/forged/cross-provider state, exchange failure stores nothing); registry inert-by-default. **Suite green (1524).** Type-clean (the package's pre-existing `@ai-sdk/provider` drift errors are unrelated to these files).

## To run live
Set `TWITTER_CLIENT_ID`/`TWITTER_CLIENT_SECRET` on the habitat and register `https://<habitat>/connect/x/callback` as the X app's redirect URI. SaaS "Connect X" affordance (the link + minted JWT) is the small remaining UI piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)