### PR TITLE
feat(deploy): pass GitHub App identity into the gaia container (ADR 0004)

### DIFF
--- a/deploy/gaia/.env.example
+++ b/deploy/gaia/.env.example
@@ -43,6 +43,15 @@ OPENROUTER_API_KEY=
 # GAIA_JWKS_URL=https://habitats.thefocus.ai/.well-known/jwks.json
 # GAIA_AUTH_AUDIENCE=https://gaia.habitats.example.com   # Gaia's own HTTPS origin
 
+# --- GitHub App identity (ADR 0004) ---
+# Gaia is the only token-minting authority: it signs App JWTs with the private
+# key and mints short-lived, down-scoped installation tokens for habitats. Put
+# the key file under the data dir (mode 0600) so it rides the identity bind
+# mount into the container at the same path — NOT in the vault JSON.
+# GITHUB_APP_ID=
+# GITHUB_APP_INSTALLATION_ID=
+# GITHUB_APP_PRIVATE_KEY_FILE=/opt/gaia-data/github-app.pem
+
 # NOTE: child-habitat secrets (X OAuth, DATABASE_URL, child provider keys) are
 # NOT set here — they go into Gaia's master vault after boot (see the runbook),
 # and Gaia binds only the named subset each habitat needs.

--- a/deploy/gaia/docker-compose.yml
+++ b/deploy/gaia/docker-compose.yml
@@ -63,6 +63,12 @@ services:
       # own keys via the master vault + secret bindings, not from here.
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
+      # GitHub App identity (ADR 0004). Gaia mints per-installation tokens
+      # with the App's private key; the key file lives under the data dir
+      # (mode 0600) so it rides the identity bind mount, never the vault.
+      GITHUB_APP_ID: ${GITHUB_APP_ID:-}
+      GITHUB_APP_INSTALLATION_ID: ${GITHUB_APP_INSTALLATION_ID:-}
+      GITHUB_APP_PRIVATE_KEY_FILE: ${GITHUB_APP_PRIVATE_KEY_FILE:-}
     labels:
       # Gaia is itself a caddy-fronted habitat: control plane over TLS + auth at
       # GAIA_HOSTNAME, reached by caddy over the network ({{upstreams 7420}}).


### PR DESCRIPTION
Forwards `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and `GITHUB_APP_PRIVATE_KEY_FILE` from `deploy/gaia/.env` through the compose `environment:` block into the gaia container, and documents the three vars in `.env.example`.

Context: the gaia host already has the App's private key installed at `/opt/gaia-data/github-app.pem` (root:root, 0600 — rides the existing identity bind mount into the container at the same path) and the values set in the host's canonical `deploy/gaia/.env`. Without this passthrough the vars never reach the container (compose uses an explicit environment block, not `env_file`), verified by recreating gaia and checking its env.

Merging touches `deploy/gaia/`, so the self-hosted runner will redeploy gaia via `redeploy.sh` and the vars go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)