### PR TITLE
Absolute-public artifact & asset URLs at emit time (#194, ADR 0005 slice A)

### DIFF
--- a/packages/habitat/src/a2a-handler.test.ts
+++ b/packages/habitat/src/a2a-handler.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { BridgeResponseMetadata } from "./bridge/types.js";
@@ -321,5 +321,69 @@ describe("tasks/cancel via the JSON-RPC transport", () => {
 
 		expect(cancelResponse.error).toBeUndefined();
 		expect(cancelResponse.result?.status?.state).toBe("canceled");
+	});
+});
+
+// ── 4. artifact URL absolutization (#194 / ADR 0005) ───────────────
+describe("HabitatAgentExecutor — artifact URLs", () => {
+	async function seedArtifact(
+		host: AgentHost,
+		url: string,
+	): Promise<void> {
+		const dir = join(host.getWorkDir(), "artifacts");
+		await mkdir(dir, { recursive: true });
+		const meta = {
+			sourcePath: "/data/out.png",
+			artifactPath: `${dir}/2026-x-foo.png`,
+			name: "Foo",
+			mimeType: "image/png",
+			timestamp: "2026-06-23T00:00:00.000Z",
+			url,
+		};
+		await writeFile(`${dir}/2026-x-foo.meta.json`, JSON.stringify(meta));
+	}
+
+	function artifactUri(events: Array<Record<string, any>>): string | undefined {
+		const ev = events.find((e) => e.kind === "artifact-update");
+		return ev?.artifact?.parts?.[0]?.file?.uri;
+	}
+
+	it("emits absolute-public FilePart URIs when an origin resolves", async () => {
+		const host = await makeHost();
+		await seedArtifact(host, "/files/artifacts/2026-x-foo.png");
+		const executor = new HabitatAgentExecutor(
+			host,
+			instantBridge(),
+			() => "https://agent.example.com",
+		);
+		const { bus, events } = fakeEventBus();
+		await executor.execute(requestContext(), bus);
+		expect(artifactUri(events)).toBe(
+			"https://agent.example.com/files/artifacts/2026-x-foo.png",
+		);
+	});
+
+	it("leaves URIs relative when no origin resolver is provided (back-compat)", async () => {
+		const host = await makeHost();
+		await seedArtifact(host, "/files/artifacts/2026-x-foo.png");
+		const executor = new HabitatAgentExecutor(host, instantBridge());
+		const { bus, events } = fakeEventBus();
+		await executor.execute(requestContext(), bus);
+		expect(artifactUri(events)).toBe("/files/artifacts/2026-x-foo.png");
+	});
+
+	it("never rewrites an already-absolute stored URI", async () => {
+		const host = await makeHost();
+		await seedArtifact(host, "https://cdn.example.com/files/artifacts/a.png");
+		const executor = new HabitatAgentExecutor(
+			host,
+			instantBridge(),
+			() => "https://agent.example.com",
+		);
+		const { bus, events } = fakeEventBus();
+		await executor.execute(requestContext(), bus);
+		expect(artifactUri(events)).toBe(
+			"https://cdn.example.com/files/artifacts/a.png",
+		);
 	});
 });

--- a/packages/habitat/src/a2a-handler.ts
+++ b/packages/habitat/src/a2a-handler.ts
@@ -32,7 +32,11 @@ import {
 } from "@umwelten/protocols";
 import type { AgentHost } from "./types.js";
 import type { ChannelBridge } from "./bridge/channel-bridge.js";
-import { listArtifacts, type ArtifactMeta } from "./tools/artifact-tools.js";
+import {
+  listArtifacts,
+  toAbsoluteArtifactUrl,
+  type ArtifactMeta,
+} from "./tools/artifact-tools.js";
 import { getSpeaker } from "./identity/agent-speaker-context.js";
 
 // ── Agent card builder ────────────────────────────────────────────
