### PR TITLE
Emit UI resources over MCP as EmbeddedResource (#196, ADR 0005 slice C)

### DIFF
--- a/packages/habitat/src/mcp-tool-bridge.test.ts
+++ b/packages/habitat/src/mcp-tool-bridge.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { tool } from "ai";
+import { z } from "zod";
+import { aiResultToMcpContent, registerAiTool } from "./mcp-tool-bridge.js";
+import { buildHabitatUIResource, withUIResources } from "./ui-resources.js";
+
+// ADR 0005 slice C (#196) — UI resources pass through as EmbeddedResource blocks.
+describe("aiResultToMcpContent", () => {
+  it("flattens a plain object result to a single text block (unchanged)", () => {
+    const content = aiResultToMcpContent({ ok: true, n: 1 });
+    expect(content).toEqual([
+      { type: "text", text: JSON.stringify({ ok: true, n: 1 }, null, 2) },
+    ]);
+  });
+
+  it("passes a string result through as text", () => {
+    expect(aiResultToMcpContent("hi")).toEqual([{ type: "text", text: "hi" }]);
+  });
+
+  it("emits an EmbeddedResource block + a text block for a UI-resource result", () => {
+    const r = buildHabitatUIResource({ uri: "ui://h/w", html: "<p>x</p>" });
+    const content = aiResultToMcpContent(
+      withUIResources({ published: true }, [r]),
+    );
+    expect(content[0]).toEqual({ type: "resource", resource: r });
+    expect(content[1].type).toBe("text");
+    // the carrier key is stripped from the text the model/client sees
+    expect(content[1].text as string).not.toContain("_uiResources");
+    expect(JSON.parse(content[1].text as string)).toEqual({ published: true });
+  });
+});
+
+describe("registerAiTool", () => {
+  function captureHandler() {
+    let handler: ((p: Record<string, unknown>) => Promise<any>) | undefined;
+    const server = {
+      registerTool: (_n: string, _c: unknown, h: typeof handler) => {
+        handler = h;
+      },
+    } as any;
+    return { server, get: () => handler! };
+  }
+
+  it("registers a handler that returns EmbeddedResource content for a UI tool", async () => {
+    const { server, get } = captureHandler();
+    const r = buildHabitatUIResource({ uri: "ui://h/w", html: "<p>x</p>" });
+    const uiTool = tool({
+      description: "emits ui",
+      inputSchema: z.object({}),
+      execute: async () => withUIResources({ published: true }, [r]),
+    });
+    registerAiTool(server, "ui_demo", uiTool);
+    const out = await get()({});
+    expect(out.content[0]).toEqual({ type: "resource", resource: r });
+  });
+
+  it("skips client-only tools without execute", () => {
+    const calls: string[] = [];
+    const server = { registerTool: (n: string) => calls.push(n) } as any;
+    registerAiTool(server, "noexec", { description: "x" } as any);
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/habitat/src/mcp-tool-bridge.ts
+++ b/packages/habitat/src/mcp-tool-bridge.ts
@@ -16,6 +16,34 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Tool } from "ai";
+import {
+	extractUIResources,
+	stripUIResources,
+	uiResourceToMcpContent,
+	type McpEmbeddedResource,
+} from "./ui-resources.js";
+
+/** An MCP tool-result content block: text or an embedded UI resource. */
+export type McpContentBlock =
+	| { type: "text"; text: string }
+	| McpEmbeddedResource;
+
+/**
+ * MCP content blocks for an AI SDK tool result (ADR 0005 slice C, #196).
+ * If the result carries UI resources, emit them as `EmbeddedResource` blocks
+ * (the rest of the result flattens to a text block); otherwise it's text-only,
+ * exactly as before. Kept pure so it's unit-testable without an McpServer.
+ */
+export function aiResultToMcpContent(result: unknown): McpContentBlock[] {
+	const uiResources = extractUIResources(result);
+	const rest = stripUIResources(result);
+	const text =
+		typeof rest === "string" ? rest : JSON.stringify(rest, null, 2);
+	return [
+		...uiResources.map((r) => uiResourceToMcpContent(r)),
+		{ type: "text", text },
+	];
+}
 
 export function registerAiTool(
 	mcpServer: McpServer,
@@ -48,15 +76,19 @@ export function registerAiTool(
 				abortSignal: new AbortController().signal,
 			});
 
-			// AI SDK tools return arbitrary objects; serialize to text for MCP.
-			const text =
-				typeof result === "string" ? result : JSON.stringify(result, null, 2);
-
-			console.log(
-				`[${new Date().toISOString()}] ✓ ${toolName} (${text.length} chars)`,
+			// AI SDK tools return arbitrary objects; serialize to text for MCP,
+			// or pass a UI resource through as an EmbeddedResource block (#196).
+			const content = aiResultToMcpContent(result);
+			const chars = content.reduce(
+				(n, c) => n + (c.type === "text" ? c.text.length : 0),
+				0,
 			);
 
-			return { content: [{ type: "text" as const, text }] };
+			console.log(
+				`[${new Date().toISOString()}] ✓ ${toolName} (${chars} chars)`,
+			);
+
+			return { content };
 		} catch (error: any) {
 			console.log(
 				`[${new Date().toISOString()}] ✗ ${toolName}: ${error.message ?? String(error)}`,

--- a/packages/habitat/src/tools/ui-resource-tools.ts
+++ b/packages/habitat/src/tools/ui-resource-tools.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import {
   buildHabitatUIResource,
   publishUIResource,
+  withUIResources,
 } from "../ui-resources.js";
 
 export interface UIResourceToolsContext {
@@ -51,12 +52,17 @@ export function createUIResourceTools(
         origin: ctx.getPublicOrigin?.(),
       });
       await publishUIResource(ctx.getWorkDir(), resource);
-      return {
-        published: true,
-        uri: resource.uri,
-        mimeType: resource.mimeType,
-        note: "UI resource queued for this turn; it renders in the chat client.",
-      };
+      // Carry the resource on the result so the MCP bridge emits it as an
+      // EmbeddedResource block (#196); the A2A path drains it from the buffer.
+      return withUIResources(
+        {
+          published: true,
+          uri: resource.uri,
+          mimeType: resource.mimeType,
+          note: "UI resource queued for this turn; it renders in the chat client.",
+        },
+        [resource],
+      );
     },
   });
 

--- a/packages/habitat/src/ui-resources.test.ts
+++ b/packages/habitat/src/ui-resources.test.ts
@@ -5,6 +5,10 @@ import { tmpdir } from "node:os";
 import {
   buildHabitatUIResource,
   uiResourceToA2APart,
+  uiResourceToMcpContent,
+  withUIResources,
+  extractUIResources,
+  stripUIResources,
   publishUIResource,
   drainUIResources,
   UI_OUTPUT_MODE,
@@ -74,6 +78,32 @@ describe("uiResourceToA2APart (normalizer)", () => {
       outputMode: UI_OUTPUT_MODE,
       mimeType: r.mimeType,
     });
+  });
+});
+
+describe("MCP carrier (#196)", () => {
+  it("uiResourceToMcpContent wraps as an EmbeddedResource block", () => {
+    const r = buildHabitatUIResource({ uri: "ui://h/w", html: "<p>x</p>" });
+    expect(uiResourceToMcpContent(r)).toEqual({ type: "resource", resource: r });
+  });
+
+  it("withUIResources / extractUIResources round-trip", () => {
+    const r = buildHabitatUIResource({ uri: "ui://h/w", html: "<p>x</p>" });
+    expect(extractUIResources(withUIResources({ ok: true }, [r]))).toEqual([r]);
+  });
+
+  it("extractUIResources returns [] for plain / non-object results", () => {
+    expect(extractUIResources({ ok: true })).toEqual([]);
+    expect(extractUIResources("text")).toEqual([]);
+    expect(extractUIResources(null)).toEqual([]);
+  });
+
+  it("stripUIResources removes only the carrier key", () => {
+    const r = buildHabitatUIResource({ uri: "ui://h/w", html: "<p>x</p>" });
+    expect(stripUIResources(withUIResources({ ok: true }, [r]))).toEqual({
+      ok: true,
+    });
+    expect(stripUIResources("text")).toBe("text");
   });
 });
 

