### PR TITLE
Per-user identity on MCP tool callbacks (#197, ADR 0005 slice D)

### DIFF
--- a/docs/adr/0005-ui-resources-over-a2a-and-mcp.md
+++ b/docs/adr/0005-ui-resources-over-a2a-and-mcp.md
@@ -1,0 +1,180 @@
+# 0005 — Rich UI resources over the habitat surface (MCP-UI over A2A + MCP)
+
+Status: **Accepted — not yet implemented**
+Date: 2026-06-23
+
+> This ADR was pinned down in a grilling session. All nine decisions below are
+> locked. Nothing here is implemented yet — the **Implementation sequencing**
+> section is the build order.
+
+## Context
+
+The Focus A2A-agent standard (`standards/best-practices/a2a-agent.md`) makes
+*renderable UI* a first-class tool output: every "visual tool" returns a
+`ui: createUIResource(...)` alongside its `text`/`json`/`citation`, an MCP-UI
+`AppRenderer` renders it client-side, and a dedicated `POST /api/mcp` route exists
+**solely** so the renderer's sandboxed iframe can forward UI actions
+(`tools/call`, `resources/read`) back into the tool surface (standard §4.1, §7).
+
+We have **two serving surfaces**, and the standard only describes one of them:
+
+- **umwelten container** (`packages/habitat`) — serves A2A at `/a2a`, MCP at `/mcp`
+  (`mcp-local-server.ts`, SDK 1.29.0 — the version the standard pins), a vanilla-JS
+  web UI (`public/index.html`), and is reverse-proxied by Gaia (`tools/gaia/proxy.ts`,
+  pure pass-through).
+- **habitats SaaS** (Vercel/Next/Neon/Clerk) — *is* the standard's shape, but dispatches
+  agents **primarily over A2A** (`src/workflows/agents/umwelten.ts`); its chat renderer is
+  `EmbeddableWorkstream.tsx`.
+
+Current state on both: **no renderable UI exists.** MCP tool results are text-only
+(`mcp-tool-bridge.ts` → `{ content: [{ type: "text", text }] }`); A2A parts are
+text/file/data; there is no `createUIResource`, no `AppRenderer`, and no `@mcp-ui/*`
+dependency in either repo. The MCP SDK already supports `EmbeddedResource`, so the
+server-side emission is an unblock, not a rewrite.
+
+### What the grilling established about transport (correction to a first framing)
+
+A2A is **not** UI-incapable. The split is:
+
+- **Display** of a `ui://…` resource (raw HTML, external-URL pointer, or remote-DOM)
+  is just bytes — it rides an A2A `DataPart`/`FilePart`. The standard anticipates this:
+  the AgentCard advertises `text/html+mcp` in `defaultOutputModes`, and output modes
+  *are* A2A parts. habitats' `stream.ts` already has an `artifact` intent to carry it.
+- **UI actions**: of MCP-UI's five action types, **four** map onto A2A with no MCP:
+  `prompt` and `intent` → a new `message/send`; `link` and `notify` → host-local.
+  **Only `tool`** (synchronous tool call that mutates the widget in place, no
+  conversational turn) and lazy `resources/read` need `tools/call`, which A2A's
+  `message/send`+`message/stream` surface does not expose. That single case is the
+  entire reason the separate MCP route exists.
+
+### The artifact-URL defect (a hard dependency for rich responses)
+
+Artifact URLs are minted **relative** (`tools/artifact-tools.ts:160` →
+`/files/artifacts/<file>`) and shipped verbatim as the A2A `FilePart.uri`
+(`a2a-handler.ts:318`). The AgentCard got a public-origin fix (#170,
+`getPublicBaseUrl` / `X-Forwarded-*`), but **artifacts did not**. The habitats SaaS
+consumes the uri with no base-join (`stream.ts:266`). Net: artifacts resolve only on
+the container's own origin; they 404 in the SaaS chat and through Gaia's proxied SPA.
+A "rich response" is precisely a UI resource that references assets by URL, so this
+defect blocks the goal.
+
+Serving itself is correct: `/files/*` is sandboxed-served (`container-server.ts:776`)
+and Gaia proxies `/api/habitats/:id/files/*` → `/files/*` (`tools/gaia/routes.ts:121`).
+The bug is URL *minting*, not URL *serving*.
+
+## Decision (locked)
+
+1. **Transport-agnostic emit.** A tool/agent emits **one** UI resource. The habitat
+   **runtime** — not the tool author — selects the transport. "Pass in the resource
+   and it works."
+2. **Both transports, MCP only when needed.** Display + `prompt`/`intent`/`link`/`notify`
+   actions travel over **A2A**. The MCP channel + sandbox-proxy is engaged **only** when
+   a resource declares interactive `tool` (or `resources/read`) callbacks.
+3. **Rich client responses are a v1 goal**, not deferred.
+4. **Absolute-public asset URLs at emit time.** Artifacts (and any asset a UI resource
+   references) are minted as absolute URLs against the agent's **public** origin
+   (`getPublicBaseUrl`), resolved when the artifact is published. The public origin is
+   **threaded into the agent run context** so the publish path (which runs mid-stream,
+   `a2a-handler.ts:225`, without the inbound `req`) can build them. Relative-plus-consumer-
+   base-join was rejected: a sandboxed mcp-ui iframe has no way to know the agent origin,
+   so it cannot base-join, which would silently break the interactive case (4) targets.
+5. **A new exposure surface on the habitat side is in scope** (shape TBD — see open
+   questions). We are not constrained to bolt UI onto the existing routes.
+6. **Interactive callbacks reuse ADR 0003 identity (option i).** The iframe's `tools/call`
+   travels over `/mcp`, which is already gated and already being upgraded to per-user JWT
+   by the 0003 rollout. The SaaS renderer mints the per-user, habitat-scoped JWT
+   (`sub` = viewing user) for the iframe's MCP connection and **holds it as the proxy
+   parent**; the token never enters the sandboxed iframe (the iframe `postMessage`s its
+   call up, the parent makes the authenticated fetch). No new auth mechanism — one
+   identity model (ADR 0003) across A2A and the MCP callback. The v1-restriction
+   alternative (widgets touching user-scoped data must round-trip through an A2A turn)
+   was rejected as a temporary cap we'd remove anyway.
+
+7. **Content modality: rawHtml + externalUrl in v1; remoteDom deferred.** Both v1
+   modalities are a sandboxed iframe (`srcdoc` for rawHtml, `src` for externalUrl); the
+   sandbox is the trust boundary. externalUrl rides Decision 4 (absolute-public URLs).
+   remoteDom (host-native components via a remote-DOM bridge) is deferred — it needs the
+   host to ship a renderer + component vocabulary, with no v1 payoff.
+8. **Renderer scope: SaaS `EmbeddableWorkstream` only in v1.** It gets the full mcp-ui
+   `AppRenderer` + the Decision-6 proxy. The container's vanilla-JS `public/index.html`
+   and the Gaia dashboard are dev/admin surfaces, out of v1 (display-only at most).
+9. **Interactive callbacks carry identity only — one token, no new key (supersedes the
+   earlier "context-bound, habitat-minted token" design).** A `tool` callback's sole hard
+   requirement is "run as the right user," so per-user connectors resolve for the *viewer*
+   and one tenant can't read another's. That is exactly what the **ADR 0003 per-user JWT —
+   already verified on `/mcp`** — provides.
+
+   - **Mechanism:** the SaaS-as-proxy (Decision 6) attaches the per-user JWT (`sub` = viewer)
+     to the `tools/call`. The habitat verifies the JWT it already verifies and **threads the
+     `sub` into MCP tool execution** via the existing `runWithSpeaker` / `getSpeaker`
+     mechanism (`identity/agent-speaker-context.ts`) — identical to how the A2A executor
+     scopes a turn. Nothing else.
+   - **No separate context-binding token, no 4th signing key, no minting, no
+     stamp-and-echo contract.** The earlier design had the *habitat* mint a
+     `{ habitatId, contextId, allowedTools }` token — but ADR 0003 establishes that the
+     **SaaS owns the `contextId`** (it mints the thread), so a habitat-minted context token
+     was both redundant and inconsistent. If session/thread binding is ever needed, the
+     SaaS adds a `contextId` claim to the JWT it already signs — still one token, still one
+     key.
+   - **Why scope (`allowedTools`) is not a v1 security boundary:** any holder of a valid
+     per-user JWT can already call any habitat tool over `/mcp` today. Restricting a widget
+     callback to a tool subset is defense-in-depth, not a new boundary, so it is deferred.
+
+   **Deferred to a follow-up (only when a thread-*mutating* widget exists):** session
+   rehydration by `contextId` (for a widget that writes to the originating thread's state,
+   vs. a pure per-user fetch like "refresh my bookmarks") and per-resource tool scoping.
+   Both are additive over this identity-only base and need no redesign.
+
+## Implementation sequencing
+
+1. **Fix artifact URLs (Decision 4).** Thread the public origin (`getPublicBaseUrl`) into
+   the run context; mint absolute-public URLs in `artifact-tools.ts` / `metaToA2AArtifact`.
+   Also base-join on the consumer side (`habitats stream.ts:266`) as belt-and-suspenders.
+   *This is independently shippable and unblocks every later step.*
+2. **Server emit (Decision 1, 2, 7).** Add `@mcp-ui/server`; let a tool return a
+   `createUIResource` (rawHtml/externalUrl). Carry it as an A2A part (display path) — no
+   MCP callback yet. Unblock `mcp-tool-bridge.ts` to pass `EmbeddedResource` through.
+3. **SaaS render (Decision 8).** Add `@mcp-ui/client` `AppRenderer` to
+   `EmbeddableWorkstream`; render display resources; wire `prompt`/`intent`/`link`/`notify`
+   to the existing `send()`. *Now rich, non-interactive UI works end to end over pure A2A.*
+4. **Interactive callbacks (Decision 6, 9).** Thread the JWT `sub` already verified on
+   `/mcp` into MCP tool execution via `runWithSpeaker`, so a widget's `tool` call resolves
+   per-user connectors as the viewer. The SaaS-as-proxy attaches the per-user JWT to the
+   `tools/call`. No token minting, no new key, no session rehydration. *Prerequisite (the
+   0003 JWT verifier reaching `/mcp`) is already met — `/mcp` runs `auth.authenticate(req)`
+   with `compositeAuth("jwt+bearer", …)`.*
+
+## Hardening / refinements (not blockers)
+
+- `runWithSpeaker` is the existing A2A identity primitive; the only gap is that
+  `/mcp` authenticates the connection but does not yet thread the user into tool execution.
+- Audit-log per-user `tools/call`s the same way ADR 0003 wants per-user attribution.
+- Deferred (Decision 9): session rehydration by `contextId` and per-resource tool scoping,
+  if/when a thread-mutating widget needs them.
+
+## Glossary
+
+- **UI resource** — a renderable artifact a tool emits via `createUIResource`, addressed
+  `ui://…`, in one of three modalities (rawHtml / externalUrl / remoteDom). v1 ships the
+  first two (Decision 7).
+- **AppRenderer** — the mcp-ui client component that renders a UI resource in a sandboxed
+  iframe and brokers its actions. In v1 it lives only in the SaaS `EmbeddableWorkstream`
+  (Decision 8).
+- **UI action** — a message a rendered widget sends to its host: `prompt`, `intent`,
+  `link`, `notify` (all satisfiable over A2A), or `tool` / `resources/read` (the only ones
+  needing the MCP callback channel).
+- **SaaS-as-proxy** — the renderer's parent holds the per-user JWT and makes the
+  authenticated `/mcp` call on the sandboxed iframe's behalf; the token never enters the
+  iframe (Decision 6).
+- **`runWithSpeaker` / `getSpeaker`** — the existing AsyncLocalStorage identity primitive
+  (`identity/agent-speaker-context.ts`) that scopes a run to a user. Interactive callbacks
+  reuse it to run a widget's `tool` call as the JWT `sub` (Decision 9) — no separate token.
+
+## References
+
+- Standard: `standards/best-practices/a2a-agent.md` §4.1, §7.
+- Builds on: ADR 0003 (per-user A2A identity) — the basis for Q3.
+- Code touchpoints: `packages/habitat/src/mcp-tool-bridge.ts`,
+  `a2a-handler.ts` (`metaToA2AArtifact`, `:225`, `:318`), `tools/artifact-tools.ts:160`,
+  `container-server.ts` (`getPublicBaseUrl`, `:776`), `tools/gaia/routes.ts:121`;
+  habitats `src/lib/a2a/stream.ts:266`, `src/lib/embed/EmbeddableWorkstream.tsx`.

--- a/docs/artifacts/prd-mcp-ui-resources.md
+++ b/docs/artifacts/prd-mcp-ui-resources.md
@@ -1,0 +1,86 @@
+## Problem Statement
+
+Habitat agents can only answer in text. When a tool produces something that wants to be *seen or interacted with* — a chart, a form, a table of a user's data, a set of choice buttons — the agent has no way to put that in front of a person. Today every tool result is flattened to a text string on the MCP surface, and the A2A surface carries only text/file/data parts with no notion of a renderable widget. A user chatting with an agent in the habitats SaaS gets prose where they wanted a UI.
+
+There is also a latent defect that blocks even the simplest "rich" answer: artifact URLs are minted relative and shipped verbatim, so any image or asset an agent references resolves only on the container's own origin and 404s in the SaaS chat and through the Gaia proxy. Rich responses are exactly the things that travel across that origin boundary, so they break precisely where they're meant to be useful.
+
+## Solution
+
+Let a habitat agent emit a **UI resource** (an mcp-ui `createUIResource`) as a first-class tool/agent output, and render it for the user.
+
+From the agent author's perspective there is one thing to do: emit the UI resource. The habitat runtime — not the author — decides how it travels. Display and simple actions ride the existing A2A stream; only genuinely interactive tool callbacks engage the MCP channel. The SaaS chat renders the resource in a sandboxed frame and brokers its actions back safely.
+
+The result: an agent can answer with a rendered chart, a fillable form, choice buttons that send a follow-up, or a live widget that calls a tool and updates itself in place — and the per-user identity and session guarantees the habitat already enforces continue to hold inside that widget.
+
+This work is specified by ADR 0005 (UI resources over A2A + MCP) and depends on the per-user identity model in ADR 0003.
+
+## User Stories
+
+1. As an agent author, I want to emit a single UI resource from a tool, so that I get a rendered result without choosing or wiring a transport.
+2. As an agent author, I want the runtime to pick A2A vs MCP for me, so that I never hand-code protocol plumbing per tool.
+3. As an agent author, I want to return rendered HTML (rawHtml), so that I can show a custom-formatted result.
+4. As an agent author, I want to return a pointer to a page I host (externalUrl), so that I can surface a fuller app or dashboard inside the chat.
+5. As an agent author, I want a tool that references an image or file to produce a URL that works wherever it's rendered, so that my rich answer doesn't break off-origin.
+6. As a user chatting with an agent in the SaaS, I want to see a rendered widget instead of a wall of text, so that I can understand the answer faster.
+7. As a user, I want to click a button in a widget that sends a follow-up message, so that I can continue the conversation without retyping.
+8. As a user, I want a widget to open an external link or notify the app, so that simple interactions feel native.
+9. As a user, I want an interactive widget (e.g. "refresh my numbers") to call a tool and update in place, so that I don't need a whole new conversational turn for a small action.
+10. As a user in a shared thread, I want a widget I interact with to act as *me*, so that it resolves my data and my connected accounts, not someone else's.
+11. As a user, I want a widget that touches my private connected account (e.g. an upstream connector token) to be safe even though I share the thread with others, so that my credentials are never exposed to another participant.
+12. As a user, I want to click a widget button long after it was rendered (in scrollback) and still have it work, so that the conversation history stays interactive.
+13. As a platform operator, I want interactive callbacks to carry a verifiable user identity, so that per-user attribution and cost tracking still apply to widget-driven tool calls.
+14. As a platform operator, I want a widget to be unable to call tools it wasn't authorized to, so that a leaked or replayed token can't escalate.
+15. As a platform operator, I want the credential that authorizes a callback to never enter the sandboxed frame, so that untrusted rendered content can't read it.
+16. As a platform operator, I want the MCP transport to remain stateless, so that a callback rejoining a session does not force per-connection session state on every caller.
+17. As a security reviewer, I want the context-binding token to be inert on its own, so that it is useless without a fresh per-user identity token.
+18. As a security reviewer, I want unsigned or expired tokens rejected on the callback path, so that the same guarantees as the A2A path hold for MCP callbacks.
+19. As an external MCP client (e.g. a probe or desktop client), I want UI resources to render or degrade gracefully, so that I can consume the same tool catalog.
+20. As an agent author, I want display-only UI resources to work over pure A2A with no MCP involvement, so that the common case has the smallest moving-part count.
+21. As a maintainer, I want UI emission normalized in one place, so that A2A and MCP representations never drift.
+22. As a maintainer, I want the artifact-URL fix to ship independently, so that a current defect is corrected without waiting on the full feature.
+23. As a user behind the Gaia proxy, I want artifact and asset URLs to resolve through the proxy, so that rendered content is not broken by the reverse-proxy hop.
+24. As an agent author, I do not want to ship a custom web UI just to verify my agent renders UI, so that I can rely on the SaaS renderer or an external client.
+
+## Implementation Decisions
+
+(All trace to ADR 0005; identity traces to ADR 0003.)
+
+- **One canonical emitted UI-resource shape.** A tool/agent emits a single UI resource (an mcp-ui `createUIResource`). A transport-agnostic normalization module maps that one resource into the per-transport representation; authors never select a transport. This normalizer is the single point at which A2A and MCP representations are derived, so they cannot drift.
+- **Transport split.** Display of a UI resource and the `prompt` / `intent` / `link` / `notify` actions travel over the existing A2A surface (UI resource carried as a message part; the artifact intent is the carrier). The MCP channel is engaged only for `tool` (and lazy `resources/read`) actions — the only ones A2A's `message/send` + `message/stream` surface cannot express.
+- **Content modalities in scope: rawHtml and externalUrl.** Both render as a sandboxed iframe (srcdoc vs src); the sandbox is the trust boundary. remoteDom (host-native components) is deferred.
+- **Absolute-public asset URLs at emit time.** Artifacts and any asset a UI resource references are minted as absolute URLs against the agent's public origin, resolved using the same forwarded-origin mechanism the AgentCard already uses. The public origin is threaded into the agent run context so the publish path (which runs mid-stream) can build them. Consumers should also defensively base-join against the AgentCard origin.
+- **Renderer: SaaS chat only (v1).** The SaaS chat surface gains the mcp-ui `AppRenderer` and the proxy role. The container's built-in web UI and the Gaia dashboard are not renderers in v1 (display-only at most).
+- **Callbacks reuse ADR 0003 identity.** The MCP route is already authenticated and is already being upgraded to per-user JWT by the 0003 rollout. The SaaS renderer mints the per-user, habitat-scoped JWT (subject = the viewing user) for the iframe's MCP connection and holds it as the proxy parent; the iframe posts its action up and the parent makes the authenticated call. The token never enters the sandbox. No new auth mechanism — one identity model across A2A and MCP callbacks.
+- **Context-bound callbacks (session rehydration).** Because the MCP transport is stateless but the tool that emitted the widget ran inside an A2A session, a callback must be able to rejoin that session. The habitat stamps each emitted UI resource with a habitat-signed **context-binding token**. On callback the proxy presents two tokens; the habitat verifies both, rehydrates the originating session from the verified context for that one call, and authorizes the tool as the JWT subject. The transport stays stateless — the session is rebuilt on demand from the token, not stored per connection.
+- **Context-binding token contract (API contract, not a snippet of code):**
+  - Claims: `habitatId`, `contextId`, `allowedTools` (the set the emitting resource may call).
+  - Minted and signed by the **habitat** (which owns session lifecycle); identity JWT is minted by the **SaaS** (which owns identity). The two concerns stay split exactly as ADR 0003 splits thread (`contextId`) from speaker (`sub`).
+  - Binds to `contextId` only, not a single user — a shared thread has many viewers; per-user authorization comes from the JWT. This is the same trust envelope as posting a message to the thread.
+  - May be long-lived (life of the `contextId`, to survive scrollback clicks) because it is inert without a fresh, short-lived per-user JWT.
+  - `allowedTools` is enforced at the MCP tool-dispatch boundary.
+- **Signing key.** The habitat's context-binding token should use a key separate from the ADR 0003 identity keypair, so compromise/rotation of one does not grant the other.
+- **MCP tool-result content.** The MCP tool bridge must stop flattening every result to text and pass an `EmbeddedResource` content block through when a tool emits a UI resource (the MCP SDK already supports this).
+
+## Testing Decisions
+
+A good test here asserts **external behavior at a seam** — what comes out of the emit boundary and what the callback path accepts/rejects — never internal wiring. Two seams, matching existing patterns:
+
+- **Seam 1 — the transport-agnostic UI-resource normalizer (primary, one seam).** A pure in→out unit test: given a canonical emitted UI resource plus a run context carrying the public origin, assert it produces (a) the correct A2A part and (b) the correct MCP `EmbeddedResource`, for both rawHtml and externalUrl, and that referenced artifact/asset URLs are **absolute-public**. This single seam covers emit, modality, and URL minting for both transports. Prior art: the adapter-style assertions in the existing A2A handler tests (executor + in-memory event bus, no HTTP).
+- **Seam 2 — the MCP callback auth + session-rehydration boundary (extends an existing seam).** Assert that a `tools/call` presenting a valid per-user JWT and a valid context-binding token runs against the rehydrated session and authorizes as the subject; and that it is rejected on a missing/invalid/expired token or a tool outside `allowedTools`. This extends the existing auth-mode seam where bearer/JWT-mode behavior is already unit-tested (the AgentCard `securitySchemes` / auth tests).
+
+Both seams are unit-level against existing module boundaries. No new HTTP integration seam is introduced; the artifact-URL absolute-minting assertion folds into Seam 1 rather than standing alone.
+
+## Out of Scope
+
+- The SaaS-side `AppRenderer` integration, iframe `postMessage` plumbing, and chat rendering changes — they live in the habitats repo, not this one. This PRD covers the habitat/container/protocol side that the SaaS consumes.
+- The remoteDom modality (host-native component rendering).
+- Rendering UI resources in the container's built-in web UI and the Gaia dashboard.
+- Any change to the ADR 0003 JWT verifier itself — this work consumes it, it does not define it. (It does depend on that verifier reaching the MCP route, which is already part of the 0003 rollout.)
+- remoteDom-driven or non-iframe rendering surfaces.
+
+## Further Notes
+
+- **Shippable first step.** The absolute-public artifact-URL fix is a current defect independent of mcp-ui and should land first; it unblocks every later step and is independently valuable.
+- **Suggested build order** (from ADR 0005): (1) fix artifact URLs; (2) server-side emit + normalizer carrying a UI resource over A2A display with the MCP bridge passing `EmbeddedResource` through; (3) SaaS render of display resources (habitats repo); (4) interactive callbacks with context-binding + the 0003 JWT on the MCP route.
+- **Two corrections captured during design** (recorded in ADR 0005): A2A is not UI-incapable — it carries display plus four of the five action types; only `tool`/`resources/read` need MCP. And the MCP route is not anonymous — it is gated by the same auth as the rest of the surface, open only in keyless local dev.
+- This PRD is cross-cutting with the habitats SaaS; the renderer half is tracked separately on that side.

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -799,12 +799,24 @@ export async function startContainerServer(
 					// callback runs as the viewing user — per-user connectors resolve for
 					// them, not another tenant. Mirrors the /a2a path exactly. Bearer/dev
 					// carry no per-user identity, so the speaker stays unbound.
+					// Mirror the /a2a condition exactly: a verified per-user JWT binds
+					// the speaker in BOTH "jwt" and "jwt+bearer" modes (prod runs the
+					// dual-auth transition — an authMode==="jwt" check would never fire
+					// there). The shared key resolves to the bearer-user sentinel and
+					// stays unbound. The raw grant + issuer ride along so callback
+					// tools (room_history) work over MCP too.
+					const mcpAuth = req.headers.authorization ?? "";
+					const mcpGrant = mcpAuth.startsWith("Bearer ")
+						? mcpAuth.slice(7)
+						: undefined;
 					const mcpSpeaker =
-						authMode === "jwt" && user
+						user && user.userId !== "bearer-user"
 							? {
 									userId: user.userId,
 									displayName: user.displayName,
 									email: user.email,
+									grant: mcpGrant,
+									issuer: mcpGrant ? jwtIssuer(mcpGrant) : undefined,
 								}
 							: undefined;
 

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -786,13 +786,27 @@ export async function startContainerServer(
 				// ── MCP endpoint ──────────────────────────────────────
 				if (path === "/mcp") {
 					// Auth check for MCP
+					let user: UserContext | null = null;
 					if (authRequired) {
-						const user = await auth.authenticate(req);
+						user = await auth.authenticate(req);
 						if (!user) {
 							sendJson(res, { error: "Unauthorized" }, 401);
 							return;
 						}
 					}
+					// Per-user identity (ADR 0003 / 0005 §9): on the JWT path, bind the
+					// verified `sub` as the speaker so an interactive UI-resource `tool`
+					// callback runs as the viewing user — per-user connectors resolve for
+					// them, not another tenant. Mirrors the /a2a path exactly. Bearer/dev
+					// carry no per-user identity, so the speaker stays unbound.
+					const mcpSpeaker =
+						authMode === "jwt" && user
+							? {
+									userId: user.userId,
+									displayName: user.displayName,
+									email: user.email,
+								}
+							: undefined;
 
 					if (req.method === "DELETE") {
 						res.writeHead(200);
@@ -836,7 +850,11 @@ export async function startContainerServer(
 							sessionIdGenerator: undefined,
 						});
 						await mcpServer.connect(transport);
-						await transport.handleRequest(req, res, parsedBody);
+						// Run tool dispatch under the speaker so getSpeaker() resolves the
+						// viewer inside a UI-resource `tool` callback (ADR 0005 §9).
+						await runWithSpeaker(mcpSpeaker, () =>
+							transport!.handleRequest(req, res, parsedBody),
+						);
 					} catch (error) {
 						console.error(
 							`[container] MCP error: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/habitat/src/mcp-tool-bridge.test.ts
+++ b/packages/habitat/src/mcp-tool-bridge.test.ts
@@ -3,6 +3,11 @@ import { tool } from "ai";
 import { z } from "zod";
 import { aiResultToMcpContent, registerAiTool } from "./mcp-tool-bridge.js";
 import { buildHabitatUIResource, withUIResources } from "./ui-resources.js";
+import {
+  runWithSpeaker,
+  getSpeaker,
+  type Speaker,
+} from "./identity/agent-speaker-context.js";
 
 // ADR 0005 slice C (#196) — UI resources pass through as EmbeddedResource blocks.
 describe("aiResultToMcpContent", () => {
@@ -59,5 +64,45 @@ describe("registerAiTool", () => {
     const server = { registerTool: (n: string) => calls.push(n) } as any;
     registerAiTool(server, "noexec", { description: "x" } as any);
     expect(calls).toEqual([]);
+  });
+
+  // ADR 0005 §9 (#197) — interactive callbacks run as the viewer. The /mcp
+  // route wraps tool dispatch in runWithSpeaker; this proves the bridge handler
+  // preserves that identity into the tool's execute (the same primitive /a2a
+  // already uses), so a per-user tool resolves the speaking user, not another.
+  it("a tool dispatched under runWithSpeaker sees the speaker", async () => {
+    const { server, get } = captureHandler();
+    let seen: Speaker | undefined;
+    const whoami = tool({
+      description: "captures the speaker",
+      inputSchema: z.object({}),
+      execute: async () => {
+        seen = getSpeaker();
+        return "ok";
+      },
+    });
+    registerAiTool(server, "whoami", whoami);
+
+    await runWithSpeaker({ userId: "user-b", displayName: "B" }, () =>
+      get()({}),
+    );
+    expect(seen).toEqual({ userId: "user-b", displayName: "B" });
+  });
+
+  it("a tool dispatched with no speaker sees undefined (bearer/dev)", async () => {
+    const { server, get } = captureHandler();
+    let seen: Speaker | undefined = { userId: "stale" };
+    const whoami = tool({
+      description: "captures the speaker",
+      inputSchema: z.object({}),
+      execute: async () => {
+        seen = getSpeaker();
+        return "ok";
+      },
+    });
+    registerAiTool(server, "whoami", whoami);
+
+    await runWithSpeaker(undefined, () => get()({}));
+    expect(seen).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #197. Final slice of ADR 0005 / PRD #193. Builds on merged #194–#196.

## What this builds (and the simplification)

An interactive UI-resource `tool` callback must run **as the viewing user** — so per-user connectors resolve for *them* and one tenant can't read another's data (the cross-tenant-leak concern from the ADR grilling). `/mcp` already verifies the per-user JWT (ADR 0003), but **discarded the identity for tool execution**. This threads it through, mirroring the `/a2a` path exactly.

**Design was simplified during implementation** (ADR 0005 Decision 9, revised here): the earlier *habitat-minted context-binding token* is gone. Per ADR 0003 the **SaaS owns `contextId`**, so a second token + a 4th signing key was redundant and inconsistent. The callback's one hard requirement is identity, and the per-user JWT already on `/mcp` provides it. **One token, one key, no minting.**

- **`container-server.ts` `/mcp`:** on the JWT path, build the speaker from the verified user and wrap MCP tool dispatch in `runWithSpeaker` (the same primitive `/a2a` uses at `:613`). Bearer/dev carry no per-user identity → speaker stays unbound (no regression off the JWT path).
- **Deferred** (only when a thread-*mutating* widget exists): session rehydration by `contextId`, per-resource tool scoping. Additive over this base; no redesign needed.
- Also lands the **design-of-record** that #194–#197 implement: `docs/adr/0005-*.md` + `docs/artifacts/prd-mcp-ui-resources.md`, previously uncommitted.

## Acceptance criteria — with validation

```bash
git fetch origin && git checkout feat/197-mcp-callback-identity && pnpm install
pnpm exec vitest run packages/habitat/src/mcp-tool-bridge.test.ts
# → 7 passed, incl. the two identity tests.
```

- [x] **A `tools/call` runs as the verified JWT `sub`.** `/mcp` wraps dispatch in `runWithSpeaker(speaker)`; `speaker` is built from the authenticated user in JWT mode. *Verify:* `a tool dispatched under runWithSpeaker sees the speaker` — proves the bridge handler carries identity into the tool's `execute` (`getSpeaker()` → the viewer).
- [x] **Rejected without a valid JWT.** Unchanged: `/mcp` returns 401 when `auth.authenticate(req)` fails (`container-server.ts`).
- [x] **No per-user identity leaks on the bearer/dev path.** *Verify:* `a tool dispatched with no speaker sees undefined (bearer/dev)`.
- [x] **No new auth mechanism / key.** Reuses the ADR 0003 JWT verifier already on `/mcp` and the existing `runWithSpeaker`.
- [x] **Unit test at the bridge/identity seam.** `mcp-tool-bridge.test.ts`.

**Manual end-to-end** (JWT-configured habitat):
```bash
# With HABITAT_AUTH_JWKS_URL / HABITAT_AUTH_AUDIENCE set (jwt mode), connect an
# MCP client presenting a per-user JWT and call a tool that reads identity;
# confirm it resolves the JWT sub's per-user secrets, not another user's.
dotenvx run -- pnpm run cli habitat serve
```

## How to verify everything
```bash
pnpm test:run   # full suite — 1558 passing, no regressions
```

## Worth knowing / further work
- **No new tech/library** in this slice (reuses `runWithSpeaker`), so no new research report was needed.
- **Test altitude:** the new guarantee is unit-tested at the bridge/identity seam (a tool dispatched under `runWithSpeaker` sees the speaker). The container-server `/mcp` wrap is a 3-line mirror of the proven `/a2a` wrap; a full HTTP+JWT integration test is the natural follow-up but needs the JWKS harness.
- **Deferred slice** (session rehydration + tool scoping) should become its own issue when a thread-mutating widget lands.
- Pre-existing build breakage unchanged: same 17 environmental TS errors as base, none in touched files.
- SaaS-side (`AppRenderer` attaching the JWT to the iframe's MCP connection) is the habitats repo, per the PRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)