### PR TITLE
Add remote-habitat agent support and A2A URL-based sender

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,7 @@ dotenvx run -- pnpm run cli mcp chat --url http://localhost:7430/mcp
 | `secretsToolSet`             | set/remove/list secrets                                                                            | Yes                    |
 | `searchToolSet`              | web search via Tavily                                                                              | Yes                    |
 | `selfModifyToolSet`          | create_tool, create_skill, reload, list, remove                                                    | Yes                    |
+| `remoteAgentToolSet`         | ask_remote_agent — A2A to peers declared with kind `remote-habitat` (registers nothing when none)  | Yes                    |
 
 `standardToolSets` includes all tool sets. All are registered by default.
 
@@ -241,6 +242,7 @@ dotenvx run -- pnpm run cli mcp chat --url http://localhost:7430/mcp
 - `search-tools.ts` — Web search via Tavily (needs `TAVILY_API_KEY`)
 - `secrets-tools.ts` — Manage secrets in the habitat store
 - `self-modify-tools.ts` — Create/remove tools and skills at runtime
+- `remote-agent-tools.ts` — `ask_remote_agent`: A2A `message/send` to remote habitats declared in `config.agents[]` (kind `remote-habitat`, URL/token via `a2aUrl`/`a2aUrlSecret`/`a2aTokenSecret`)
 
 #### `src/habitat/gaia/` — Gaia Orchestrator
 

