### PR TITLE
feat(twitter-habitat): declare DATABASE_URL secret for the feed tools

### DIFF
--- a/examples/twitter-habitat/config.json
+++ b/examples/twitter-habitat/config.json
@@ -34,6 +34,13 @@
       "description": "LLM provider key for this habitat.",
       "required": true,
       "type": "secret"
+    },
+    {
+      "name": "DATABASE_URL",
+      "label": "Feed database (Neon)",
+      "description": "Postgres/Neon connection string for the twitter-feed data. Powers the feed tools (high_engagement, person_recent, list_digest). Optional — bookmarks and mentions use your connected X account and don't need it.",
+      "required": false,
+      "type": "secret"
     }
   ]
 }


### PR DESCRIPTION
Adds `DATABASE_URL` to the Twitter habitat's `requiredSecrets` so the habitats SaaS attach form renders a field for it and an operator can deliver it (operator-write allowlist keys off `requiredSecrets`).

It's the Neon connection string the twitter-feed pipeline syncs; the feed tools (`high_engagement`, `person_recent`, `list_digest`) read it. Marked **optional** — `bookmarks`/`mentions` use the connected X account and don't need it, so a missing DB degrades those three tools gracefully instead of blocking attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)