--- a/packages/habitat/src/ui-resources.ts
+++ b/packages/habitat/src/ui-resources.ts
@@ -131,6 +131,69 @@ export function uiResourceToA2APart(resource: HabitatUIResource): DataPart {
   };
 }
 
+/** An MCP `EmbeddedResource` content block — the tool-result content type. */
+export interface McpEmbeddedResource {
+  type: "resource";
+  resource: HabitatUIResource;
+}
+
+/**
+ * Normalizer (MCP direction): map a UI resource onto an MCP `EmbeddedResource`
+ * content block (ADR 0005 slice C, #196). Same source resource as the A2A
+ * DataPart so the two transports can never drift.
+ */
+export function uiResourceToMcpContent(
+  resource: HabitatUIResource,
+): McpEmbeddedResource {
+  return { type: "resource", resource };
+}
+
+// ── Tool-result carrier ────────────────────────────────────────────────
+//
+// A tool signals "my result contains UI resources" by attaching them under a
+// reserved key. The MCP bridge extracts them into EmbeddedResource content
+// blocks instead of flattening the whole result to text. Generic — any tool
+// (including slice D's interactive tools) can opt in.
+
+/** Reserved key carrying UI resources on a tool result. */
+export const UI_RESOURCE_RESULT_KEY = "_uiResources";
+
+/** Attach UI resources to a tool result object for the MCP bridge to extract. */
+export function withUIResources<T extends Record<string, unknown>>(
+  result: T,
+  resources: HabitatUIResource[],
+): T & { [UI_RESOURCE_RESULT_KEY]: HabitatUIResource[] } {
+  return { ...result, [UI_RESOURCE_RESULT_KEY]: resources };
+}
+
+/** Read UI resources carried on a tool result (empty if none / wrong shape). */
+export function extractUIResources(result: unknown): HabitatUIResource[] {
+  if (!result || typeof result !== "object") return [];
+  const carried = (result as Record<string, unknown>)[UI_RESOURCE_RESULT_KEY];
+  if (!Array.isArray(carried)) return [];
+  return carried.filter(
+    (r): r is HabitatUIResource =>
+      !!r &&
+      typeof r === "object" &&
+      typeof (r as HabitatUIResource).uri === "string",
+  );
+}
+
+/** Return a copy of the tool result with the UI-resource carrier removed. */
+export function stripUIResources(result: unknown): unknown {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return result;
+  }
+  if (!(UI_RESOURCE_RESULT_KEY in (result as Record<string, unknown>))) {
+    return result;
+  }
+  const { [UI_RESOURCE_RESULT_KEY]: _omit, ...rest } = result as Record<
+    string,
+    unknown
+  >;
+  return rest;
+}
+
 // ── Per-turn filesystem buffer (mirrors the artifact side-channel) ──────
 
 /** Append a UI resource to the per-turn buffer under {workDir}/ui-resources. */


