### PR TITLE
fix(gaia): re-seed merges secrets.json instead of clobbering rotated tokens

### DIFF
--- a/packages/habitat/src/tools/gaia/docker.merge.test.ts
+++ b/packages/habitat/src/tools/gaia/docker.merge.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { mergeSecretsJson } from "./docker.js";
+
+const seed = JSON.stringify(
+  { OPENROUTER_API_KEY: "new-key", TWITTER_CLIENT_ID: "cid" },
+  null,
+  2,
+);
+
+describe("mergeSecretsJson (re-seed preserves habitat-owned secrets)", () => {
+  it("preserves per-user TOKEN:<sub> keys the seed doesn't manage", () => {
+    const existing = JSON.stringify({
+      OPENROUTER_API_KEY: "old-key",
+      "TWITTER_REFRESH_TOKEN:user_abc": "rotated-per-user-token",
+    });
+    const out = JSON.parse(mergeSecretsJson(existing, seed));
+    // per-user token survives the rebuild
+    expect(out["TWITTER_REFRESH_TOKEN:user_abc"]).toBe("rotated-per-user-token");
+    // operator-seeded key updates
+    expect(out.OPENROUTER_API_KEY).toBe("new-key");
+    expect(out.TWITTER_CLIENT_ID).toBe("cid");
+  });
+
+  it("returns the seed verbatim when the volume has no existing secrets", () => {
+    expect(mergeSecretsJson("", seed)).toBe(seed);
+    expect(mergeSecretsJson("   \n", seed)).toBe(seed);
+  });
+
+  it("falls back to the seed when existing content isn't valid JSON", () => {
+    expect(mergeSecretsJson("not json{", seed)).toBe(seed);
+  });
+
+  it("operator seed wins on key conflict", () => {
+    const existing = JSON.stringify({ OPENROUTER_API_KEY: "stale" });
+    const out = JSON.parse(mergeSecretsJson(existing, seed));
+    expect(out.OPENROUTER_API_KEY).toBe("new-key");
+  });
+});

--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -45,6 +45,24 @@ function spawnWithStdin(
   });
 }
 
+/**
+ * Merge a freshly-built secrets.json seed with the volume's existing contents.
+ * Operator-seeded keys win on conflict; existing-only keys (per-user
+ * `TOKEN:<sub>` entries and runtime-rotated refresh tokens the habitat owns)
+ * are preserved. Falls back to the raw seed when there's nothing to merge or
+ * either side isn't valid JSON. Pure (no IO) so it's unit-testable.
+ */
+export function mergeSecretsJson(existingRaw: string, seed: string): string {
+  if (!existingRaw.trim()) return seed;
+  try {
+    const existing = JSON.parse(existingRaw) as Record<string, unknown>;
+    const incoming = JSON.parse(seed) as Record<string, unknown>;
+    return JSON.stringify({ ...existing, ...incoming }, null, 2) + "\n";
+  } catch {
+    return seed;
+  }
+}
+
 /** Default Docker network children attach to when none is configured. */
 const DEFAULT_NETWORK_NAME = "gaia-net";
 /**
@@ -286,14 +304,52 @@ export class DockerManager {
 
     // Write each file using a one-shot container with stdin piped via spawn
     for (const file of files) {
+      // secrets.json is owned partly by the operator (seeded bindings from
+      // Gaia's vault) and partly by the running habitat (per-user
+      // `TOKEN:<sub>` entries and single-use refresh tokens it rotates at
+      // runtime). A blind overwrite on rebuild would wipe the habitat-owned
+      // keys — which silently breaks per-user auth (e.g. Twitter) after every
+      // rebuild. Merge instead: keep existing keys the seed doesn't manage,
+      // let seeded keys update.
+      let content = file.content;
+      if (file.path === "secrets.json") {
+        content = await this.mergeSecretsSeed(volume, file.content);
+      }
       await spawnWithStdin("docker", [
         "run", "--rm", "-i",
         "-v", `${volume}:/data`,
         "alpine:3.20",
         "sh", "-c",
         `mkdir -p "$(dirname "/data/${file.path}")" && cat > "/data/${file.path}"`,
-      ], file.content);
+      ], content);
     }
+  }
+
+  /**
+   * Merge a freshly-built secrets.json seed with whatever the volume already
+   * holds, so habitat-rotated / per-user secrets survive a re-seed. Seeded
+   * (operator) keys win on conflict; existing-only keys are preserved. Falls
+   * back to the raw seed if either side isn't valid JSON (first-time seed,
+   * corruption).
+   */
+  private async mergeSecretsSeed(
+    volume: string,
+    seed: string,
+  ): Promise<string> {
+    let existingRaw = "";
+    try {
+      const { stdout } = await execFile("docker", [
+        "run", "--rm",
+        "-v", `${volume}:/data`,
+        "alpine:3.20",
+        "sh", "-c",
+        "cat /data/secrets.json 2>/dev/null || true",
+      ]);
+      existingRaw = stdout;
+    } catch {
+      /* volume may be empty / file absent — treat as no existing secrets */
+    }
+    return mergeSecretsJson(existingRaw, seed);
   }
 
   /** Stop and remove a container (volume is preserved). */


### PR DESCRIPTION
**Bug:** `rebuild_habitat` → `seedVolume` wrote `secrets.json` with `cat >` (truncate), overwriting the persistent volume's file with only the operator vault seed — wiping habitat-owned keys: per-user `TOKEN:<sub>` entries and the single-use refresh tokens the habitat rotates at runtime. So per-user auth (Twitter bookmarks) broke after every rebuild (`needs_reauth`).

**Fix:** `seedVolume` now merges — reads the existing `secrets.json` and applies the seed on top (operator keys win on conflict; existing-only keys preserved). Pure `mergeSecretsJson` + unit tests. The volume already persisted; this stops the re-seed stomping it.

Verified: 4/4 merge tests + 12/12 existing gaia-seed/docker tests, tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)