### PR TITLE
feat(card): declare requiredCredentials on the agent card (ADR 0004)

### DIFF
--- a/examples/twitter-habitat/config.json
+++ b/examples/twitter-habitat/config.json
@@ -4,5 +4,36 @@
   "defaultModel": "openai/gpt-4o-mini",
   "toolsDir": "tools",
   "stimulusFile": "STIMULUS.md",
-  "agents": []
+  "agents": [],
+  "requiredSecrets": [
+    {
+      "name": "TWITTER_CLIENT_ID",
+      "label": "X / Twitter Client ID",
+      "description": "OAuth 2.0 client ID from your X developer app (confidential client).",
+      "required": true,
+      "type": "secret"
+    },
+    {
+      "name": "TWITTER_CLIENT_SECRET",
+      "label": "X / Twitter Client Secret",
+      "description": "OAuth 2.0 client secret from your X developer app.",
+      "required": true,
+      "type": "secret"
+    },
+    {
+      "name": "TWITTER_REFRESH_TOKEN",
+      "label": "Connect your X account",
+      "description": "Authorize the app once; the refresh token is minted into the habitat — you never paste it.",
+      "required": true,
+      "type": "oauth",
+      "connectPath": "/connect/x"
+    },
+    {
+      "name": "OPENROUTER_API_KEY",
+      "label": "OpenRouter API key",
+      "description": "LLM provider key for this habitat.",
+      "required": true,
+      "type": "secret"
+    }
+  ]
 }

--- a/packages/habitat/src/a2a-handler.test.ts
+++ b/packages/habitat/src/a2a-handler.test.ts
@@ -438,3 +438,38 @@ describe("HabitatAgentExecutor — artifact URLs", () => {
 		);
 	});
 });
+
+describe("buildAgentCard — requiredCredentials (ADR 0004)", () => {
+	function hostWithSecrets(): AgentHost {
+		return {
+			getConfig: () => ({
+				name: "Twitter",
+				agents: [],
+				requiredSecrets: [
+					{ name: "TWITTER_CLIENT_ID", label: "X Client ID", required: true, type: "secret" },
+					{ name: "TWITTER_CLIENT_SECRET", required: true }, // no type → defaults to secret
+					{ name: "TWITTER_REFRESH_TOKEN", label: "Connect X", required: true, type: "oauth", connectPath: "/connect/x" },
+				],
+			}),
+			getStimulus: async () => ({ options: { role: "x agent" } }),
+			getWorkDir: () => "/tmp",
+		} as unknown as AgentHost;
+	}
+
+	it("emits requiredCredentials from config.requiredSecrets", async () => {
+		const card = await buildAgentCard({ baseUrl: "http://h", habitat: hostWithSecrets() });
+		const byName = Object.fromEntries(
+			(card.requiredCredentials ?? []).map((c) => [c.name, c]),
+		);
+		expect(byName.TWITTER_CLIENT_ID).toMatchObject({ label: "X Client ID", type: "secret", required: true });
+		// missing type defaults to "secret"; missing label defaults to name
+		expect(byName.TWITTER_CLIENT_SECRET).toMatchObject({ type: "secret", label: "TWITTER_CLIENT_SECRET" });
+		// oauth credential carries its connect path so the SaaS renders a Connect button
+		expect(byName.TWITTER_REFRESH_TOKEN).toMatchObject({ type: "oauth", connectPath: "/connect/x" });
+	});
+
+	it("omits requiredCredentials when the config declares none", async () => {
+		const card = await buildAgentCard({ baseUrl: "http://h", habitat: await makeHost() });
+		expect(card.requiredCredentials).toBeUndefined();
+	});
+});

--- a/packages/habitat/src/a2a-handler.ts
+++ b/packages/habitat/src/a2a-handler.ts
@@ -71,9 +71,28 @@ export interface AgentCardOptions {
   jwtMode?: boolean;
 }
 
+/**
+ * A credential the agent needs to function, advertised on its card so an
+ * attaching client can collect it (ADR 0004). `secret` → a form field; `oauth`
+ * → a "Connect" button driving the agent's own OAuth at `connectPath`.
+ */
+export interface RequiredCredential {
+  name: string;
+  label: string;
+  description?: string;
+  required: boolean;
+  type: "secret" | "oauth";
+  connectPath?: string;
+}
+
+/** An A2A AgentCard plus our `requiredCredentials` extension. */
+export type HabitatAgentCard = AgentCard & {
+  requiredCredentials?: RequiredCredential[];
+};
+
 export async function buildAgentCard(
   options: AgentCardOptions,
-): Promise<AgentCard> {
+): Promise<HabitatAgentCard> {
   const { baseUrl, habitat } = options;
   const config = habitat.getConfig();
   const stimulus = await habitat.getStimulus();
@@ -96,7 +115,22 @@ export async function buildAgentCard(
     },
   ];
 
+  // Declare the app credentials this agent needs to function (ADR 0004), so an
+  // attaching client (the habitats SaaS) can render a form / OAuth "Connect"
+  // instead of anyone hand-setting secrets. Sourced from config.requiredSecrets.
+  const requiredCredentials: RequiredCredential[] = (
+    config.requiredSecrets ?? []
+  ).map((s) => ({
+    name: s.name,
+    label: s.label ?? s.name,
+    description: s.description,
+    required: s.required,
+    type: s.type ?? "secret",
+    ...(s.connectPath ? { connectPath: s.connectPath } : {}),
+  }));
+
   return {
+    ...(requiredCredentials.length ? { requiredCredentials } : {}),
     name,
     description,
     url: `${baseUrl}/a2a`,

--- a/packages/habitat/src/types.ts
+++ b/packages/habitat/src/types.ts
@@ -91,6 +91,21 @@ export interface RequiredSecret {
 	name: string;
 	description?: string;
 	required: boolean;
+	/**
+	 * How a client (e.g. the habitats SaaS attach flow) should collect this
+	 * credential. "secret" → a text/password field the user fills in; "oauth"
+	 * → a "Connect" button that runs the agent's own OAuth at `connectPath`
+	 * (the user never pastes a token). Defaults to "secret".
+	 */
+	type?: "secret" | "oauth";
+	/**
+	 * For `type: "oauth"`: the relative path to the agent's own connect/OAuth
+	 * surface (e.g. "/connect/x"). The client opens it (with the per-user JWT)
+	 * to mint the token directly into the habitat.
+	 */
+	connectPath?: string;
+	/** Human-facing label for a form field (defaults to `name`). */
+	label?: string;
 }
 
 // ── Agent identity & scopes (Habitat Runtime spec, Phase 2) ──────────


### PR DESCRIPTION
**Why:** so attaching an agent in the habitats SaaS can render a credential form + OAuth "Connect" from the card — instead of anyone hand-setting secrets (curl/CLI). The card declared *how to auth to the agent* but never *what app credentials it needs*.

**This slice (umwelten):** `RequiredSecret` gains `type` (`secret`|`oauth`), `connectPath`, `label`. `buildAgentCard` emits a `requiredCredentials[]` block (`HabitatAgentCard = AgentCard & { requiredCredentials? }`) from `config.requiredSecrets`. The Twitter habitat declares CLIENT_ID/SECRET (secret), the X connection (oauth → `/connect/x`), OPENROUTER_API_KEY.

Next slices: SaaS parses `requiredCredentials` and renders the attach form (#9), then wires entered creds → habitat + OAuth (#10).

Tests added (assert emission, type/label defaults, oauth connectPath); tsc + eslint clean. Note: local vitest can't load this suite (sandbox missing the *declared* `@mcp-ui/server` dep); CI installs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)