@@ -131,9 +135,23 @@ export class HabitatAgentExecutor implements AgentExecutor {
    */
   private activeTasks = new Map<string, ActiveTask>();
 
-  constructor(habitat: AgentHost, bridge: ChannelBridge) {
+  /**
+   * Resolve the agent's public origin at emit time (#194). The artifact build
+   * runs mid-stream with no inbound request in hand, so the container server
+   * threads a resolver that reads the most recent request's public origin
+   * (X-Forwarded-* / BASE_URL / Host, via getPublicBaseUrl). Undefined → emit
+   * the stored relative URL unchanged (back-compat / local dev).
+   */
+  private resolvePublicOrigin?: () => string | undefined;
+
+  constructor(
+    habitat: AgentHost,
+    bridge: ChannelBridge,
+    resolvePublicOrigin?: () => string | undefined,
+  ) {
     this.habitat = habitat;
     this.bridge = bridge;
+    this.resolvePublicOrigin = resolvePublicOrigin;
   }
 
   async execute(
@@ -311,11 +329,14 @@ export class HabitatAgentExecutor implements AgentExecutor {
   }
 
   private metaToA2AArtifact(meta: ArtifactMeta, index: number): A2AArtifact {
+    // Absolutize the stored relative URL against the resolved public origin so
+    // the FilePart.uri resolves for off-origin consumers (SaaS, Gaia) — #194.
+    const uri = toAbsoluteArtifactUrl(meta.url, this.resolvePublicOrigin?.());
     const parts: (TextPart | FilePart)[] = [
       {
         kind: "file",
         file: {
-          uri: meta.url,
+          uri,
           mimeType: meta.mimeType,
           name: meta.name,
         },
@@ -347,6 +368,12 @@ export interface A2AHandlerOptions {
   requiresApiKey?: boolean;
   /** Advertise per-user JWT capability (bearerFormat: JWT) — jwt/jwt+bearer mode. */
   jwtMode?: boolean;
+  /**
+   * Resolve the agent's public origin at artifact-emit time (#194). The
+   * container server passes a getter over the most recent request's resolved
+   * origin so emitted FilePart URIs are absolute. Omit → relative URLs.
+   */
+  resolvePublicOrigin?: () => string | undefined;
 }
 
 /**
@@ -368,7 +395,11 @@ export async function createA2AHandler(
     jwtMode: options.jwtMode,
   });
 
-  const executor = new HabitatAgentExecutor(options.habitat, options.bridge);
+  const executor = new HabitatAgentExecutor(
+    options.habitat,
+    options.bridge,
+    options.resolvePublicOrigin,
+  );
 
   return createA2AServer({ agentCard, executor });
 }

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -30,7 +30,7 @@ import { registerAiTool } from "./mcp-tool-bridge.js";
 import type { Habitat } from "./habitat.js";
 import type { AgentHost } from "./types.js";
 import { resolveProjectDir, saveConfig, fileExists } from "./config.js";
-import { listArtifacts } from "./tools/artifact-tools.js";
+import { listArtifacts, toAbsoluteArtifactUrl } from "./tools/artifact-tools.js";
 import { createA2AHandler, type A2AHandler } from "./a2a-handler.js";
 import { runWithSpeaker } from "./identity/agent-speaker-context.js";
 import { getPublicBaseUrl } from "@umwelten/protocols";
@@ -327,6 +327,12 @@ export async function startContainerServer(
 
 	// A2A handler — initialized lazily on first request (needs port for baseUrl)
 	let a2aHandler: A2AHandler | null = null;
+	// Most-recent request's resolved public origin (#194). The A2A artifact-emit
+	// path runs mid-stream with no request in hand, so it reads this holder,
+	// which every request refreshes via getPublicBaseUrl(req). The public origin
+	// is a deployment property (BASE_URL / Fly edge headers), so concurrent
+	// requests resolve the same value — the shared holder is race-tolerant.
+	let lastPublicOrigin: string | undefined;
 	async function getA2AHandler(actualPort: number): Promise<A2AHandler> {
 		if (!a2aHandler) {
 			const baseUrl = `http://${host === "0.0.0.0" ? "localhost" : host}:${actualPort}`;
@@ -337,6 +343,7 @@ export async function startContainerServer(
 				name: serverName,
 				requiresApiKey: authRequired,
 				jwtMode: authMode === "jwt" || authMode === "jwt+bearer",
+				resolvePublicOrigin: () => lastPublicOrigin,
 			});
 		}
 		return a2aHandler;
@@ -375,6 +382,11 @@ export async function startContainerServer(
 
 			const { path, query } = parseRoute(req.url ?? "/");
 			const reqStart = Date.now();
+
+			// Refresh the resolved public origin for this request (#194), so the
+			// A2A artifact-emit path (which has no req) mints absolute FilePart
+			// URIs. Mirrors the agent-card self-describe at the /.well-known route.
+			lastPublicOrigin = getPublicBaseUrl(req);
 
 			// Log non-static requests
 			const shouldLog =
@@ -927,7 +939,10 @@ export async function startContainerServer(
 
 					// GET /api/artifacts — list published artifacts
 					if (path === "/api/artifacts" && req.method === "GET") {
-						const metas = await listArtifacts(habitat.getWorkDir());
+						const origin = getPublicBaseUrl(req);
+						const metas = (await listArtifacts(habitat.getWorkDir())).map(
+							(m) => ({ ...m, url: toAbsoluteArtifactUrl(m.url, origin) }),
+						);
 						sendJson(res, { artifacts: metas, count: metas.length });
 						return;
 					}

--- a/packages/habitat/src/tool-sets.ts
+++ b/packages/habitat/src/tool-sets.ts
@@ -154,6 +154,13 @@ export const artifactToolSet: ToolSet = {
     createArtifactTools({
       getWorkDir: () => habitat.getWorkDir(),
       getSessionId: () => (habitat as any)._currentSessionId,
+      // Absolutize the model-facing artifact URL when a public origin is known
+      // (#194). The tool runs with no inbound request, so fall back to BASE_URL
+      // (set per child by Gaia / in prod). Undefined ⇒ relative URL (local dev).
+      getPublicOrigin: () => {
+        const base = process.env.BASE_URL?.trim();
+        return base ? base.replace(/\/$/, "") : undefined;
+      },
     }),
 };
 

--- a/packages/habitat/src/tools/artifact-tools.test.ts
+++ b/packages/habitat/src/tools/artifact-tools.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { toAbsoluteArtifactUrl } from "./artifact-tools.js";
+
+// #194 / ADR 0005 — artifact metadata stores a relative `/files/...` path;
+// we absolutize at egress against the resolved public origin.
+describe("toAbsoluteArtifactUrl", () => {
+  it("joins a relative artifact path onto the public origin", () => {
+    expect(
+      toAbsoluteArtifactUrl(
+        "/files/artifacts/2026-x-foo.png",
+        "https://agent.example.com",
+      ),
+    ).toBe("https://agent.example.com/files/artifacts/2026-x-foo.png");
+  });
+
+  it("origin-roots the path regardless of any path on the origin", () => {
+    // WHATWG URL: a leading slash is origin-rooted (drops the origin's path).
+    expect(
+      toAbsoluteArtifactUrl(
+        "/files/artifacts/a.png",
+        "https://host.example.com/ignored/base",
+      ),
+    ).toBe("https://host.example.com/files/artifacts/a.png");
+  });
+
+  it("returns the URL unchanged when no origin is provided (local dev)", () => {
+    expect(toAbsoluteArtifactUrl("/files/artifacts/a.png", undefined)).toBe(
+      "/files/artifacts/a.png",
+    );
+  });
+
+  it("never double-joins an already-absolute URL", () => {
+    const abs = "https://cdn.example.com/files/artifacts/a.png";
+    expect(toAbsoluteArtifactUrl(abs, "https://agent.example.com")).toBe(abs);
+  });
+
+  it("trims a trailing slash on the origin without doubling", () => {
+    expect(
+      toAbsoluteArtifactUrl("/files/artifacts/a.png", "https://agent.example.com/"),
+    ).toBe("https://agent.example.com/files/artifacts/a.png");
+  });
+});

--- a/packages/habitat/src/tools/artifact-tools.ts
+++ b/packages/habitat/src/tools/artifact-tools.ts
@@ -36,6 +36,32 @@ export interface ArtifactMeta {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
+/**
+ * Resolve an artifact URL to an absolute, public-origin URL (#194 / ADR 0005).
+ *
+ * Artifact metadata stores a *relative* path (`/files/artifacts/...`) so it
+ * stays portable across redeploys and origin changes. We absolutize at the
+ * egress boundary — when emitting over A2A, returning from the API, or handing
+ * a URL to the model — using the agent's resolved public origin.
+ *
+ * - No origin → return the URL unchanged (back-compat / local dev).
+ * - Already absolute (`http(s)://`) → return unchanged (never double-join).
+ * - Relative → join against the origin via WHATWG URL semantics. A leading
+ *   slash is origin-rooted, which is exactly what `/files/...` wants.
+ */
+export function toAbsoluteArtifactUrl(
+  url: string,
+  origin: string | undefined,
+): string {
+  if (!origin) return url;
+  if (/^https?:\/\//i.test(url)) return url;
+  try {
+    return new URL(url, origin).toString();
+  } catch {
+    return url;
+  }
+}
+
 const MIME_MAP: Record<string, string> = {
   ".png": "image/png",
   ".jpg": "image/jpeg",
@@ -84,6 +110,13 @@ function formatTimestamp(): string {
 export interface ArtifactToolsContext {
   getWorkDir(): string;
   getSessionId?(): string | undefined;
+  /**
+   * Resolve the agent's public origin (e.g. `https://agent.example.com`) so the
+   * published-artifact URL handed back to the model is absolute and resolves
+   * from the SaaS chat / through the Gaia proxy (#194). Undefined → the tool
+   * returns the relative `/files/...` path (local dev).
+   */
+  getPublicOrigin?(): string | undefined;
 }
 
 // ── List artifacts helper (used by API endpoint too) ─────────────────
@@ -170,17 +203,22 @@ export function createArtifactTools(
         url,
       };
 
-      // Write metadata
+      // Write metadata — store the RELATIVE url so it stays portable across
+      // redeploys / origin changes (#194). Absolutize only at egress (below).
       const metaPath = join(
         artifactsDir,
         `${ts}-${slug}.meta.json`,
       );
       await writeFile(metaPath, JSON.stringify(meta, null, 2), "utf-8");
 
+      // Hand the model an absolute, public-origin URL so the link it embeds in
+      // its reply resolves from the SaaS chat / through the Gaia proxy.
+      const publicUrl = toAbsoluteArtifactUrl(url, ctx.getPublicOrigin?.());
+
       return {
         published: true,
         name,
-        url,
+        url: publicUrl,
         mimeType,
         artifactPath,
         sessionId,

--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -213,6 +213,12 @@ export class DockerManager {
         "--label", `caddy=${hostname}`,
         "--label", "caddy.reverse_proxy={{upstreams 8080}}",
       );
+      // Public origin for absolute artifact/asset URLs (#194). Gaia's proxy
+      // does not set X-Forwarded-* and rewrites Host to the internal docker
+      // name, so getPublicBaseUrl can't infer the public origin from headers
+      // inside the child. BASE_URL (which it prefers when no X-Forwarded-* is
+      // present) pins it to the Caddy-published https origin.
+      args.push("--env", `BASE_URL=https://${hostname}`);
     }
 
     // Per-user identity (ADR 0003): when a JWKS is configured, spawn the child

--- a/packages/protocols/src/a2a/client.ts
+++ b/packages/protocols/src/a2a/client.ts
@@ -175,9 +175,22 @@ export async function sendA2AMessage(
             const textParts = parts
               .filter((p: any) => p.kind === "text" || p.type === "text")
               .map((p: any) => p.text);
+            // Defensive base-join (#194): habitats mint absolute artifact URIs,
+            // but tolerate a relative `/files/...` from older/other agents by
+            // resolving it against this endpoint's origin (WHATWG URL: a
+            // leading slash is origin-rooted). Already-absolute URIs pass through.
+            const origin = `http://${endpoint.host ?? DEFAULT_HOST}:${endpoint.port}`;
+            const resolveUri = (uri: string | undefined): string | undefined => {
+              if (!uri) return uri;
+              try {
+                return new URL(uri, origin).toString();
+              } catch {
+                return uri;
+              }
+            };
             const artifacts = (result?.artifacts ?? []).map((a: any) => ({
               name: a.name,
-              uri: a.parts?.[0]?.file?.uri,
+              uri: resolveUri(a.parts?.[0]?.file?.uri),
             }));
             resolve({
               text: textParts.join("\n") || "(no text response)",

--- a/reports/2026-06-23-public-origin-urls-and-a2a-fileparts.md
+++ b/reports/2026-06-23-public-origin-urls-and-a2a-fileparts.md
@@ -1,0 +1,256 @@
+# Public-origin URLs for habitat artifacts + A2A FilePart semantics
+
+> **Issue #194.** Habitat agents emit artifact/asset links as relative `/files/artifacts/…`
+> paths. These resolve only when the consumer already sits at the habitat's own origin —
+> they break from the SaaS chat surface and through the Gaia reverse proxy. We need to mint
+> **absolute, public-origin** URLs *at emit time*, and the public origin must be threaded
+> into the agent run context, because the publish path runs mid-stream with **no inbound
+> HTTP request** to read forwarding headers from.
+>
+> **TL;DR.** Re-use `getPublicBaseUrl` (it already powers the agent-card self-describe at
+> `container-server.ts:435`), but you cannot call it from the artifact path — there's no
+> `req` there. Capture the public origin on the *most recent inbound request* (the A2A POST
+> / chat request that started the run) and stash it in the run context, then have
+> `publish_artifact` join `meta.url` against it. Ship absolute `FilePart.file.uri`. Add a
+> **defensive consumer-side base-join** against the AgentCard origin, because (a) the spec
+> does **not** forbid relative URIs and (b) **Gaia's proxy does not set `X-Forwarded-*`**,
+> so a naive `getPublicBaseUrl(req)` returns the *internal docker host* behind Gaia.
+
+---
+
+## 1. Public-origin resolution behind reverse proxies
+
+### 1.1 What `getPublicBaseUrl` does today
+
+`packages/protocols/src/mcp-serve/public-url.ts` (`getPublicBaseUrl(req)`) derives an origin
+in strict precedence:
+
+1. **`X-Forwarded-Proto` + (`X-Forwarded-Host` ?? `Host`)** — if a forwarded proto is
+   present and *some* host is known, return `${proto}://${host}`. `firstHeader()` takes the
+   first comma-split token and trims (handles `proto1, proto2` proxy chains).
+2. **`process.env.BASE_URL`** — explicit env override, trailing slash trimmed.
+3. **`Host` header alone** — proto inferred: `http` for `localhost`/`127.0.0.1`/`[::1]`,
+   else `https`.
+4. **`http://localhost:8080`** — last-ditch fallback.
+
+It **always trusts `X-Forwarded-*` when present** — there is no allow-list of trusted proxy
+IPs, no check that the request actually arrived via a known intermediary. That is fine on
+**Fly.io**, where the Fly edge *replaces* any client-supplied `X-Forwarded-Proto`/`Host`
+(the comment at `public-url.ts:2-4` says exactly this), but it is a **host-header-spoofing
+sink** in any topology where an untrusted client can reach the Node server directly with a
+forged `X-Forwarded-Host`.
+
+This is the canonical "host header injection" footgun: an attacker who can hit the origin
+directly sets `X-Forwarded-Host: evil.example`, and every absolute URL we mint (artifact
+links, OAuth redirects, agent-card `url`) now points at their host — the classic
+password-reset-poisoning / cache-poisoning / stored-open-redirect vector. The fix is the
+standard one: **only trust forwarded headers from a known, trusted intermediary, and ensure
+that intermediary overwrites (not appends) the inbound header.** Fly does this for us; Gaia
+does **not** (see §1.3). See the security write-ups in *Sources*.
+
+### 1.2 Threading the origin into the run context (the actual #194 work)
+
+The artifact publish path (`tools/artifact-tools.ts:160`) builds `url = /files/artifacts/${file}`
+with **no `req` in scope** — it runs deep inside a streaming model turn. So `getPublicBaseUrl`
+cannot be called there. Two seams already prove the pattern we should mirror:
+
+- `container-server.ts:435` — the `/.well-known/agent-card.json` handler overrides the
+  card's cached `http://localhost:PORT` `url` with `getPublicBaseUrl(req)` ("self-describe
+  with the PUBLIC url" — #170). This is request-scoped, so it has `req`.
+- `a2a-handler.ts:64-115` / `:332` — `buildAgentCard` bakes a **fixed internal** `baseUrl`
+  (`http://localhost:${actualPort}`) at construction time, *because* it has no request. The
+  agent card's `url` is then patched per-request at `:438`.
+
+The artifact path is the same shape as `buildAgentCard`: no request, needs the public origin.
+**Recommended approach:** capture `getPublicBaseUrl(req)` at the *entry* of the inbound
+request that starts the run (the A2A POST handler, the chat HTTP handler) and pass it down
+through the `ChannelBridge` → run context → `ArtifactToolsContext`. Concretely, add
+`getPublicBaseUrl?(): string | undefined` to `ArtifactToolsContext` (next to the existing
+`getWorkDir()` / `getSessionId?()`), populated from the request-captured origin. Then:
+
+```ts
+const base = ctx.getPublicBaseUrl?.();              // captured at request entry
+const relPath = `/files/artifacts/${artifactFilename}`;
+const url = base ? new URL(relPath, base).href : relPath;   // absolute when known
+```
+
+Keep `meta.url` storing the **relative** path on disk (it is origin-independent and survives
+origin changes / redeploys); compute the absolute URL at emit time and at A2A-artifact build
+time (`a2a-handler.ts:313-323`). Do **not** persist the absolute origin into `.meta.json` —
+that re-introduces a stale-origin bug across redeploys.
+
+> **Open design question to flag:** the A2A executor's `metaToA2AArtifact` (`a2a-handler.ts:313`)
+> also runs in `onDone`, *after* the inbound request object is out of scope. It must read the
+> same captured origin from the executor/bridge context, not from a (non-existent) `req`.
+
+### 1.3 The umwelten proxy chain — **critical finding**
+
+Two different fronting topologies, with **different** forwarded-header behavior:
+
+| Path | Sets `X-Forwarded-Proto`/`-Host`? | Result of `getPublicBaseUrl(req)` |
+|------|-----------------------------------|-----------------------------------|
+| **Fly.io edge** (single habitat) | **Yes** — edge replaces them | Correct public origin ✅ |
+| **Caddy → habitat** (`*.habitats.thefocus.ai`) | Yes, if `reverse_proxy` config forwards them (Caddy sets them by default) | Correct, **if** Caddy passes them ✅ |
+| **Gaia internal proxy** (`tools/gaia/proxy.ts`) | **No** — see below | **Internal docker host** ❌ |
+
+`gaia/proxy.ts:35-46` builds the upstream request with `{ ...req.headers, host:
+`${childHost}:${CHILD_INTERNAL_PORT}`, authorization: Bearer … }`. It **overwrites `Host`**
+with the internal docker service name (e.g. `gaia-<id>:8080`) and **adds no `X-Forwarded-*`
+headers**. So a habitat behind Gaia that calls `getPublicBaseUrl(req)` will:
+
+- see no `X-Forwarded-Proto` → skip branch 1,
+- fall to `BASE_URL` (if the container env sets it) → **this is the only reliable signal
+  inside a Gaia child**, else
+- fall to the rewritten `Host` (`gaia-<id>:8080`) → mints `http://gaia-<id>:8080/files/…`,
+  which is useless to any external consumer.
+
+**Implications for #194:**
+1. For Gaia-managed habitats, **set `BASE_URL`** in each child container's env to its
+   external origin (the per-habitat `*.habitats.thefocus.ai` hostname). `getPublicBaseUrl`
+   already prefers `BASE_URL` over a bare `Host`. This is the cleanest knob and is consistent
+   with how Fly secrets/env inject config (see *flyio* report §4). The Gaia registry seeds
+   `config.json`/`secrets.json` into named volumes; `BASE_URL` should be seeded the same way.
+2. Optionally, have `gaia/proxy.ts` inject `X-Forwarded-Host`/`X-Forwarded-Proto` from the
+   *external* Gaia origin before forwarding (so children behind Gaia behave like children
+   behind Fly). This is a small, contained change and makes the whole fleet uniform — but it
+   means Gaia becomes a trusted header-setter and must **strip any client-supplied
+   `X-Forwarded-*`** first (it currently spreads `...req.headers` verbatim, which would *pass
+   a spoofed value straight through* — fix that regardless).
+
+> Topology background is already covered — don't re-derive it: Gaia drives the host Docker
+> daemon, children bind `127.0.0.1` on ports 7440–7499, reached only via the Gaia reverse
+> proxy (see `reports/2026-06-18-gaia-deployment-and-habitat-orchestration.md`). Fly edge
+> header handling + `fly secrets`/`[env]` injection (see
+> `reports/2026-06-18-flyio-habitat-container-deploy.md` §4).
+
+---
+
+## 2. A2A `FilePart` URI semantics
+
+### 2.1 What `@a2a-js/sdk@0.3.13` actually types (installed version)
+
+From `@a2a-js/sdk@0.3.13` (`packages/habitat/package.json` → `^0.3.13`), the type is a
+discriminated union — `FilePart.file` is `FileWithBytes | FileWithUri`:
+
+```ts
+interface FilePart { file: FileWithBytes | FileWithUri; kind: "file"; metadata?: {…}; }
+interface FileWithBytes { bytes: string; mimeType?: string; name?: string; }  // base64
+interface FileWithUri  { uri: string;   mimeType?: string; name?: string; }  // "A URL pointing to the file's content."
+```
+
+`uri` is **just `string`** — no format/absoluteness constraint at the type level, no
+validator. The doc-comment calls it "A URL pointing to the file's content."
+
+### 2.2 What the protocol spec says — **relative is NOT a hard violation**
+
+The official A2A spec (a2a-protocol.org v0.3.0) describes `FileWithUri.uri` as a URL to the
+file's content and gives only a **size heuristic** for choosing bytes vs uri ("small →
+`file_with_bytes`; large → read directly from `file_with_uri`"). It **does not normatively
+require an absolute URI**, does not define relative-URI resolution, and does not say what
+base a consumer resolves against.
+
+**Finding that affects the approach:** shipping a relative `uri` is therefore **not a clean
+spec violation — it is underspecified and fragile.** The spec gives no contract for *what
+origin* a relative `uri` resolves against, so each consumer is free to guess (or fail). That
+is precisely why the SaaS chat and the A2A client mishandle today's `/files/artifacts/…`.
+The correct fix is still to emit **absolute** URIs (unambiguous, self-contained, what every
+consumer can fetch), but we should **not** describe relative URIs as "illegal" in commit
+messages / ADRs — describe them as "underspecified; resolution is consumer-dependent, so we
+mint absolute."
+
+### 2.3 `FileWithUri` vs `FileWithBytes`
+
+For habitat artifacts that already live on disk and are served at a stable public URL,
+**`FileWithUri` is correct** (avoids base64-bloating every A2A message with potentially
+large images/PDFs; matches the spec's "large file" guidance). `FileWithBytes` would only be
+warranted for tiny inline assets or when no reachable public origin exists. Keep
+`metaToA2AArtifact` on `FileWithUri`; just make the `uri` absolute.
+
+---
+
+## 3. Defensive consumer-side base-join (WHATWG URL)
+
+Even after we mint absolute URIs, the consumer should **not assume** every `FilePart.uri`
+it ever receives is absolute (other agents, older habitat versions, the relative URIs we
+ship today, §2.2). Today **no consumer does any join**: `a2a/client.ts:178-181` reads
+`a.parts?.[0]?.file?.uri` and passes it straight through. Add a defensive join against the
+AgentCard origin (the card's `url`/`provider.url` — `a2a-handler.ts:438,442` advertise both).
+
+Use the WHATWG `URL` constructor with the card origin as base:
+
+```ts
+function resolveArtifactUri(uri: string, agentOrigin: string): string {
+  try { return new URL(uri, agentOrigin).href; }  // absolute uri ignores base; relative is joined
+  catch { return uri; }
+}
+```
+
+**WHATWG gotchas to encode in this helper / its tests:**
+
+- **Already-absolute `uri` wins.** `new URL("https://x/y", base)` ignores `base` entirely —
+  safe to always pass our minted absolute URIs through this function.
+- **Leading slash = origin-rooted, path replaced.** `new URL("/files/a.png",
+  "https://h.example/agent/sub")` → `https://h.example/files/a.png` (the base **path** is
+  discarded; only scheme+host+port survive). This is exactly what we want for
+  `/files/artifacts/…`, but only if `agentOrigin` carries the right host — pass the card
+  **origin**, not a deep path.
+- **No leading slash = relative to base directory.** `new URL("a.png",
+  "https://h.example/agent")` → `https://h.example/a.png` (note: the last path segment
+  `agent` is treated as a file and dropped). Surprising; our paths are slash-rooted so this
+  won't bite, but document it so nobody "fixes" the leading slash away.
+- **`new URL` throws on an invalid/empty base when `uri` is relative** — hence the
+  `try/catch` returning the raw `uri` rather than crashing the whole A2A response parse.
+- Resolve against the card's `provider.url` (human-facing origin) or `url` minus the `/a2a`
+  suffix — both are the same origin in our cards, so either works; prefer the bare origin.
+
+---
+
+## Executive summary
+
+- **Re-use `getPublicBaseUrl`, but the artifact path has no `req`.** Capture the public
+  origin at the inbound request entry (A2A POST / chat handler) and thread it through the run
+  context into `ArtifactToolsContext.getPublicBaseUrl()`; join `meta.url` with `new URL(rel,
+  base)` at emit time and in `metaToA2AArtifact`. Mirror the existing agent-card pattern at
+  `container-server.ts:435`. Keep `.meta.json` storing the **relative** path (origin-stable).
+- **Gaia's proxy breaks `getPublicBaseUrl` — top priority.** `tools/gaia/proxy.ts` sets no
+  `X-Forwarded-*` and overwrites `Host` with the internal docker name, so a Gaia child would
+  mint `http://gaia-<id>:8080/files/…`. Fix by **setting `BASE_URL`** per child container
+  (seeded into its volume like config/secrets), and/or having Gaia inject external
+  `X-Forwarded-*` (after stripping client-supplied ones).
+- **Relative `FilePart.uri` is underspecified, not a spec violation.** The A2A spec
+  (`@a2a-js/sdk@0.3.13`) types `uri` as a plain `string` with no absoluteness rule and gives
+  only a size heuristic for bytes-vs-uri. Frame the change as "mint absolute because
+  relative resolution is consumer-dependent," not as "fixing an illegal value."
+- **Keep `FileWithUri` (not `FileWithBytes`).** Artifacts are on-disk and served at a stable
+  public URL; uri avoids base64-bloating A2A messages and matches the spec's large-file
+  guidance.
+- **Add a defensive consumer-side base-join** in `a2a/client.ts` (currently passes
+  `file.uri` through untouched). Use `new URL(uri, agentCardOrigin)` in a try/catch:
+  absolute URIs pass through unchanged, leading-slash paths re-root onto the card origin,
+  invalid bases fall back to the raw uri.
+
+### Findings that change the implementation approach
+
+1. **`getPublicBaseUrl` trusts `X-Forwarded-*` unconditionally (no proxy allow-list).** Safe
+   behind Fly (edge overwrites the headers) but a host-header-spoofing sink if any untrusted
+   client can reach a habitat origin directly. Gaia currently spreads `...req.headers`
+   verbatim, so it would *forward a spoofed `X-Forwarded-Host` straight through* — strip
+   client-supplied `X-Forwarded-*` at the Gaia proxy regardless of which fix we pick.
+2. **Behind Gaia, `getPublicBaseUrl(req)` returns the internal docker host, not the public
+   origin** (proxy sets no forwarding headers + rewrites `Host`). The publish path must lean
+   on `BASE_URL` (or a Gaia-injected `X-Forwarded-*`) for Gaia-managed habitats, otherwise
+   absolute URLs will be wrong precisely in the topology #194 cares about.
+3. **Relative `FilePart.uri` is spec-valid-but-undefined**, so the consumer-side base-join is
+   not optional polish — it's the correctness guarantee for any artifact uri that isn't
+   already absolute (today's habitats, third-party agents, mixed versions).
+
+## Sources
+
+- [Understanding X-Forwarded-Host: Security & Best Practices (Requestly)](https://requestly.com/blog/x-forwarded-host/)
+- [X-Forwarded-Host is always trusted / used in url_for — rails/rails#29893](https://github.com/rails/rails/issues/29893)
+- [IP Spoofing via HTTP Headers (OWASP)](https://owasp.org/www-community/pages/attacks/ip_spoofing_via_http_headers)
+- [Spoofing of X-Forwarded-Host during HTTPS redirect — ingress-nginx#13158](https://github.com/kubernetes/ingress-nginx/issues/13158)
+- [Understanding the X-Forwarded-For HTTP Header — Security Risks & Best Practices (DevSec)](https://devsec-blog.com/2025/04/understanding-the-x-forwarded-for-http-header-security-risks-and-best-practices/)
+- [Agent2Agent (A2A) Protocol Official Specification v0.3.0](https://a2a-protocol.org/v0.3.0/specification/)
+- [A2A specification.md (a2aproject/A2A)](https://github.com/a2aproject/A2A/blob/main/docs/specification.md)
+- [URL — WHATWG URL Standard / MDN `URL()` constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)


### PR DESCRIPTION
Closes #194. First slice of ADR 0005 / PRD #193. Unblocks #195 → #196 → #197.

## What this builds

Artifact URLs were minted **relative** (`/files/artifacts/...`) and shipped verbatim as the A2A `FilePart.uri`, so they resolved only on the container's own origin and **404'd in the SaaS chat and through the Gaia proxy** — exactly where rich responses need them. This mints **absolute, public-origin** URLs at every egress boundary, while keeping the stored `.meta.json` **relative** (portable across redeploys / origin changes).

End-to-end behavior:
- A shared `toAbsoluteArtifactUrl()` helper does the egress join (no origin → unchanged; already-absolute → unchanged; relative → WHATWG base-join, leading-slash origin-rooted).
- The container server refreshes the **per-request public origin** (`getPublicBaseUrl`, honoring `X-Forwarded-*` / `BASE_URL` / `Host`) into a holder; the A2A executor reads it at artifact-emit time (which runs mid-stream with no `req`) and absolutizes `FilePart.uri`.
- `/api/artifacts` absolutizes per-request directly.
- `publishArtifact` hands the model an absolute URL while persisting the relative path.
- Defensive consumer-side base-join in the protocols A2A client (tolerates relative URIs from other/older agents).
- **Gaia** injects `BASE_URL=https://<hostname>` per child — its proxy sets no `X-Forwarded-*` and rewrites `Host`, so `getPublicBaseUrl` can't infer the origin inside the child (key finding from the research report below).

Research: `reports/2026-06-23-public-origin-urls-and-a2a-fileparts.md` (forwarded-header pitfalls, A2A `FilePart` URI semantics, the Gaia origin-detection gap).

## Acceptance criteria — with validation steps

**Run the automated tests (covers criteria 1, 3, 6):**
```bash
git fetch origin && git checkout feat/194-absolute-public-artifact-urls
pnpm install
pnpm exec vitest run packages/habitat/src/tools/artifact-tools.test.ts packages/habitat/src/a2a-handler.test.ts
# → 19 passed. The "HabitatAgentExecutor — artifact URLs" block asserts the
#   emit-seam produces absolute-public FilePart URIs (and relative back-compat).
```

- [x] **The agent run context carries the resolved public origin (honoring forwarding headers).** The container server refreshes `lastPublicOrigin = getPublicBaseUrl(req)` each request and passes a resolver into the A2A handler. *Verify:* unit test `emits absolute-public FilePart URIs when an origin resolves`.
- [x] **A published artifact's URL is absolute, rooted at the public origin.** `publishArtifact` returns `toAbsoluteArtifactUrl(rel, origin)`; `.meta.json` keeps the relative path. *Verify manually:*
  ```bash
  BASE_URL=https://agent.example.com dotenvx run -- pnpm run cli habitat serve --port 7430 &
  # in the chat UI / via a tool call, publish an artifact, then:
  curl -s -H "x-forwarded-proto: https" -H "x-forwarded-host: agent.example.com" \
    http://localhost:7430/api/artifacts | jq '.artifacts[0].url'
  # → "https://agent.example.com/files/artifacts/..."  (absolute, not "/files/...")
  ```
- [x] **The A2A artifact-update event carries an absolute-public URI.** *Verify:* the executor emit-seam test, or POST a `message/send` to `/a2a` behind forwarded headers and inspect the `artifact-update` event's `parts[0].file.uri`.
- [x] **An artifact URL through the Gaia proxy resolves (no 404 off-origin).** Gaia now sets `BASE_URL=https://<hostname>` on each child. *Verify:* with `GAIA_BASE_DOMAIN` set, start a child via Gaia and confirm published artifact URLs use `https://<id>.<domain>/files/...` and load through Caddy.
- [x] **Consumer-side defensive base-join against the agent origin.** protocols A2A client resolves `file.uri` against the endpoint origin. *Verify:* a relative `/files/...` from an agent is returned absolute by `sendA2AMessage`.
- [x] **Covered by a unit test at the emit seam.** `a2a-handler.test.ts` → `HabitatAgentExecutor — artifact URLs` (3 cases).

## How to verify everything (full)
```bash
pnpm test:run          # full unit suite — 1535 passing, no regressions
pnpm exec vitest run packages/habitat/src/tools/artifact-tools.test.ts packages/habitat/src/a2a-handler.test.ts
```

## Worth knowing / further work
- **Pre-existing build breakage:** `pnpm -r build` fails with **17 TS errors at base** (unchanged by this PR), from `@ai-sdk/provider` 2.0.0-vs-3.0.10 duplication and newer `@types/node` `AbortSignal.timeout`/`fetch` arity in `core/*` and `protocols/mcp/*` — none in files this PR touches. Flagging, not fixing (out of scope, and per the repo's "don't make wild-ass changes" rule).
- **`getPublicBaseUrl` trusts `X-Forwarded-*` with no proxy allow-list**, and Gaia's proxy spreads inbound `req.headers` verbatim — a client could spoof `X-Forwarded-Host` to a habitat reached directly. This PR sidesteps it for Gaia children via `BASE_URL`, but **stripping inbound `X-Forwarded-*` at the Gaia proxy** is recommended follow-up (security hardening, separate concern).
- **Standalone Fly habitat without `BASE_URL`:** the A2A `FilePart` path is still correct (forwarded headers via the per-request holder), but the `publishArtifact` model-facing URL falls back to relative. Setting `BASE_URL` is the recommendation; noted for the deployment docs.
- The SaaS-side rendering/consumption of these URLs is tracked in the habitats repo (out of scope here, per the PRD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)