### PR TITLE
feat(secrets): operator can set card-declared credentials via /api/secrets (ADR 0004)

### DIFF
--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -661,16 +661,26 @@ export async function startContainerServer(
 					const prefixes = parseSecretWritePrefixes(
 						process.env.HABITAT_SECRET_WRITE_PREFIXES,
 					);
-					if (prefixes.length === 0) {
+					// Operators may also set credentials the habitat declared it
+					// needs (config.requiredSecrets) — the SaaS attach form (ADR 0004).
+					const declaredNames = (habitat.getConfig().requiredSecrets ?? []).map(
+						(s) => s.name,
+					);
+					if (prefixes.length === 0 && declaredNames.length === 0) {
 						sendJson(res, { error: "Not found" }, 404);
 						return;
 					}
+					let isOperator = false;
 					if (authRequired) {
 						const user = await auth.authenticate(req);
 						if (!user) {
 							sendJson(res, { error: "Unauthorized" }, 401);
 							return;
 						}
+						// Shared-key (HABITAT_API_KEY) callers authenticate as the
+						// fixed 'bearer-user' sentinel; per-user JWTs carry a real sub.
+						// Only the operator may set declared app credentials.
+						isOperator = user.userId === "bearer-user";
 					}
 					let body: { name?: unknown; value?: unknown };
 					try {
@@ -688,14 +698,10 @@ export async function startContainerServer(
 						sendJson(res, { error: "name and non-empty value required" }, 400);
 						return;
 					}
-					if (!isSecretWriteAllowed(name, prefixes)) {
-						sendJson(
-							res,
-							{
-								error: `secret name not allowed (must match one of: ${prefixes.join(", ")})`,
-							},
-							403,
-						);
+					if (
+						!isSecretWriteAllowed(name, prefixes, { declaredNames, isOperator })
+					) {
+						sendJson(res, { error: "secret name not allowed" }, 403);
 						return;
 					}
 					await habitat.setSecret(name, value);

--- a/packages/habitat/src/web/secret-write.test.ts
+++ b/packages/habitat/src/web/secret-write.test.ts
@@ -39,3 +39,31 @@ describe("isSecretWriteAllowed", () => {
     expect(isSecretWriteAllowed("FOO:bar", ["TWITTER_REFRESH_TOKEN:", "FOO:"])).toBe(true);
   });
 });
+
+describe("isSecretWriteAllowed — operator-set declared credentials (ADR 0004)", () => {
+  const declaredNames = ["TWITTER_CLIENT_ID", "TWITTER_CLIENT_SECRET"];
+
+  it("lets the operator set a credential the habitat declared", () => {
+    expect(
+      isSecretWriteAllowed("TWITTER_CLIENT_ID", [], { declaredNames, isOperator: true }),
+    ).toBe(true);
+  });
+  it("denies a non-operator (per-user JWT) from setting a declared credential", () => {
+    expect(
+      isSecretWriteAllowed("TWITTER_CLIENT_ID", [], { declaredNames, isOperator: false }),
+    ).toBe(false);
+  });
+  it("denies an UNdeclared name even for the operator", () => {
+    expect(
+      isSecretWriteAllowed("HABITAT_API_KEY", [], { declaredNames, isOperator: true }),
+    ).toBe(false);
+  });
+  it("still allows per-user prefix writes regardless of operator status", () => {
+    expect(
+      isSecretWriteAllowed("TWITTER_REFRESH_TOKEN:u1", ["TWITTER_REFRESH_TOKEN:"], {
+        declaredNames,
+        isOperator: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/habitat/src/web/secret-write.ts
+++ b/packages/habitat/src/web/secret-write.ts
@@ -27,7 +27,22 @@ export function parseSecretWritePrefixes(raw: string | undefined): string[] {
  * True when `name` may be written: at least one prefix is configured, and the
  * name starts with a configured prefix and has a non-empty suffix after it.
  */
-export function isSecretWriteAllowed(name: string, prefixes: string[]): boolean {
-  if (prefixes.length === 0) return false;
-  return prefixes.some((p) => name.startsWith(p) && name.length > p.length);
+export function isSecretWriteAllowed(
+  name: string,
+  prefixes: string[],
+  opts: { declaredNames?: string[]; isOperator?: boolean } = {},
+): boolean {
+  // Per-user token delivery: any authed caller may write a prefixed name with a
+  // non-empty suffix (e.g. TWITTER_REFRESH_TOKEN:<sub>).
+  if (prefixes.some((p) => name.startsWith(p) && name.length > p.length)) {
+    return true;
+  }
+  // Operator setup (ADR 0004): the OPERATOR (shared-key auth) may set a
+  // credential the habitat declared it needs in config.requiredSecrets — e.g.
+  // TWITTER_CLIENT_ID/SECRET entered in the SaaS attach form. Gated to the
+  // operator so a per-user JWT can't overwrite app-level secrets.
+  if (opts.isOperator && (opts.declaredNames ?? []).includes(name)) {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
**Slice 3a.** Lets the SaaS attach form deliver the credentials a habitat declares in `config.requiredSecrets` (e.g. `TWITTER_CLIENT_ID/SECRET`) into the running habitat — safely.

`isSecretWriteAllowed` now also accepts an **exact-match** write of a **declared** name, but **only for the operator** (shared `HABITAT_API_KEY`, which authenticates as the fixed `bearer-user` sentinel). A per-user JWT still can't write app-level secrets (only its prefix-gated `TOKEN:<sub>`). The endpoint enables when the habitat declares `requiredSecrets` too.

Tests: operator-set allowed; non-operator denied; undeclared denied; per-user prefix unaffected. 11/11, tsc + eslint clean.

Next (Slice 3b): the SaaS attach action POSTs the entered creds here, and wires the OAuth Connect. (One open question: how the SaaS authenticates as operator to a JWT-only habitat — see chat.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)