### PR TITLE
feat(secrets): honor operator-claim JWT for declared-credential writes (ADR 0004)

### DIFF
--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -677,10 +677,12 @@ export async function startContainerServer(
 							sendJson(res, { error: "Unauthorized" }, 401);
 							return;
 						}
-						// Shared-key (HABITAT_API_KEY) callers authenticate as the
-						// fixed 'bearer-user' sentinel; per-user JWTs carry a real sub.
-						// Only the operator may set declared app credentials.
-						isOperator = user.userId === "bearer-user";
+						// Operator = the shared HABITAT_API_KEY (fixed 'bearer-user'
+						// sentinel) OR a JWT the SaaS minted with the `operator` claim
+						// for a habitat admin (ADR 0004). Only operators may set the
+						// credentials the habitat declares it needs.
+						isOperator =
+							user.userId === "bearer-user" || user.operator === true;
 					}
 					let body: { name?: unknown; value?: unknown };
 					try {

--- a/packages/habitat/src/web/auth/jwt-auth.test.ts
+++ b/packages/habitat/src/web/auth/jwt-auth.test.ts
@@ -27,11 +27,13 @@ function mint(opts: {
   iss?: string;
   expiresIn?: string; // jose duration, e.g. '5m' or '-1m'
   name?: string;
+  operator?: boolean;
   signer?: CryptoKey;
   alg?: string;
 } = {}): Promise<string> {
   const claims: Record<string, unknown> = {};
   if (opts.name) claims.name = opts.name;
+  if (opts.operator) claims.operator = true;
   let jwt = new SignJWT(claims)
     .setProtectedHeader({ alg: opts.alg ?? 'ES256' })
     .setIssuedAt()
@@ -70,6 +72,7 @@ describe('jwtAuth — valid tokens (pinned public key)', () => {
       displayName: 'Will',
       email: undefined,
       provider: 'oauth',
+      operator: false,
     });
   });
 
@@ -77,6 +80,14 @@ describe('jwtAuth — valid tokens (pinned public key)', () => {
     const provider = jwtAuth({ audience: AUD, publicKeyPem: spkiPem });
     const user = await provider.authenticate(bearer(await mint({ sub: 'u2' })));
     expect(user?.userId).toBe('u2');
+  });
+
+  it('surfaces the operator claim (ADR 0004)', async () => {
+    const provider = jwtAuth({ audience: AUD, issuer: ISS, publicKeyPem: spkiPem });
+    const op = await provider.authenticate(bearer(await mint({ sub: 'admin', operator: true })));
+    expect(op?.operator).toBe(true);
+    const reg = await provider.authenticate(bearer(await mint({ sub: 'user' })));
+    expect(reg?.operator).toBe(false);
   });
 });
 

--- a/packages/habitat/src/web/auth/jwt-auth.ts
+++ b/packages/habitat/src/web/auth/jwt-auth.ts
@@ -72,6 +72,12 @@ interface HabitatJwtPayload extends JWTPayload {
   email?: string;
   /** Optional org id (habitats is org-scoped). */
   org?: string;
+  /**
+   * Operator grant (ADR 0004): the issuer (habitats SaaS) asserts this caller
+   * is a habitat operator/admin and may set the credentials the habitat
+   * declares in config.requiredSecrets. Minted only for habitat mutators.
+   */
+  operator?: boolean;
 }
 
 /**
@@ -133,6 +139,7 @@ export function jwtAuth(opts: JwtAuthOptions): AuthProvider {
           displayName: claims.name,
           email: claims.email,
           provider: 'oauth',
+          operator: claims.operator === true,
         };
       } catch {
         // Invalid signature / aud / exp / alg → unauthenticated. The caller (the

--- a/packages/habitat/src/web/types.ts
+++ b/packages/habitat/src/web/types.ts
@@ -22,6 +22,12 @@ export interface UserContext {
   email?: string;
   /** How this user was authenticated. */
   provider?: 'dev' | 'google' | 'github' | 'oauth';
+  /**
+   * True when the caller is a habitat operator/admin — either the shared
+   * HABITAT_API_KEY, or a JWT carrying the `operator` claim (ADR 0004). Gates
+   * writing the credentials the habitat declares in config.requiredSecrets.
+   */
+  operator?: boolean;
 }
 
 /** Strategy for resolving a UserContext from a request. */


### PR DESCRIPTION
**Slice 3b (umwelten side).** Lets the SaaS deliver card-declared operator secrets to a **JWT-only** habitat with no shared key: it mints a per-user JWT with an `operator` claim for a habitat admin; `jwt-auth` surfaces it; the `/api/secrets` gate (3a) treats it as operator. Regular per-user JWTs still can't touch app secrets. Same JWKS the habitat already trusts for identity.

Tests: operator claim surfaced; 26 pass; tsc + eslint clean. Pairs with the SaaS minting + delivery (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)