### PR TITLE
fix(habitat): bind per-user JWT speaker in jwt+bearer mode (ADR 0003)

### DIFF
--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -576,13 +576,19 @@ export async function startContainerServer(
 							return;
 						}
 					}
-					// Per-user identity (ADR 0003 step 2): only the JWT path carries a
-					// real end-user `sub`. Bind it as the speaker so the executor uses
-					// it as interaction.userId. Bearer/dev have no per-user identity —
-					// leave the speaker unbound so the executor keeps its thread-scoped
-					// `a2a:${contextId}` fallback (no regression off the JWT path).
+					// Per-user identity (ADR 0003 step 2): bind the verified end-user
+					// `sub` as the speaker so the executor uses it as
+					// interaction.userId. This must fire in BOTH "jwt" and
+					// "jwt+bearer" modes — a JWT-capable habitat that also accepts the
+					// shared HABITAT_API_KEY during transition still carries a real
+					// per-user sub on the JWT path. The shared key resolves to the
+					// `bearer-user` sentinel (operator, no per-user identity) and
+					// dev/open leave `user` null; in those cases leave the speaker
+					// unbound so the executor keeps its thread-scoped
+					// `a2a:${contextId}` fallback. Never discard a verified per-user
+					// identity by silently falling back to anonymous.
 					const speaker =
-						authMode === "jwt" && user
+						user && user.userId !== "bearer-user"
 							? {
 									userId: user.userId,
 									displayName: user.displayName,


### PR DESCRIPTION
## Problem
A JWT-capable habitat that also accepts the shared `HABITAT_API_KEY` runs in `authMode: "jwt+bearer"`. The `/a2a` handler bound the verified end-user `sub` as the speaker only when `authMode === "jwt"` (strict), so in `jwt+bearer` it **verified the per-user JWT and then discarded the identity**, falling back to the anonymous `a2a:${contextId}` thread id.

Effect: per-user upstream tokens broke. The OAuth connect flow stored e.g. `TWITTER_REFRESH_TOKEN:<sub>` under the real `sub`, but chat arrived "anonymous", so the lookup missed and the agent reported "X account isn't connected" despite a successful OAuth.

## Fix
Bind the speaker for **any** verified per-user JWT (both `jwt` and `jwt+bearer`). Only the shared-key (`bearer-user`) and dev/open paths keep the thread-scoped fallback. A verified identity is never silently anonymized.

Mirrors the existing `jwtMode = authMode === "jwt" || authMode === "jwt+bearer"` treatment elsewhere in the server (the speaker-binding site was just missed).

Verified live: rebuilt the base + twitter-habitat images, redeployed, and the chat path now resolves the real `sub`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)