### PR TITLE
feat(habitat): generic GET /connect landing page (ADR 0004 §7)

### DIFF
--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -49,7 +49,11 @@ import {
 	isSecretWriteAllowed,
 } from "./web/secret-write.js";
 import { buildDefaultConnectors } from "./connectors/registry.js";
-import { startConnect, completeConnect } from "./web/connect.js";
+import {
+	startConnect,
+	completeConnect,
+	renderConnectLanding,
+} from "./web/connect.js";
 import { defaultRoutes } from "./web/routes/index.js";
 import type {
 	AuthProvider,
@@ -439,6 +443,27 @@ export async function startContainerServer(
 				// GET /connect/:provider          -> start (redirect to provider)
 				// GET /connect/:provider/callback -> finish (exchange + store)
 				// Inert (404) unless a connector for :provider is registered.
+				// Generic connect landing (ADR 0004 section 7): the agent's own surface.
+				if (path === "/connect" && req.method === "GET") {
+					const tok = query.jwt || query.token;
+					const authReq = tok
+						? ({ headers: { authorization: `Bearer ${tok}` } } as unknown as IncomingMessage)
+						: req;
+					const user = await auth.authenticate(authReq);
+					if (!user) {
+						sendJson(res, { error: "Unauthorized — the connect link needs a valid per-user token" }, 401);
+						return;
+					}
+					res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+					res.end(
+						renderConnectLanding(
+							[...connectors.values()].map((c) => ({ name: c.name, label: c.label })),
+							tok ?? "",
+						),
+					);
+					return;
+				}
+
 				if (path.startsWith("/connect/") && req.method === "GET") {
 					const parts = path.split("/").filter(Boolean);
 					const provider = parts[1];

--- a/packages/habitat/src/web/connect.test.ts
+++ b/packages/habitat/src/web/connect.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { startConnect, completeConnect, callbackUri } from "./connect.js";
+import {
+	startConnect,
+	completeConnect,
+	callbackUri,
+	renderConnectLanding,
+} from "./connect.js";
 import { createXConnector } from "../connectors/x.js";
 import { signState } from "../connectors/state.js";
 
@@ -12,6 +17,21 @@ describe("callbackUri", () => {
 		expect(callbackUri("https://h.example/", "x")).toBe(
 			"https://h.example/connect/x/callback",
 		);
+	});
+});
+
+describe("renderConnectLanding", () => {
+	it("lists each connector with a start link carrying the token", () => {
+		const html = renderConnectLanding(
+			[{ name: "x", label: "X (Twitter)" }],
+			"tok-123",
+		);
+		expect(html).toContain("/connect/x?jwt=tok-123");
+		expect(html).toContain("Connect X (Twitter)");
+	});
+	it("shows a nothing-to-connect message when empty (SaaS stays generic)", () => {
+		const html = renderConnectLanding([], "tok");
+		expect(html).toContain("no connections to authorize");
 	});
 });
 

--- a/packages/habitat/src/web/connect.ts
+++ b/packages/habitat/src/web/connect.ts
@@ -15,6 +15,42 @@ export function callbackUri(publicBaseUrl: string, provider: string): string {
   return `${publicBaseUrl.replace(/\/$/, "")}/connect/${provider}/callback`;
 }
 
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * The agent's generic connect landing page (ADR 0004 §7). The SaaS sends the
+ * user here (`/connect?jwt=…`) with their identity; the *agent* decides what can
+ * be connected. Lists each registered connector with a start link that carries
+ * the same token forward. Empty list ⇒ "nothing to connect" (the SaaS stays
+ * fully generic — it never needs to know the agent's providers).
+ */
+export function renderConnectLanding(
+  connectors: { name: string; label: string }[],
+  token: string,
+): string {
+  const q = token ? `?jwt=${encodeURIComponent(token)}` : "";
+  const items =
+    connectors.length === 0
+      ? `<p>This agent has no connections to authorize.</p>`
+      : `<ul style="list-style:none;padding:0">${connectors
+          .map(
+            (c) =>
+              `<li style="margin:.5rem 0"><a href="/connect/${encodeURIComponent(
+                c.name,
+              )}${q}" style="display:inline-block;padding:.6rem 1rem;border:1px solid #ccc;border-radius:8px;text-decoration:none">Connect ${escapeHtml(
+                c.label,
+              )} →</a></li>`,
+          )
+          .join("")}</ul>`;
+  return `<!doctype html><meta charset="utf-8"><title>Authorize connections</title><body style="font-family:system-ui;max-width:32rem;margin:3rem auto;padding:0 1rem"><h1>Authorize connections</h1>${items}</body>`;
+}
+
 /** Start: produce the provider authorize URL for this speaker. */
 export function startConnect(args: {
   connector: UpstreamConnector;


### PR DESCRIPTION
Follow-up to #190. Adds the agent's own generic connect surface: `GET /connect?jwt=…` verifies the speaker and lists registered connectors (each → `/connect/:provider?jwt=…`), or shows "no connections to authorize". Lets the SaaS link to **one generic URL per agent** without knowing its providers. Tests + type-clean; suite 1526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)