--- a/examples/help-habitat/README.md
+++ b/examples/help-habitat/README.md
@@ -1,0 +1,22 @@
+# Help habitat
+
+The conversational **@Help** agent for [Habitats](https://habitats.thefocus.ai):
+a docs-grounded product guide users can mention in any room. Its persona and
+product knowledge live in `STIMULUS.md`; it runs on the base habitat image, so
+deployment is just seeding `config.json` + `STIMULUS.md` onto the container
+volume (Gaia binds `OPENROUTER_API_KEY`).
+
+## Talking to Gaia
+
+Help can optionally answer **live operational questions** ("which agents are
+running?", "is the Twitter agent up?") by delegating to the Gaia orchestrator
+over A2A. `config.json` declares Gaia as a `remote-habitat` agent, which
+activates the runtime's `ask_remote_agent` tool:
+
+| Secret | Purpose |
+| --- | --- |
+| `GAIA_A2A_URL` | Base URL of Gaia's A2A endpoint (e.g. `https://gaia.habitats.example.com`, or `http://172.17.0.1:7420` when the container can reach the host directly). |
+| `GAIA_A2A_TOKEN` | Bearer token for Gaia's `/a2a` (its `HABITAT_API_KEY`). Omit if Gaia runs open. |
+
+Both secrets are optional — without them Help simply answers from its built-in
+product knowledge and points users at their operator for live status.

--- a/examples/help-habitat/STIMULUS.md
+++ b/examples/help-habitat/STIMULUS.md
@@ -54,6 +54,27 @@ agents **declare what they need**, and you grant it from the **Configure** panel
 which are connected, **Authorize** your own accounts, and enter any credentials
 an agent declares.
 
+## Asking Gaia (live status)
+
+You may have an `ask_remote_agent` tool with a remote agent called **gaia** —
+Gaia is the orchestrator that runs and monitors the agent containers behind
+this deployment. Use it when a question needs **live operational facts** you
+don't have, such as:
+
+- "Which agents are available / running right now?"
+- "Is the Twitter agent up? Why isn't it responding?"
+- "What's the status of <some habitat>?"
+
+Send Gaia a short, specific question (e.g. `ask_remote_agent` with agentId
+`gaia` and message "List the managed habitats and their container status") and
+translate its answer into plain user-facing language — users don't know or care
+about containers, ports, or Docker. Never expose tokens, URLs, or raw error
+dumps from Gaia's reply.
+
+If the tool is missing, not configured, or the call fails, just answer from
+what you know and suggest the user ask their habitat's operator — don't
+speculate about live status you can't see.
+
 ## Common questions, and how to answer them
 
 - **"How do I talk to an agent?"** → Make sure it's attached (Configure → Attach),

--- a/examples/help-habitat/config.json
+++ b/examples/help-habitat/config.json
@@ -3,13 +3,36 @@
   "defaultProvider": "openrouter",
   "defaultModel": "anthropic/claude-sonnet-4.6",
   "stimulusFile": "STIMULUS.md",
-  "agents": [],
+  "agents": [
+    {
+      "id": "gaia",
+      "name": "Gaia",
+      "kind": "remote-habitat",
+      "projectPath": "agents/gaia",
+      "a2aUrlSecret": "GAIA_A2A_URL",
+      "a2aTokenSecret": "GAIA_A2A_TOKEN"
+    }
+  ],
   "requiredSecrets": [
     {
       "name": "OPENROUTER_API_KEY",
       "label": "OpenRouter API key",
       "description": "LLM provider key for this habitat.",
       "required": true,
+      "type": "secret"
+    },
+    {
+      "name": "GAIA_A2A_URL",
+      "label": "Gaia A2A URL",
+      "description": "Base URL of the Gaia orchestrator's A2A endpoint (e.g. https://gaia.habitats.example.com). Optional — without it Help answers from its built-in product knowledge only.",
+      "required": false,
+      "type": "secret"
+    },
+    {
+      "name": "GAIA_A2A_TOKEN",
+      "label": "Gaia A2A token",
+      "description": "Bearer token for Gaia's /a2a endpoint (its HABITAT_API_KEY). Optional if Gaia runs open.",
+      "required": false,
       "type": "secret"
     }
   ]

--- a/packages/habitat/src/index.ts
+++ b/packages/habitat/src/index.ts
@@ -87,6 +87,7 @@ export {
 	provisionToolSet,
 	execToolSet,
 	artifactToolSet,
+	remoteAgentToolSet,
 } from "./tool-sets.js";
 
 // ── Session management ──────────────────────────────────────────────────

--- a/packages/habitat/src/tool-sets.ts
+++ b/packages/habitat/src/tool-sets.ts
@@ -14,6 +14,7 @@ import { createSecretsTools } from "./tools/secrets-tools.js";
 import { createSearchTools } from "./tools/search-tools.js";
 import { createSelfModifyTools } from "./tools/self-modify-tools.js";
 import { createInspectTools } from "./tools/inspect-tools.js";
+import { createRemoteAgentTools } from "./tools/remote-agent-tools.js";
 import {
   wgetTool,
   markifyTool,
@@ -180,6 +181,21 @@ export const uiResourceToolSet: ToolSet = {
     }),
 };
 
+/**
+ * Remote habitats: ask_remote_agent — A2A message/send to peers declared in
+ * config.agents[] with kind "remote-habitat" (e.g. the Gaia orchestrator).
+ * Registers no tools when the habitat declares no remote peers.
+ */
+export const remoteAgentToolSet: ToolSet = {
+  name: "remote-agents",
+  description: "Talk to remote habitats (A2A) declared in this habitat's config",
+  createTools: (habitat) =>
+    createRemoteAgentTools({
+      getConfig: () => habitat.getConfig(),
+      getSecret: (name) => habitat.getSecret(name),
+    }),
+};
+
 /** Self-modification: create/remove/reload tools and skills at runtime. */
 export const selfModifyToolSet: ToolSet = {
   name: "self-modify",
@@ -213,6 +229,7 @@ export const standardToolSets: ToolSet[] = [
   searchToolSet,
   selfModifyToolSet,
   inspectToolSet,
+  remoteAgentToolSet,
 ];
 
 /**
@@ -230,6 +247,7 @@ export const containerToolSets: ToolSet[] = [
   artifactToolSet,
   uiResourceToolSet,
   inspectToolSet,
+  remoteAgentToolSet,
 ];
 
 /**
@@ -247,4 +265,5 @@ export const managedContainerToolSets: ToolSet[] = [
   artifactToolSet,
   uiResourceToolSet,
   inspectToolSet,
+  remoteAgentToolSet,
 ];

--- a/packages/habitat/src/tools/gaia/docker.port.test.ts
+++ b/packages/habitat/src/tools/gaia/docker.port.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for host-port selection (pickHostPort).
+ *
+ * The regression that motivated these: a rebuild counted the entry's OWN
+ * registry-recorded port as "in use", so every rebuild hopped to the next
+ * port — breaking anything pinned to the old one and slowly exhausting the
+ * 7440–7499 range.
+ */
+
+import { describe, it, expect } from "vitest";
+import { pickHostPort } from "./docker.js";
+import type { GaiaHabitatEntry } from "./types.js";
+
+function entry(id: string, containerPort?: number): GaiaHabitatEntry {
+	return { id, containerPort } as GaiaHabitatEntry;
+}
+
+describe("pickHostPort", () => {
+	it("starts at 7440 when nothing is allocated", () => {
+		expect(pickHostPort([])).toBe(7440);
+	});
+
+	it("skips ports held by other entries", () => {
+		expect(pickHostPort([entry("a", 7440), entry("b", 7441)])).toBe(7442);
+	});
+
+	it("a rebuild reuses the entry's own recorded port", () => {
+		const self = entry("a", 7443);
+		expect(pickHostPort([self, entry("b", 7440)], self)).toBe(7443);
+	});
+
+	it("does not treat the self port as taken even at range start", () => {
+		const self = entry("a", 7440);
+		expect(pickHostPort([self], self)).toBe(7440);
+	});
+
+	it("falls back to the next free port when the recorded port is now held by another entry", () => {
+		const self = entry("a", 7440);
+		// Registry drift: another entry got recorded on the same port.
+		expect(pickHostPort([entry("b", 7440), self], self)).toBe(7441);
+	});
+
+	it("ignores an out-of-range recorded port", () => {
+		const self = entry("a", 9999);
+		expect(pickHostPort([self], self)).toBe(7440);
+	});
+
+	it("throws when the whole range is exhausted by other entries", () => {
+		const others = Array.from({ length: 60 }, (_, i) =>
+			entry(`e${i}`, 7440 + i),
+		);
+		expect(() => pickHostPort(others)).toThrow(/No available ports/);
+	});
+});

--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -108,6 +108,40 @@ function volumeName(id: string): string {
 }
 
 /**
+ * Choose the host port for a habitat container (pure; exported for tests).
+ *
+ * Ports recorded by OTHER entries are taken. The entry's own recorded port is
+ * explicitly free — a restart/rebuild reclaims it, so the habitat stays at a
+ * stable address instead of hopping ports on every rebuild (which broke
+ * anything pinned to the old port and leaked the 7440–7499 range dry).
+ */
+export function pickHostPort(
+  entries: GaiaHabitatEntry[],
+  self?: Pick<GaiaHabitatEntry, "id" | "containerPort">,
+): number {
+  const usedPorts = new Set(
+    entries
+      .filter((e) => e.containerPort && e.id !== self?.id)
+      .map((e) => e.containerPort!),
+  );
+  const preferred = self?.containerPort;
+  if (
+    preferred &&
+    preferred >= HABITAT_PORT_BASE &&
+    preferred <= HABITAT_PORT_MAX &&
+    !usedPorts.has(preferred)
+  ) {
+    return preferred;
+  }
+  for (let port = HABITAT_PORT_BASE; port <= HABITAT_PORT_MAX; port++) {
+    if (!usedPorts.has(port)) return port;
+  }
+  throw new Error(
+    `No available ports in range ${HABITAT_PORT_BASE}–${HABITAT_PORT_MAX}`,
+  );
+}
+
+/**
  * Public hostname a habitat is served at via the Caddy label proxy (#170).
  * Explicit `entry.hostname` wins; otherwise derive `<id>.$GAIA_BASE_DOMAIN`.
  * Returns undefined when neither is set — no Caddy label is emitted (local dev).
@@ -151,16 +185,11 @@ export class DockerManager {
    * Find the next available port in the 7440–7499 range.
    * Checks which ports are already bound by running containers.
    */
-  private async findAvailablePort(entries: GaiaHabitatEntry[]): Promise<number> {
-    const usedPorts = new Set(
-      entries
-        .filter((e) => e.containerPort)
-        .map((e) => e.containerPort!),
-    );
-    for (let port = HABITAT_PORT_BASE; port <= HABITAT_PORT_MAX; port++) {
-      if (!usedPorts.has(port)) return port;
-    }
-    throw new Error(`No available ports in range ${HABITAT_PORT_BASE}–${HABITAT_PORT_MAX}`);
+  private async findAvailablePort(
+    entries: GaiaHabitatEntry[],
+    self?: Pick<GaiaHabitatEntry, "id" | "containerPort">,
+  ): Promise<number> {
+    return pickHostPort(entries, self);
   }
 
   /**
@@ -200,8 +229,10 @@ export class DockerManager {
     // Stop + remove if already exists
     await this.stopContainer(entry.id).catch(() => {});
 
-    // Pick a port
-    const hostPort = await this.findAvailablePort(allEntries ?? []);
+    // Pick a port — a restart/rebuild keeps the entry's existing port (its own
+    // registry record must not count as "in use", or every rebuild would hop
+    // to the next port and eventually exhaust the 7440–7499 range).
+    const hostPort = await this.findAvailablePort(allEntries ?? [], entry);
 
     // Session egress (#119): the sessions subdir lives on the host so it
     // survives volume lifecycle and is readable by host-side introspection.

--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -384,7 +384,10 @@ export function createHabitatLifecycleTools(
 		}),
 
 		rebuild_habitat: tool({
-			description: "Rebuild a habitat (stop + start with fresh image).",
+			description:
+				"Restart a habitat: stop, re-seed config/secrets onto its volume, start. " +
+				"Runs the image the habitat already uses — it does NOT rebuild any Docker image; " +
+				"run build_image first to pick up new code.",
 			inputSchema: z.object({
 				id: z.string().describe("Habitat ID to rebuild"),
 			}),

--- a/packages/habitat/src/tools/remote-agent-tools.test.ts
+++ b/packages/habitat/src/tools/remote-agent-tools.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for remote-agent tools (kind: "remote-habitat" → ask_remote_agent).
+ *
+ * Covers: registration gating (no remote peers → no tool), endpoint/token
+ * resolution from entry vs secrets, lookup by id and name, and the structured
+ * error shapes the model is expected to relay.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { createRemoteAgentTools } from "./remote-agent-tools.js";
+import type { HabitatConfig } from "../types.js";
+
+const gaiaEntry = {
+	id: "gaia",
+	name: "Gaia",
+	projectPath: "agents/gaia",
+	kind: "remote-habitat" as const,
+	a2aUrlSecret: "GAIA_A2A_URL",
+	a2aTokenSecret: "GAIA_A2A_TOKEN",
+};
+
+function makeCtx(opts: {
+	agents?: HabitatConfig["agents"];
+	secrets?: Record<string, string>;
+	send?: any;
+}) {
+	return {
+		getConfig: () => ({ agents: opts.agents ?? [] }) as HabitatConfig,
+		getSecret: (name: string) => opts.secrets?.[name],
+		send: opts.send,
+	};
+}
+
+async function callAsk(tools: Record<string, any>, input: unknown) {
+	return tools.ask_remote_agent.execute(input, {} as any);
+}
+
+describe("createRemoteAgentTools", () => {
+	it("registers no tools when the config declares no remote-habitat agents", () => {
+		expect(createRemoteAgentTools(makeCtx({}))).toEqual({});
+		// repo-kind agents don't count
+		expect(
+			createRemoteAgentTools(
+				makeCtx({
+					agents: [{ id: "proj", name: "Proj", projectPath: "agents/proj" }],
+				}),
+			),
+		).toEqual({});
+	});
+
+	it("mentions declared remote agents in the tool description", () => {
+		const tools = createRemoteAgentTools(makeCtx({ agents: [gaiaEntry] }));
+		expect(tools.ask_remote_agent).toBeDefined();
+		expect((tools.ask_remote_agent as any).description).toContain("gaia");
+	});
+
+	it("sends via the resolved secret URL + token and returns the reply", async () => {
+		const send = vi.fn().mockResolvedValue({ text: "3 habitats running" });
+		const tools = createRemoteAgentTools(
+			makeCtx({
+				agents: [gaiaEntry],
+				secrets: {
+					GAIA_A2A_URL: "https://gaia.example.com",
+					GAIA_A2A_TOKEN: "tok-123",
+				},
+				send,
+			}),
+		);
+		const out = await callAsk(tools, {
+			agentId: "gaia",
+			message: "what's running?",
+		});
+		expect(send).toHaveBeenCalledWith({
+			endpoint: "https://gaia.example.com",
+			text: "what's running?",
+			apiKey: "tok-123",
+		});
+		expect(out).toEqual({ agentId: "gaia", response: "3 habitats running" });
+	});
+
+	it("resolves by display name (case-insensitive) and inline a2aUrl", async () => {
+		const send = vi.fn().mockResolvedValue({ text: "ok" });
+		const tools = createRemoteAgentTools(
+			makeCtx({
+				agents: [{ ...gaiaEntry, a2aUrlSecret: undefined, a2aUrl: "http://172.17.0.1:7420" }],
+				send,
+			}),
+		);
+		const out = await callAsk(tools, { agentId: "GAIA", message: "hi" });
+		expect(send).toHaveBeenCalledWith({
+			endpoint: "http://172.17.0.1:7420",
+			text: "hi",
+			apiKey: undefined,
+		});
+		expect(out.agentId).toBe("gaia");
+	});
+
+	it("returns REMOTE_AGENT_NOT_FOUND with the declared list", async () => {
+		const tools = createRemoteAgentTools(makeCtx({ agents: [gaiaEntry] }));
+		const out = await callAsk(tools, { agentId: "nope", message: "hi" });
+		expect(out.error).toBe("REMOTE_AGENT_NOT_FOUND");
+		expect(out.message).toContain("gaia");
+	});
+
+	it("returns REMOTE_AGENT_NOT_CONFIGURED when the URL secret is unset", async () => {
+		const send = vi.fn();
+		const tools = createRemoteAgentTools(
+			makeCtx({ agents: [gaiaEntry], send }),
+		);
+		const out = await callAsk(tools, { agentId: "gaia", message: "hi" });
+		expect(out.error).toBe("REMOTE_AGENT_NOT_CONFIGURED");
+		expect(out.message).toContain("GAIA_A2A_URL");
+		expect(send).not.toHaveBeenCalled();
+	});
+
+	it("wraps transport failures as REMOTE_AGENT_ASK_FAILED", async () => {
+		const send = vi.fn().mockRejectedValue(new Error("HTTP 401"));
+		const tools = createRemoteAgentTools(
+			makeCtx({
+				agents: [{ ...gaiaEntry, a2aUrl: "https://gaia.example.com" }],
+				send,
+			}),
+		);
+		const out = await callAsk(tools, { agentId: "gaia", message: "hi" });
+		expect(out).toEqual({
+			error: "REMOTE_AGENT_ASK_FAILED",
+			message: "HTTP 401",
+		});
+	});
+
+	it("passes artifacts through when the remote reply includes them", async () => {
+		const send = vi.fn().mockResolvedValue({
+			text: "report ready",
+			artifacts: [{ name: "report.html", uri: "https://gaia.example.com/files/r.html" }],
+		});
+		const tools = createRemoteAgentTools(
+			makeCtx({
+				agents: [{ ...gaiaEntry, a2aUrl: "https://gaia.example.com" }],
+				send,
+			}),
+		);
+		const out = await callAsk(tools, { agentId: "gaia", message: "report" });
+		expect(out.artifacts).toHaveLength(1);
+	});
+});

--- a/packages/habitat/src/tools/remote-agent-tools.ts
+++ b/packages/habitat/src/tools/remote-agent-tools.ts
@@ -1,0 +1,140 @@
+/**
+ * Remote-habitat tools: talk to other habitats over A2A.
+ *
+ * Implements the tool side of the `remote-habitat` agent kind (see
+ * `types.ts` — "a pointer to another habitat reachable via A2A"). A habitat
+ * declares remote peers in `config.agents[]`:
+ *
+ *   {
+ *     "id": "gaia",
+ *     "name": "Gaia",
+ *     "kind": "remote-habitat",
+ *     "projectPath": "agents/gaia",
+ *     "a2aUrlSecret": "GAIA_A2A_URL",
+ *     "a2aTokenSecret": "GAIA_A2A_TOKEN"
+ *   }
+ *
+ * and the `ask_remote_agent` tool sends one-shot A2A `message/send` calls to
+ * them. Endpoint + token resolve from the entry itself (`a2aUrl`) or from
+ * habitat secrets/env (`a2aUrlSecret` / `a2aTokenSecret`), so example configs
+ * stay deployment-agnostic. Entries without a resolvable URL surface a
+ * structured error instead of failing silently.
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+import type { Tool } from "ai";
+import { sendA2AMessageToUrl } from "@umwelten/protocols";
+import type { A2AMessageResponse } from "@umwelten/protocols";
+import type { AgentEntry, HabitatConfig } from "../types.js";
+
+/** Narrow habitat surface so tests don't need a full Habitat. */
+export interface RemoteAgentToolsContext {
+	getConfig(): HabitatConfig;
+	getSecret(name: string): string | undefined;
+	/** Injectable A2A sender (tests). Defaults to sendA2AMessageToUrl. */
+	send?: typeof sendA2AMessageToUrl;
+}
+
+function remoteEntries(config: HabitatConfig): AgentEntry[] {
+	return (config.agents ?? []).filter((a) => a.kind === "remote-habitat");
+}
+
+function findRemoteEntry(
+	config: HabitatConfig,
+	agentId: string,
+): AgentEntry | undefined {
+	const needle = agentId.trim().toLowerCase();
+	return remoteEntries(config).find(
+		(a) =>
+			a.id.toLowerCase() === needle || a.name?.toLowerCase() === needle,
+	);
+}
+
+function resolveEndpoint(
+	entry: AgentEntry,
+	getSecret: (name: string) => string | undefined,
+): string | undefined {
+	const url =
+		entry.a2aUrl?.trim() ||
+		(entry.a2aUrlSecret ? getSecret(entry.a2aUrlSecret)?.trim() : undefined);
+	return url || undefined;
+}
+
+export function createRemoteAgentTools(
+	ctx: RemoteAgentToolsContext,
+): Record<string, Tool> {
+	const send = ctx.send ?? sendA2AMessageToUrl;
+	const declared = remoteEntries(ctx.getConfig())
+		.map((a) => a.id)
+		.join(", ");
+
+	// No remote peers declared → no tool. Config changes that add one land via
+	// re-seed + restart, so a creation-time decision is safe.
+	if (!declared) return {};
+
+	const ask_remote_agent = tool({
+		description:
+			"Send a message to a remote agent (another habitat reachable over A2A) and return its reply. " +
+			"Use this to delegate questions the remote agent can answer better — e.g. ask an orchestrator " +
+			"about the live status of managed agents. " +
+			`Remote agents declared for this habitat: ${declared}.`,
+		inputSchema: z.object({
+			agentId: z
+				.string()
+				.describe("ID or name of the remote agent (from this habitat's config)"),
+			message: z
+				.string()
+				.describe("Message to send to the remote agent (question, task, etc.)"),
+		}),
+		execute: async ({ agentId, message }) => {
+			const config = ctx.getConfig();
+			const entry = findRemoteEntry(config, agentId);
+			if (!entry) {
+				const available = remoteEntries(config).map((a) => a.id);
+				return {
+					error: "REMOTE_AGENT_NOT_FOUND",
+					message: available.length
+						? `No remote agent "${agentId}". Declared remote agents: ${available.join(", ")}`
+						: `No remote agent "${agentId}" — this habitat declares no remote-habitat agents.`,
+				};
+			}
+
+			const endpoint = resolveEndpoint(entry, (n) => ctx.getSecret(n));
+			if (!endpoint) {
+				return {
+					error: "REMOTE_AGENT_NOT_CONFIGURED",
+					message:
+						`Remote agent "${entry.id}" has no reachable URL. ` +
+						(entry.a2aUrlSecret
+							? `Set the "${entry.a2aUrlSecret}" secret to its base URL.`
+							: `Set "a2aUrl" (or "a2aUrlSecret") on its config entry.`),
+				};
+			}
+
+			const apiKey = entry.a2aTokenSecret
+				? ctx.getSecret(entry.a2aTokenSecret)
+				: undefined;
+
+			try {
+				const response: A2AMessageResponse = await send({
+					endpoint,
+					text: message,
+					apiKey,
+				});
+				return {
+					agentId: entry.id,
+					response: response.text,
+					...(response.artifacts ? { artifacts: response.artifacts } : {}),
+				};
+			} catch (err) {
+				return {
+					error: "REMOTE_AGENT_ASK_FAILED",
+					message: err instanceof Error ? err.message : String(err),
+				};
+			}
+		},
+	});
+
+	return { ask_remote_agent };
+}

--- a/packages/habitat/src/types.ts
+++ b/packages/habitat/src/types.ts
@@ -267,6 +267,22 @@ export interface AgentEntry {
 	/** What this agent is. Defaults to "repo". */
 	kind?: AgentKind;
 	/**
+	 * `remote-habitat` only: base URL (or full `/a2a` endpoint) of the remote
+	 * agent, e.g. `https://gaia.habitats.example.com` or `http://172.17.0.1:7420`.
+	 * Prefer {@link a2aUrlSecret} when the URL differs per deployment.
+	 */
+	a2aUrl?: string;
+	/**
+	 * `remote-habitat` only: name of a habitat secret (or env var) holding the
+	 * remote agent's base URL. Checked when {@link a2aUrl} is unset.
+	 */
+	a2aUrlSecret?: string;
+	/**
+	 * `remote-habitat` only: name of a habitat secret (or env var) holding the
+	 * Bearer token for the remote agent's `/a2a` endpoint. Omit for open agents.
+	 */
+	a2aTokenSecret?: string;
+	/**
 	 * Read/write mode. Policy-enforced (not kernel-enforced).
 	 * `read` blocks write_file/exec into this agent's repo and forces read-only
 	 * Claude Code tool subsets.

--- a/packages/protocols/src/a2a/client.test.ts
+++ b/packages/protocols/src/a2a/client.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for the URL-based A2A sender and the shared payload decoder.
+ * (The host:port sender is exercised by integration tests against real
+ * containers; here we cover the pure/fetch-backed paths.)
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { decodeA2ASendPayload, sendA2AMessageToUrl } from "./client.js";
+
+const ORIGIN = "https://gaia.example.com";
+
+function messageResult(text: string) {
+	return {
+		jsonrpc: "2.0",
+		id: "1",
+		result: { kind: "message", parts: [{ kind: "text", text }] },
+	};
+}
+
+describe("decodeA2ASendPayload", () => {
+	it("decodes a Message-shaped result", () => {
+		expect(decodeA2ASendPayload(messageResult("hello"), ORIGIN).text).toBe(
+			"hello",
+		);
+	});
+
+	it("decodes a Task-shaped result (status.message.parts)", () => {
+		const parsed = {
+			result: {
+				status: { message: { parts: [{ kind: "text", text: "done" }] } },
+			},
+		};
+		expect(decodeA2ASendPayload(parsed, ORIGIN).text).toBe("done");
+	});
+
+	it("resolves relative artifact URIs against the origin", () => {
+		const parsed = {
+			result: {
+				parts: [{ kind: "text", text: "t" }],
+				artifacts: [
+					{ name: "r.html", parts: [{ file: { uri: "/files/r.html" } }] },
+				],
+			},
+		};
+		const out = decodeA2ASendPayload(parsed, ORIGIN);
+		expect(out.artifacts?.[0].uri).toBe(`${ORIGIN}/files/r.html`);
+	});
+
+	it("throws on a JSON-RPC error payload", () => {
+		expect(() =>
+			decodeA2ASendPayload({ error: { message: "unauthorized" } }, ORIGIN),
+		).toThrow("unauthorized");
+	});
+});
+
+describe("sendA2AMessageToUrl", () => {
+	afterEach(() => vi.unstubAllGlobals());
+
+	function stubFetch(status: number, body: unknown) {
+		const fetchMock = vi.fn().mockResolvedValue({
+			status,
+			text: async () =>
+				typeof body === "string" ? body : JSON.stringify(body),
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		return fetchMock;
+	}
+
+	it("appends /a2a to a bare origin and sends the bearer token", async () => {
+		const fetchMock = stubFetch(200, messageResult("pong"));
+		const out = await sendA2AMessageToUrl({
+			endpoint: "https://gaia.example.com",
+			text: "ping",
+			apiKey: "tok",
+		});
+		expect(out.text).toBe("pong");
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe("https://gaia.example.com/a2a");
+		expect(init.headers.authorization).toBe("Bearer tok");
+		const rpc = JSON.parse(init.body);
+		expect(rpc.method).toBe("message/send");
+		expect(rpc.params.message.parts[0].text).toBe("ping");
+	});
+
+	it("keeps an explicit /a2a path (no double append)", async () => {
+		const fetchMock = stubFetch(200, messageResult("ok"));
+		await sendA2AMessageToUrl({ endpoint: "http://172.17.0.1:7420/a2a", text: "x" });
+		expect(fetchMock.mock.calls[0][0]).toBe("http://172.17.0.1:7420/a2a");
+	});
+
+	it("throws on HTTP error status with the body excerpt", async () => {
+		stubFetch(401, "nope");
+		await expect(
+			sendA2AMessageToUrl({ endpoint: "https://gaia.example.com", text: "x" }),
+		).rejects.toThrow(/HTTP 401/);
+	});
+
+	it("throws on invalid JSON", async () => {
+		stubFetch(200, "<html>not json</html>");
+		await expect(
+			sendA2AMessageToUrl({ endpoint: "https://gaia.example.com", text: "x" }),
+		).rejects.toThrow(/Invalid A2A response/);
+	});
+});

--- a/packages/protocols/src/a2a/client.ts
+++ b/packages/protocols/src/a2a/client.ts
@@ -58,6 +58,129 @@ const DEFAULT_HOST = "127.0.0.1";
 const AGENT_CARD_TIMEOUT_MS = 5_000;
 const MESSAGE_TIMEOUT_MS = 120_000;
 
+/**
+ * Decode the JSON-RPC payload of a `message/send` response into an
+ * {@link A2AMessageResponse}. Shared by the host:port and full-URL senders.
+ *
+ * The result can be a Message (with .parts directly) or a Task (with
+ * .status.message.parts). Tolerate both shapes. Relative `/files/...`
+ * artifact URIs are resolved against `origin` (#194).
+ */
+export function decodeA2ASendPayload(
+  parsed: any,
+  origin: string,
+): A2AMessageResponse {
+  if (parsed.error) {
+    const errMsg = parsed.error.message ?? JSON.stringify(parsed.error);
+    throw new Error(errMsg);
+  }
+  const result = parsed.result ?? parsed;
+  const parts =
+    result?.parts ??
+    result?.status?.message?.parts ??
+    result?.message?.parts ??
+    [];
+  const textParts = parts
+    .filter((p: any) => p.kind === "text" || p.type === "text")
+    .map((p: any) => p.text);
+  const resolveUri = (uri: string | undefined): string | undefined => {
+    if (!uri) return uri;
+    try {
+      return new URL(uri, origin).toString();
+    } catch {
+      return uri;
+    }
+  };
+  const artifacts = (result?.artifacts ?? []).map((a: any) => ({
+    name: a.name,
+    uri: resolveUri(a.parts?.[0]?.file?.uri),
+  }));
+  return {
+    text: textParts.join("\n") || "(no text response)",
+    artifacts: artifacts.length > 0 ? artifacts : undefined,
+  };
+}
+
+/** Options for {@link sendA2AMessageToUrl}. */
+export interface SendA2AMessageToUrlOptions {
+  /**
+   * Base URL of the agent (e.g. `https://gaia.example.com` or
+   * `http://172.17.0.1:7420`) or its full `/a2a` JSON-RPC endpoint.
+   * A missing `/a2a` path suffix is appended automatically.
+   */
+  endpoint: string;
+  /** User text to send. */
+  text: string;
+  /** Optional Bearer token. */
+  apiKey?: string;
+  /** Optional A2A contextId to thread messages into the same session. */
+  contextId?: string;
+  /** Abort the request after this many ms (default 120s). */
+  timeoutMs?: number;
+}
+
+/**
+ * Send a non-streaming A2A `message/send` to a full URL and collect the
+ * response. Unlike {@link sendA2AMessage} (plain-HTTP host:port, used for
+ * local containers), this speaks to any http(s) URL — e.g. an agent behind
+ * a reverse proxy — via global fetch.
+ */
+export async function sendA2AMessageToUrl(
+  options: SendA2AMessageToUrlOptions,
+): Promise<A2AMessageResponse> {
+  const { endpoint, text, apiKey, contextId, timeoutMs } = options;
+  const url = new URL(endpoint);
+  if (!url.pathname.replace(/\/+$/, "").endsWith("/a2a")) {
+    url.pathname = `${url.pathname.replace(/\/+$/, "")}/a2a`;
+  }
+
+  const messageId = `a2a-msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const rpcBody = JSON.stringify({
+    jsonrpc: "2.0",
+    id: `a2a-${Date.now()}`,
+    method: "message/send",
+    params: {
+      message: {
+        messageId,
+        role: "user",
+        parts: [{ kind: "text", text }],
+        ...(contextId ? { contextId } : {}),
+      },
+    },
+  });
+
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (apiKey) headers.authorization = `Bearer ${apiKey}`;
+
+  const res = await fetch(url.toString(), {
+    method: "POST",
+    headers,
+    body: rpcBody,
+    signal: AbortSignal.timeout(timeoutMs ?? MESSAGE_TIMEOUT_MS),
+  });
+  const data = await res.text();
+  if (res.status >= 400) {
+    throw new Error(
+      `A2A request to ${url.origin} returned HTTP ${res.status}: ${data.slice(0, 300)}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    throw new Error(`Invalid A2A response from ${url.origin}: ${data.slice(0, 300)}`);
+  }
+  try {
+    return decodeA2ASendPayload(parsed, url.origin);
+  } catch (err) {
+    throw new Error(
+      `A2A error from ${url.origin}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 function describe(endpoint: A2AEndpoint): string {
   return endpoint.label ?? `${endpoint.host ?? DEFAULT_HOST}:${endpoint.port}`;
 }
@@ -157,48 +280,26 @@ export async function sendA2AMessage(
             );
             return;
           }
+          let parsed: unknown;
           try {
-            const parsed = JSON.parse(data);
-            if (parsed.error) {
-              const errMsg = parsed.error.message ?? JSON.stringify(parsed.error);
-              reject(new Error(`A2A error from ${where}: ${errMsg}`));
-              return;
-            }
-            // The result can be a Message (with .parts directly) or a Task
-            // (with .status.message.parts). Tolerate both shapes.
-            const result = parsed.result ?? parsed;
-            const parts =
-              result?.parts ??
-              result?.status?.message?.parts ??
-              result?.message?.parts ??
-              [];
-            const textParts = parts
-              .filter((p: any) => p.kind === "text" || p.type === "text")
-              .map((p: any) => p.text);
-            // Defensive base-join (#194): habitats mint absolute artifact URIs,
-            // but tolerate a relative `/files/...` from older/other agents by
-            // resolving it against this endpoint's origin (WHATWG URL: a
-            // leading slash is origin-rooted). Already-absolute URIs pass through.
-            const origin = `http://${endpoint.host ?? DEFAULT_HOST}:${endpoint.port}`;
-            const resolveUri = (uri: string | undefined): string | undefined => {
-              if (!uri) return uri;
-              try {
-                return new URL(uri, origin).toString();
-              } catch {
-                return uri;
-              }
-            };
-            const artifacts = (result?.artifacts ?? []).map((a: any) => ({
-              name: a.name,
-              uri: resolveUri(a.parts?.[0]?.file?.uri),
-            }));
-            resolve({
-              text: textParts.join("\n") || "(no text response)",
-              artifacts: artifacts.length > 0 ? artifacts : undefined,
-            });
+            parsed = JSON.parse(data);
           } catch {
             reject(
               new Error(`Invalid A2A response from ${where}: ${data.slice(0, 300)}`),
+            );
+            return;
+          }
+          try {
+            // Defensive base-join (#194): habitats mint absolute artifact URIs,
+            // but tolerate a relative `/files/...` from older/other agents by
+            // resolving it against this endpoint's origin.
+            const origin = `http://${endpoint.host ?? DEFAULT_HOST}:${endpoint.port}`;
+            resolve(decodeA2ASendPayload(parsed, origin));
+          } catch (err) {
+            reject(
+              new Error(
+                `A2A error from ${where}: ${err instanceof Error ? err.message : String(err)}`,
+              ),
             );
           }
         });

--- a/packages/protocols/src/a2a/client.ts
+++ b/packages/protocols/src/a2a/client.ts
@@ -177,6 +177,7 @@ export async function sendA2AMessageToUrl(
   } catch (err) {
     throw new Error(
       `A2A error from ${url.origin}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 }

--- a/packages/protocols/src/a2a/index.ts
+++ b/packages/protocols/src/a2a/index.ts
@@ -9,11 +9,13 @@
 export {
   fetchAgentCard,
   sendA2AMessage,
+  sendA2AMessageToUrl,
 } from "./client.js";
 export type {
   A2AEndpoint,
   AgentCardSummary,
   A2AMessageResponse,
+  SendA2AMessageToUrlOptions,
 } from "./client.js";
 
 export { createA2AServer } from "./server.js";

--- a/packages/protocols/src/index.ts
+++ b/packages/protocols/src/index.ts
@@ -10,6 +10,7 @@
 export {
   fetchAgentCard,
   sendA2AMessage,
+  sendA2AMessageToUrl,
   createA2AServer,
   a2aChat,
   fetchJson,
@@ -20,6 +21,7 @@ export type {
   A2AEndpoint,
   AgentCardSummary,
   A2AMessageResponse,
+  SendA2AMessageToUrlOptions,
   A2AServer,
   A2AServerOptions,
   AgentExecutor,

--- a/packages/umwelten/src/index.ts
+++ b/packages/umwelten/src/index.ts
@@ -238,6 +238,7 @@ export {
 	mcpToolToToolDefinition,
 	fetchAgentCard,
 	sendA2AMessage,
+	sendA2AMessageToUrl,
 	createA2AServer,
 } from "@umwelten/protocols";
 
@@ -259,6 +260,7 @@ export type {
 	A2AEndpoint,
 	AgentCardSummary,
 	A2AMessageResponse,
+	SendA2AMessageToUrlOptions,
 	A2AServer,
 	A2AServerOptions,
 	AgentExecutor,


### PR DESCRIPTION
## Summary

Adds support for habitats to delegate questions to remote peers (e.g., an orchestrator like Gaia) over A2A. Introduces a new `remote-habitat` agent kind, an `ask_remote_agent` tool, and a URL-based A2A message sender to complement the existing host:port sender.

## Key Changes

### A2A Protocol (`packages/protocols/src/a2a/`)
- **`decodeA2ASendPayload()`**: Extracted shared JSON-RPC response decoder from `sendA2AMessage()`. Handles both Message and Task response shapes, resolves relative artifact URIs against an origin, and throws on JSON-RPC errors.
- **`sendA2AMessageToUrl()`**: New function to send A2A `message/send` requests to full URLs (http/https) via global `fetch`. Complements the existing host:port sender for agents behind reverse proxies or in cloud deployments. Appends `/a2a` path automatically, supports Bearer token auth, and uses `AbortSignal.timeout()` for request timeouts.
- **`SendA2AMessageToUrlOptions`**: Interface for URL sender configuration (endpoint, text, apiKey, contextId, timeoutMs).
- **Unit tests** (`client.test.ts`): Cover payload decoding (Message/Task shapes, artifact URI resolution, error handling) and URL sender (path normalization, bearer token injection, HTTP error handling, JSON parse errors).

### Remote Agent Tools (`packages/habitat/src/tools/remote-agent-tools.ts`)
- **`createRemoteAgentTools()`**: Factory that registers an `ask_remote_agent` tool when the habitat config declares `remote-habitat` agents. No tool is registered if no remote peers are declared.
- **`ask_remote_agent` tool**: Accepts `agentId` (ID or display name, case-insensitive) and `message`. Resolves endpoint from `a2aUrl` or `a2aUrlSecret`, token from `a2aTokenSecret`, and delegates to the A2A sender. Returns structured error objects (`REMOTE_AGENT_NOT_FOUND`, `REMOTE_AGENT_NOT_CONFIGURED`, `REMOTE_AGENT_ASK_FAILED`) instead of throwing, so the model can relay them to users.
- **Unit tests** (`remote-agent-tools.test.ts`): Cover tool registration gating, endpoint/token resolution (inline vs. secrets), lookup by ID and name, error shapes, and artifact pass-through.

### Docker Port Selection (`packages/habitat/src/tools/gaia/docker.ts`)
- **`pickHostPort()`**: Extracted pure port-selection logic. Fixes a regression where rebuilding a habitat would count its own registry-recorded port as "in use," causing every rebuild to hop to the next port and eventually exhaust the 7440–7499 range. Now accepts an optional `self` parameter to exclude the entry's own port from the "used" set, allowing restarts to reclaim their stable address.
- **`findAvailablePort()`**: Updated to pass the entry being rebuilt to `pickHostPort()`.
- **Unit tests** (`docker.port.test.ts`): Cover port allocation, self-port reuse on rebuild, out-of-range port fallback, and range exhaustion.

### Configuration & Types (`packages/habitat/src/types.ts`)
- **`AgentEntry`**: Added three new optional fields for `remote-habitat` agents:
  - `a2aUrl`: Direct base URL of the remote agent
  - `a2aUrlSecret`: Name of a secret/env var holding the URL (preferred for deployment-agnostic configs)
  - `a2aTokenSecret`: Name of a secret/env var holding the Bearer token

### Tool Set Integration (`packages/habitat/src/tool-sets.ts`)
- **`remoteAgentToolSet`**: New tool set that creates remote agent tools. Wired into the habitat's tool registry.

### Example: Help Habitat (`examples/help-habitat/`)
- **`config.json`**: Declares Gaia as a `remote-habitat` agent with URL and token secrets.
- **`STIMULUS.md`**: Added guidance on using `ask_

https://claude.ai/code/session_015vujgcmQQgLNM5H71XaaA7