### PR DESCRIPTION
Closes #196. ADR 0005 / PRD #193 slice C. Builds on merged #194 + #195; unblocks #197 (interactive callbacks).

## What this builds

The MCP tool bridge flattened **every** tool result to a text content block. Now a tool that emits a UI resource produces an `EmbeddedResource` content block over MCP — reusing the slice-B normalizer so the MCP and A2A representations derive from **one** source. After this, the same UI-emitting tool that surfaces a `DataPart` over A2A also surfaces a resource block over `/mcp`, so an external MCP client (probe, desktop client) receives a renderable resource instead of stringified text. Still display-only.

- **`ui-resources.ts`**: `uiResourceToMcpContent()` (MCP normalizer → `{ type:"resource", resource }`), plus a generic tool-result carrier — `withUIResources` / `extractUIResources` / `stripUIResources` — so any tool can signal "my result contains UI resources" (generalizes to slice D's tools too).
- **`mcp-tool-bridge.ts`**: `aiResultToMcpContent()` (pure, unit-testable) emits `[...EmbeddedResource blocks, text]`; **plain tools stay text-only, unchanged**.
- **`publish_ui_resource`** carries the resource on its result (`withUIResources`) so MCP emits it; the A2A path still drains the per-turn buffer.

## Acceptance criteria — with validation

```bash
git fetch origin && git checkout feat/196-ui-resource-over-mcp && pnpm install
pnpm exec vitest run packages/habitat/src/mcp-tool-bridge.test.ts packages/habitat/src/ui-resources.test.ts
# → 18 passed.
```

- [x] **A tool emitting a UI resource produces an `EmbeddedResource` content block (not flattened text).** `aiResultToMcpContent`. *Verify:* `aiResultToMcpContent > emits an EmbeddedResource block + a text block`. *Manual:* `dotenvx run -- pnpm run cli habitat serve`, then `mcp test-tool` / `mcp chat` the agent, call `publish_ui_resource`, observe the `resource` content block.
- [x] **Non-UI tool results unchanged.** `aiResultToMcpContent` returns a single text block for plain/string results. *Verify:* the `flattens a plain object` + `passes a string through` tests.
- [x] **MCP representation derived from the same normalizer as A2A.** Both `uiResourceToMcpContent` and `uiResourceToA2APart` live in `ui-resources.ts` over one `HabitatUIResource`.
- [x] **An external MCP client receives the resource block.** `registerAiTool` test drives the registered handler via a fake server and asserts the `resource` block; the carrier key is stripped from the text the client sees.
- [x] **Unit test at the bridge seam.** `mcp-tool-bridge.test.ts` (pure function + `registerAiTool`).

## How to verify everything
```bash
pnpm test:run   # full suite — 1556 passing, no regressions
```

## Worth knowing / further work
- The carrier (`_uiResources` key) is a small generic convention so the bridge stays tool-agnostic and slice D's interactive tools reuse it. It's stripped from the text block, so the model/client never sees the raw key.
- Over the A2A/Interaction path the tool result still includes the resource (low-cost echo of HTML the model itself supplied); the A2A executor delivers via the per-turn buffer (slice B), not this carrier.
- Pre-existing build breakage unchanged: same 17 environmental TS errors as base, none in touched files.
- SaaS-side rendering of the resource block is the habitats repo (out of scope per the PRD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)