### PR TITLE
fix(core): surface the real stream error instead of "No output generated"

### DIFF
--- a/packages/core/src/cognition/runner-stream-error.test.ts
+++ b/packages/core/src/cognition/runner-stream-error.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Runner streamText error surfacing.
+ *
+ * Regression test for the bug where a provider/tool failure surfaced on the
+ * AI SDK stream as an `error` event was swallowed by the fullStream consumer,
+ * so the runner later threw the opaque "No output generated. Check the stream
+ * for errors." instead of the real cause — masking it from every caller
+ * (including, over A2A, the habitats room).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const streamTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock('ai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ai')>();
+  return { ...actual, streamText: streamTextMock };
+});
+
+import { BaseModelRunner } from './runner.js';
+import { Interaction } from '../interaction/core/interaction.js';
+import { Stimulus } from '../stimulus/stimulus.js';
+
+function makeInteraction() {
+  return new Interaction(
+    {
+      provider: 'minimax',
+      name: 'MiniMax-M2.5',
+      costs: { promptTokens: 0.3, completionTokens: 1.2 },
+    },
+    new Stimulus({ role: 'assistant' }),
+  );
+}
+
+async function* fullStreamOf(events: unknown[]) {
+  for (const e of events) yield e;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  streamTextMock.mockReset();
+});
+
+describe('Runner streamText error surfacing', () => {
+  it('throws the real stream error, not the opaque "No output generated"', async () => {
+    const runner = new BaseModelRunner();
+    const interaction = makeInteraction();
+
+    // Bypass provider/model resolution and request building so the test
+    // exercises only the fullStream consumption + error handling.
+    vi.spyOn(runner, 'startUp').mockResolvedValue({
+      startTime: new Date('2026-01-01T00:00:00.000Z'),
+      modelIdString: 'minimax/MiniMax-M2.5',
+    } as any);
+    vi.spyOn(runner, 'makeStreamOptions').mockResolvedValue({} as any);
+
+    const realError = new Error('twitter tool failed: 429 rate limited');
+    streamTextMock.mockReturnValue({
+      fullStream: fullStreamOf([{ type: 'error', error: realError }]),
+      // Reading `.text` after a stream error throws the opaque AI SDK message.
+      // The fix must short-circuit (throw the real error) before this is read.
+      get text() {
+        return Promise.reject(
+          new Error('No output generated. Check the stream for errors.'),
+        );
+      },
+      usage: Promise.resolve({}),
+    });
+
+    let caught: unknown;
+    try {
+      await runner.streamText(interaction);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toContain('twitter tool failed: 429 rate limited');
+    expect(message).not.toContain('No output generated');
+  });
+});

--- a/packages/core/src/cognition/runner.ts
+++ b/packages/core/src/cognition/runner.ts
@@ -230,6 +230,10 @@ export class BaseModelRunner implements ModelRunner {
     let fullText = "";
     let reasoningText = "";
     let reasoningDetails: any[] = [];
+    // Captures an `error` event surfaced on the stream (provider/tool failure)
+    // so we can fail with the real cause instead of the opaque downstream
+    // "No output generated" thrown when we later read response.text.
+    let streamError: unknown;
 
     try {
       const streamOptions = await this.makeStreamOptions(interaction, signal);
@@ -353,6 +357,16 @@ export class BaseModelRunner implements ModelRunner {
               });
               break;
             }
+            case "error": {
+              // The AI SDK surfaces provider/tool/stream failures as an
+              // `error` event in fullStream. Capture the REAL cause here;
+              // without this case it falls through to `default` (swallowed)
+              // and `await response.text` later throws the opaque
+              // "No output generated. Check the stream for errors.", masking
+              // the actual error from every caller (incl. the A2A/habitats UI).
+              streamError = (ev as { error?: unknown }).error ?? ev;
+              break;
+            }
             default:
               break;
           }
@@ -370,6 +384,21 @@ export class BaseModelRunner implements ModelRunner {
         if (fullText !== undefined && fullText !== null) {
           observer?.onTextDelta?.(fullText);
         }
+      }
+
+      // If the stream surfaced an error event, fail now with the real cause.
+      // Otherwise the `await response.text` below throws the opaque AI SDK
+      // "No output generated. Check the stream for errors." and the actual
+      // provider/tool error (only logged via onError) never reaches the
+      // caller — or, over A2A, the habitats room.
+      if (streamError) {
+        throw streamError instanceof Error
+          ? streamError
+          : new Error(
+              typeof streamError === "string"
+                ? streamError
+                : JSON.stringify(streamError),
+            );
       }
 
       // If no text was captured from streaming, try to get it from the response object


### PR DESCRIPTION
## Symptom (seen in the habitats SaaS room)
Asking `@Gaia Orchestrator` "is Twitter working?" returned, as the agent's reply:

> Error: Model streamText failed: No output generated. Check the stream for errors.

That's an opaque mask — the real failure (a tool/provider error) was being swallowed before it could reach the caller or the habitats UI.

## Root cause
`packages/core/src/cognition/runner.ts` — the `streamText` `fullStream` consumer has cases for `text-delta`, `reasoning-*`, `tool-call`, `tool-result`, and `default: break`, but **no `case "error"`**. When the AI SDK emits an `error` stream event, it falls through `default` and is dropped. `fullText` stays empty, so the code then does `await response.text`, which throws the AI SDK's `NoOutputGenerated: "No output generated. Check the stream for errors."` — wrapped by `handleError` as `Model streamText failed: …`. The genuine error was only visible via the `onError` console log (`request-options.ts`).

## Fix
- Add `case "error"` to capture the real error from the stream.
- Before falling back to `await response.text`, if an error was captured, **throw the real cause** so it propagates through `handleError` → `channel-bridge` → `a2a-handler` (`onError` → `Error: <real>`) → the habitats room.
- New test `runner-stream-error.test.ts` asserts a stream `error` event surfaces as the real message, not "No output generated".

## Verification
- `vitest run` runner suites → 14/14 pass
- eslint: 0 errors (pre-existing `any` warnings only); `tsc` clean on changed files

## Note
This is the agent-side (pancake) half. Once merged + pancake redeployed, the habitats room will show the **real** error (e.g. the actual Twitter/provider failure) instead of the opaque one. Optional follow-up: have habitats render agent error replies as a distinct failure state rather than a normal message bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)