### PR TITLE
feat(habitat): advertise provider.url + connect surface in the agent card (ADR 0004)

### DIFF
--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -53,6 +53,7 @@ import {
 	startConnect,
 	completeConnect,
 	renderConnectLanding,
+	connectExtension,
 } from "./web/connect.js";
 import { defaultRoutes } from "./web/routes/index.js";
 import type {
@@ -431,10 +432,34 @@ export async function startContainerServer(
 					// callers at the externally reachable origin via X-Forwarded-*.
 					// Mirrors the MCP/OAuth surface (agent-surface.ts). Falls back to
 					// the Host header / BASE_URL when no forwarding headers are present.
-					sendJson(res, {
+					const publicBase = getPublicBaseUrl(req);
+					const card: Record<string, unknown> = {
 						...handler.agentCard,
-						url: `${getPublicBaseUrl(req)}/a2a`,
-					});
+						url: `${publicBase}/a2a`,
+					};
+					// provider.url = the agent's own human-facing surface (web UI root)
+					// so the SaaS renders a per-agent link from the card, not an env var.
+					card.provider =
+						(handler.agentCard as { provider?: unknown }).provider ?? {
+							organization: serverName,
+							url: publicBase,
+						};
+					// Advertise the per-user connect surface as an A2A extension when a
+					// connector is registered (self-describing for the SaaS).
+					if (connectors.size > 0) {
+						const caps =
+							(handler.agentCard.capabilities as
+								| { extensions?: unknown[] }
+								| undefined) ?? {};
+						card.capabilities = {
+							...caps,
+							extensions: [
+								...((caps.extensions as unknown[]) ?? []),
+								connectExtension(publicBase),
+							],
+						};
+					}
+					sendJson(res, card);
 					return;
 				}
 

--- a/packages/habitat/src/web/connect.test.ts
+++ b/packages/habitat/src/web/connect.test.ts
@@ -4,6 +4,8 @@ import {
 	completeConnect,
 	callbackUri,
 	renderConnectLanding,
+	connectExtension,
+	CONNECT_EXTENSION_URI,
 } from "./connect.js";
 import { createXConnector } from "../connectors/x.js";
 import { signState } from "../connectors/state.js";
@@ -17,6 +19,14 @@ describe("callbackUri", () => {
 		expect(callbackUri("https://h.example/", "x")).toBe(
 			"https://h.example/connect/x/callback",
 		);
+	});
+});
+
+describe("connectExtension", () => {
+	it("advertises the connect surface URL under the stable extension URI", () => {
+		const ext = connectExtension("https://h.example/");
+		expect(ext.uri).toBe(CONNECT_EXTENSION_URI);
+		expect(ext.params.url).toBe("https://h.example/connect");
 	});
 });
 

--- a/packages/habitat/src/web/connect.ts
+++ b/packages/habitat/src/web/connect.ts
@@ -15,6 +15,26 @@ export function callbackUri(publicBaseUrl: string, provider: string): string {
   return `${publicBaseUrl.replace(/\/$/, "")}/connect/${provider}/callback`;
 }
 
+/**
+ * A2A extension URI advertising the per-user connect surface (ADR 0004 §7).
+ * Consumers (the SaaS) match on this URI in `capabilities.extensions` and read
+ * `params.url` to find the agent's `/connect` landing — self-describing, so no
+ * hardcoded convention or env var on the consumer side.
+ */
+export const CONNECT_EXTENSION_URI = "https://umwelten.dev/a2a/ext/connect/v1";
+
+export function connectExtension(publicBaseUrl: string): {
+  uri: string;
+  description: string;
+  params: { url: string };
+} {
+  return {
+    uri: CONNECT_EXTENSION_URI,
+    description: "Per-user upstream connect surface (ADR 0004).",
+    params: { url: `${publicBaseUrl.replace(/\/$/, "")}/connect` },
+  };
+}
+
 function escapeHtml(s: string): string {
   return s
     .replace(/&/g, "&amp;")
@@ -102,7 +122,11 @@ export async function completeConnect(args: {
   } = args;
 
   if (query.error) {
-    return { ok: false, status: 400, message: `provider error: ${query.error}` };
+    return {
+      ok: false,
+      status: 400,
+      message: `provider error: ${query.error}`,
+    };
   }
   const code = query.code;
   const state = query.state;


### PR DESCRIPTION
Makes the agent card self-describing so the SaaS reads links from it instead of a global env var.

- **`provider.url`** = the agent's own public surface (web UI root) → the SaaS renders a per-agent "open" link (Gaia → its dashboard).
- When a connector is registered, advertise the per-user connect surface as an **A2A extension** (`capabilities.extensions[].uri = CONNECT_EXTENSION_URI`, `params.url = …/connect`) — the spec's blessed mechanism for a custom URI.

Both applied at request time with the externally-reachable origin (X-Forwarded-*). `connectExtension()` is unit-tested; suite 1527.

Pairs with the habitats side (consume `provider.url` for the link, drop `NEXT_PUBLIC_GAIA_URL`; target the connect extension from "Authorize").

🤖 Generated with [Claude Code](https://claude.com/claude-code)