### PR TITLE
feat(providers): LunaRoute hosted router provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Usage: `new Interaction(modelDetails, stimulus)` then `interaction.streamText()`
 
 ### `src/providers/` — LLM Backends
 
-Unified access to 11 providers via `BaseProvider` (abstract class with `listModels()` and `getLanguageModel()`).
+Unified access to 12 providers via `BaseProvider` (abstract class with `listModels()` and `getLanguageModel()`).
 
 - `base.ts` — `BaseProvider` abstract class
 - `google.ts` — Gemini models (needs `GOOGLE_GENERATIVE_AI_API_KEY`)
@@ -136,6 +136,7 @@ Unified access to 11 providers via `BaseProvider` (abstract class with `listMode
 - `fireworks.ts` — Fireworks.ai models (needs `FIREWORKS_API_KEY`)
 - `minimax.ts` — MiniMax models (needs `MINIMAX_API_KEY`)
 - `nvidia.ts` — NVIDIA-hosted models (needs `NVIDIA_API_KEY`)
+- `lunaroute.ts` — [LunaRoute](https://lunaroute.com) hosted inference router for open-weight models. OpenAI-compatible gateway at `https://gw.lunaroute.com/v1` (needs `LUNAROUTE_API_KEY`; override base with `LUNAROUTE_BASE_URL`). Served model IDs carry variant suffixes (e.g. `glm-5.2-nvfp4`) — check `umwelten models --provider lunaroute`
 - `github-models.ts` — GitHub-hosted models (needs `GITHUB_TOKEN`)
 - `ollama.ts` — Local models (no key needed)
 - `lmstudio.ts` — Local REST API (no key needed)
@@ -580,6 +581,7 @@ mise run habitat-browse       # against a habitat's sessions
 - `TOGETHER_API_KEY` — Together AI
 - `MINIMAX_API_KEY` — MiniMax
 - `NVIDIA_API_KEY` — NVIDIA-hosted models
+- `LUNAROUTE_API_KEY` — LunaRoute hosted router (`LUNAROUTE_BASE_URL` overrides `https://gw.lunaroute.com/v1`)
 - `TAVILY_API_KEY` — Web search tool
 - `MARKIFY_URL` — Optional external HTML-to-markdown service
 - `LLAMASWAP_HOST` — Override the default `http://localhost:8080/v1` for llama-swap

--- a/packages/core/src/cognition/models.ts
+++ b/packages/core/src/cognition/models.ts
@@ -9,6 +9,7 @@ import { createMiniMaxProvider } from "../providers/minimax.js";
 import { createDeepInfraProvider } from "../providers/deepinfra.js";
 import { createTogetherAIProvider } from "../providers/togetherai.js";
 import { createNvidiaProvider } from "../providers/nvidia.js";
+import { createLunaRouteProvider } from "../providers/lunaroute.js";
 import type { ModelDetails } from "./types.js";
 // Function to get all available models from all providers
 export async function getAllModels(): Promise<ModelDetails[]> {
@@ -40,6 +41,9 @@ export async function getAllModels(): Promise<ModelDetails[]> {
         : []),
       ...(process.env.NVIDIA_API_KEY
         ? [{ label: "nvidia", listModels: () => createNvidiaProvider(process.env.NVIDIA_API_KEY!).listModels() }]
+        : []),
+      ...(process.env.LUNAROUTE_API_KEY
+        ? [{ label: "lunaroute", listModels: () => createLunaRouteProvider(process.env.LUNAROUTE_API_KEY!, process.env.LUNAROUTE_BASE_URL).listModels() }]
         : []),
     ];
 

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -17,6 +17,7 @@ import { BaseProvider } from "./base.js";
 import { createLMStudioProvider } from "./lmstudio.js";
 import { createLlamaBarnProvider } from "./llamabarn.js";
 import { createLlamaSwapProvider } from "./llamaswap.js";
+import { createLunaRouteProvider, getLunaRouteModelUrl } from "./lunaroute.js";
 import { installLocalFetchDispatcher } from "./local-fetch.js";
 import { registerProvider, getRegisteredProvider, listRegisteredProviders } from "./registry.js";
 
@@ -70,6 +71,12 @@ registerProvider("togetherai", {
   create: (key) => createTogetherAIProvider(key!),
   envVar: "TOGETHER_API_KEY",
   getModelUrl: getTogetherAIModelUrl,
+});
+
+registerProvider("lunaroute", {
+  create: (key) => createLunaRouteProvider(key!, process.env.LUNAROUTE_BASE_URL),
+  envVar: "LUNAROUTE_API_KEY",
+  getModelUrl: getLunaRouteModelUrl,
 });
 
 registerProvider("ollama", {

--- a/packages/core/src/providers/lunaroute.integration.test.ts
+++ b/packages/core/src/providers/lunaroute.integration.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { createLunaRouteProvider } from './lunaroute.js';
+import { generateText, streamText } from 'ai';
+
+const API_KEY = process.env.LUNAROUTE_API_KEY;
+
+describe('LunaRoute Provider', () => {
+  describe('Provider Instance', () => {
+    it('should create a provider instance with a key', () => {
+      const provider = createLunaRouteProvider('test-key');
+      expect(provider).toBeDefined();
+    });
+
+    it('should throw without an API key', () => {
+      expect(() => createLunaRouteProvider(undefined as unknown as string)).toThrow();
+    });
+  });
+
+  describe('Model Listing', () => {
+    it('should list available models', async () => {
+      if (!API_KEY) {
+        console.warn('⚠️ LUNAROUTE_API_KEY not set, skipping test');
+        return;
+      }
+      const provider = createLunaRouteProvider(API_KEY);
+      const models = await provider.listModels();
+      expect(models).toBeInstanceOf(Array);
+      expect(models.length).toBeGreaterThan(0);
+      console.log('LunaRoute models:', models.map((m) => m.name));
+      models.forEach((model) => {
+        expect(model.name).toBeDefined();
+        expect(model.provider).toBe('lunaroute');
+        expect(model.costs).toBeDefined();
+      });
+    });
+
+    it('should include a glm-5.2 variant with pricing', async () => {
+      if (!API_KEY) {
+        console.warn('⚠️ LUNAROUTE_API_KEY not set, skipping test');
+        return;
+      }
+      const provider = createLunaRouteProvider(API_KEY);
+      const models = await provider.listModels();
+      // Gateway serves variant IDs, e.g. "glm-5.2-nvfp4"
+      const glm = models.find((m) => m.name.startsWith('glm-5.2'));
+      expect(glm).toBeDefined();
+      expect(glm!.costs.promptTokens).toBeGreaterThan(0);
+      expect(glm!.costs.completionTokens).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Text Generation (glm-5.2)', () => {
+    async function glmModelName(): Promise<string> {
+      const provider = createLunaRouteProvider(API_KEY!);
+      const models = await provider.listModels();
+      const glm = models.find((m) => m.name.startsWith('glm-5.2'));
+      expect(glm).toBeDefined();
+      return glm!.name;
+    }
+
+    it('should generate text', async () => {
+      if (!API_KEY) {
+        console.warn('⚠️ LUNAROUTE_API_KEY not set, skipping test');
+        return;
+      }
+      const provider = createLunaRouteProvider(API_KEY);
+      const model = provider.getLanguageModel({ name: await glmModelName(), provider: 'lunaroute' });
+      const response = await generateText({
+        model,
+        prompt: 'Say "hello" and nothing else.',
+      });
+      expect(response.text).toBeTruthy();
+      expect(typeof response.text).toBe('string');
+      console.log('glm-5.2 says:', response.text);
+    }, 180_000);
+
+    it('should stream text and report usage', async () => {
+      if (!API_KEY) {
+        console.warn('⚠️ LUNAROUTE_API_KEY not set, skipping test');
+        return;
+      }
+      const provider = createLunaRouteProvider(API_KEY);
+      const model = provider.getLanguageModel({ name: await glmModelName(), provider: 'lunaroute' });
+      const result = streamText({
+        model,
+        prompt: 'Count from 1 to 5, digits only.',
+      });
+      let streamed = '';
+      for await (const chunk of result.textStream) {
+        streamed += chunk;
+      }
+      expect(streamed).toBeTruthy();
+      const usage = await result.usage;
+      expect(usage.totalTokens).toBeGreaterThan(0);
+    }, 180_000);
+  });
+});

--- a/packages/core/src/providers/lunaroute.ts
+++ b/packages/core/src/providers/lunaroute.ts
@@ -1,0 +1,93 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type { LanguageModel } from "ai";
+import { BaseProvider } from "./base.js";
+import type { ModelDetails, ModelRoute } from "../cognition/types.js";
+
+const DEFAULT_BASE_URL = "https://gw.lunaroute.com/v1";
+
+/**
+ * Published LunaRoute pricing per 1M tokens (lunaroute.com, 2026-07-06).
+ * The gateway's /v1/models does not include pricing, and served model IDs
+ * carry variant suffixes (e.g. "glm-5.2-nvfp4"), so lookup is by longest
+ * matching prefix.
+ */
+const KNOWN_PRICING: Record<string, { promptTokens: number; completionTokens: number }> = {
+  "glm-5.2": { promptTokens: 2.1, completionTokens: 6.6 },
+  "kimi-k2.7": { promptTokens: 1.5, completionTokens: 6.0 },
+  "qwen-3.7-plus": { promptTokens: 0.4, completionTokens: 1.6 },
+  "minimax-m3": { promptTokens: 0.45, completionTokens: 1.8 },
+  "deepseek-v4-pro": { promptTokens: 2.61, completionTokens: 5.22 },
+};
+
+function pricingForModel(id: string): { promptTokens: number; completionTokens: number } | undefined {
+  const key = Object.keys(KNOWN_PRICING)
+    .filter((k) => id === k || id.startsWith(`${k}-`))
+    .sort((a, b) => b.length - a.length)[0];
+  return key ? KNOWN_PRICING[key] : undefined;
+}
+
+export class LunaRouteProvider extends BaseProvider {
+  constructor(apiKey: string, baseUrl: string = DEFAULT_BASE_URL) {
+    super(apiKey, baseUrl);
+    this.validateConfig();
+  }
+
+  async listModels(): Promise<ModelDetails[]> {
+    const response = await fetch(`${this.baseUrl}/models`, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+    });
+    const data = await response.json();
+
+    if (!response.ok || !Array.isArray(data?.data)) {
+      throw new Error(
+        `LunaRoute API error: ${data?.error?.message || data?.error || response.statusText || "unexpected response format"}`,
+      );
+    }
+
+    return data.data.map((model: any) => {
+      const created =
+        typeof model.created === "number" && model.created > 0
+          ? new Date(model.created * 1000)
+          : undefined;
+      // Prefer pricing from the API response; fall back to the published table
+      const apiPrompt = parseFloat(model.pricing?.prompt ?? "");
+      const apiCompletion = parseFloat(model.pricing?.completion ?? "");
+      const fallback = pricingForModel(model.id);
+      return {
+        provider: "lunaroute",
+        name: model.id,
+        contextLength: model.context_length,
+        costs: {
+          promptTokens: Number.isFinite(apiPrompt) ? apiPrompt * 1_000_000 : fallback?.promptTokens ?? 0,
+          completionTokens: Number.isFinite(apiCompletion) ? apiCompletion * 1_000_000 : fallback?.completionTokens ?? 0,
+        },
+        details: {
+          ownedBy: model.owned_by,
+        },
+        addedDate: created,
+        lastUpdated: created,
+      } as ModelDetails;
+    });
+  }
+
+  getLanguageModel(route: ModelRoute): LanguageModel {
+    this.validateConfig();
+    const lunaroute = createOpenAICompatible({
+      name: "lunaroute",
+      baseURL: this.baseUrl || DEFAULT_BASE_URL,
+      apiKey: this.apiKey,
+      includeUsage: true,
+    });
+    return lunaroute(route.name);
+  }
+}
+
+export function createLunaRouteProvider(apiKey: string, baseUrl?: string): LunaRouteProvider {
+  return new LunaRouteProvider(apiKey, baseUrl);
+}
+
+export function getLunaRouteModelUrl(_modelId: string): string {
+  return "https://lunaroute.com";
+}

--- a/packages/habitat/src/tools/gaia/fnox.ts
+++ b/packages/habitat/src/tools/gaia/fnox.ts
@@ -87,6 +87,7 @@ if_missing = "warn"
 [secrets]
 # GOOGLE_GENERATIVE_AI_API_KEY = { provider = "onepass", description = "Google Gemini API key" }
 # OPENROUTER_API_KEY = { provider = "onepass", description = "OpenRouter API key" }
+# LUNAROUTE_API_KEY = { provider = "onepass", description = "LunaRoute API key" }
 # GITHUB_TOKEN = { provider = "onepass", description = "GitHub personal access token" }
 # GITHUB_APP_PRIVATE_KEY = { provider = "onepass", description = "GitHub App private key" }
 # GITHUB_APP_ID = { provider = "onepass", description = "GitHub App ID" }
@@ -365,6 +366,7 @@ export class FnoxResolver {
 const FALLBACK_SECRET_NAMES = [
 	"GOOGLE_GENERATIVE_AI_API_KEY",
 	"OPENROUTER_API_KEY",
+	"LUNAROUTE_API_KEY",
 	"GITHUB_TOKEN",
 	"GITHUB_APP_PRIVATE_KEY",
 	"GITHUB_APP_ID",

--- a/reports/2026-07-06-lunaroute-provider-integration.md
+++ b/reports/2026-07-06-lunaroute-provider-integration.md
@@ -1,0 +1,151 @@
+# Adding LunaRoute as an umwelten provider
+
+Research report, 2026-07-06 (rev 2 — first draft wrongly researched `erans/lunaroute`, an unrelated local proxy with the same name).
+
+> **Status: implemented and verified 2026-07-06.** Provider at `packages/core/src/providers/lunaroute.ts`, registered in `providers/index.ts` (`LUNAROUTE_API_KEY`, optional `LUNAROUTE_BASE_URL`), listed in `getAllModels()`. Gaia: `LUNAROUTE_API_KEY` added to fnox `FALLBACK_SECRET_NAMES` + fnox.toml template; container attach-inference derives the env name from the provider automatically.
+>
+> **Corrections found during verification:**
+> - The inference gateway is **`https://gw.lunaroute.com/v1`** — not `api.lunaroute.com` (that host serves the app API and rejects inference keys with `Invalid or expired token`) and not the `api.lunaroute.ai` printed in the site copy (does not resolve).
+> - Served model IDs carry **variant suffixes**: `glm-5.2-nvfp4`, `glm-5.2-nvfp4-ballast` — not the bare `glm-5.2` from the marketing page. Pricing fallback matches by prefix.
+> - `/v1/models` **does work** on the gateway and returns rich metadata (context_length 1M, max_output 131072, capabilities incl. `tools`, `reasoning`, `json_schema`, `anthropic_messages`) but **no pricing** — the published table remains the cost source.
+>
+> Verified end-to-end: `models --provider lunaroute` lists both variants with pricing; `run -p lunaroute -m glm-5.2-nvfp4` streams a response with correct cost math ($0.003151 for 61/458 tokens — note glm-5.2 emits reasoning tokens, so completion counts run high); all 6 integration tests pass (`vitest run --config vitest.integration.config.ts …/lunaroute.integration.test.ts`).
+
+## What LunaRoute is
+
+[LunaRoute](https://lunaroute.com) is a **hosted, OpenAI-compatible inference router** for open-weight frontier models — single endpoint, automatic failover, latency-based routing. Same product category as OpenRouter, and the integration is the same shape as our `openrouter` provider: Bearer key + OpenAI-compatible API.
+
+| Thing | Value |
+| --- | --- |
+| Base URL | `https://api.lunaroute.com/v1` — **verified live**. The site's copy says `api.lunaroute.ai`, but that host does not resolve (checked 2026-07-06); `.com` answers correctly. |
+| Auth | `Authorization: Bearer $LUNAROUTE_API_KEY` (keys from https://app.lunaroute.com → dashboard → keys) |
+| Chat | `POST /v1/chat/completions` (OpenAI format) |
+| Models | `GET /v1/models` **exists** — returns 401 `{"error":"Authorization header required"}` without a key, so listing is live-enumerable with auth |
+| Model IDs | Bare names, no namespace prefix: `glm-5.2`, `kimi-k2.7`, `qwen-3.7-plus`, `minimax-m3`, `deepseek-v4-pro` |
+| Billing | Monthly credit plans ($10–$200), balances roll over; metered per token |
+| Data | "Request bodies stored: never, nowhere" — processed in memory only; US-based upstream providers |
+
+Published pricing (per 1M tokens, as of 2026-07-06):
+
+| Model | Context | Input | Output |
+| --- | --- | --- | --- |
+| glm-5.2 | 200K | $2.10 | $6.60 |
+| kimi-k2.7 | 256K | $1.50 | $6.00 |
+| qwen-3.7-plus | 128K | $0.40 | $1.60 |
+| minimax-m3 | 1M | $0.45 | $1.80 |
+| deepseek-v4-pro | 164K | $2.61 | $5.22 |
+
+## Integration: mirror the openrouter provider
+
+This is the simplest provider class we have — keyed, OpenAI-compatible, live model listing. No new dependencies: `@ai-sdk/openai-compatible` is already in core (llamaswap/lmstudio use it).
+
+### `packages/core/src/providers/lunaroute.ts`
+
+```typescript
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type { LanguageModel } from "ai";
+import { BaseProvider } from "./base.js";
+import type { ModelDetails, ModelRoute } from "../cognition/types.js";
+
+const BASE_URL = "https://api.lunaroute.com/v1";
+
+// Published pricing per 1M tokens — fallback in case /v1/models omits pricing.
+// Verify against the live /v1/models response once a key is available.
+const PRICING: Record<string, { promptTokens: number; completionTokens: number }> = {
+  "glm-5.2": { promptTokens: 2.1, completionTokens: 6.6 },
+  "kimi-k2.7": { promptTokens: 1.5, completionTokens: 6.0 },
+  "qwen-3.7-plus": { promptTokens: 0.4, completionTokens: 1.6 },
+  "minimax-m3": { promptTokens: 0.45, completionTokens: 1.8 },
+  "deepseek-v4-pro": { promptTokens: 2.61, completionTokens: 5.22 },
+};
+
+export class LunaRouteProvider extends BaseProvider {
+  constructor(apiKey: string) {
+    super(apiKey, BASE_URL);
+    this.validateConfig();
+  }
+
+  async listModels(): Promise<ModelDetails[]> {
+    const response = await fetch(`${this.baseUrl}/models`, {
+      headers: { Authorization: `Bearer ${this.apiKey}` },
+    });
+    const data = await response.json();
+    if (!response.ok || !Array.isArray(data?.data)) {
+      throw new Error(`LunaRoute API error: ${data?.error || response.statusText}`);
+    }
+    return data.data.map((model: any) => ({
+      provider: "lunaroute",
+      name: model.id,
+      contextLength: model.context_length,
+      costs: PRICING[model.id] ?? { promptTokens: 0, completionTokens: 0 },
+      // If /v1/models returns pricing fields, map them here instead of PRICING
+    } as ModelDetails));
+  }
+
+  getLanguageModel(route: ModelRoute): LanguageModel {
+    this.validateConfig();
+    const lunaroute = createOpenAICompatible({
+      name: "lunaroute",
+      baseURL: this.baseUrl!,
+      apiKey: this.apiKey,
+      includeUsage: true, // usage in streamed responses → cost tracking works
+    });
+    return lunaroute(route.name);
+  }
+}
+
+export function createLunaRouteProvider(apiKey: string): LunaRouteProvider {
+  return new LunaRouteProvider(apiKey);
+}
+
+export function getLunaRouteModelUrl(_modelId: string): string {
+  return "https://lunaroute.com"; // no per-model pages found yet
+}
+```
+
+### Registration — `providers/index.ts`
+
+```typescript
+registerProvider("lunaroute", {
+  create: (key) => createLunaRouteProvider(key!),
+  envVar: "LUNAROUTE_API_KEY",
+  getModelUrl: getLunaRouteModelUrl,
+});
+```
+
+The registry handles the missing-key error path automatically (`getModelProvider` throws `LUNAROUTE_API_KEY environment variable is required`).
+
+### Files to touch
+
+| File | Change |
+| --- | --- |
+| `packages/core/src/providers/lunaroute.ts` | New provider (above) |
+| `packages/core/src/providers/index.ts` | Import + `registerProvider("lunaroute", …)` |
+| `packages/core/src/cognition/models.ts` | Add to `getAllModels()`, gated on `process.env.LUNAROUTE_API_KEY` like the other keyed providers |
+| `packages/core/src/providers/lunaroute.integration.test.ts` | Gated on `LUNAROUTE_API_KEY`: listModels shape, one cheap `generateText` (`qwen-3.7-plus` is the cheapest), streaming usage present |
+| `.env` | Add `LUNAROUTE_API_KEY=…` |
+| `CLAUDE.md` / `LLM.txt` | Providers list + env var section |
+
+No runner/request-option defaults touched — no HARD RULES in play.
+
+### Usage after implementation
+
+```bash
+dotenvx run -- pnpm run cli models --provider lunaroute
+dotenvx run -- pnpm run cli run -p lunaroute -m glm-5.2 --prompt "Hello"
+```
+
+## To verify with a live key (blocked on `LUNAROUTE_API_KEY` in `.env`)
+
+1. **`/v1/models` response shape** — field names (`context_length`? pricing included?). If pricing comes back in the payload, drop the static `PRICING` table and map it like openrouter does.
+2. **Streaming** — confirm SSE + `include_usage` works (`includeUsage: true` sends `stream_options`); if the backend rejects `stream_options`, drop the flag and rely on non-streamed usage.
+3. **Tool calling** — umwelten's habitat/eval paths depend on it; run one tool-loop smoke test (e.g. `tools demo`) against `glm-5.2`.
+4. **Base URL** — re-confirm `.com` vs `.ai` at implementation time; site copy and DNS currently disagree (`.ai` doesn't resolve, `.com` verified).
+
+## Sources
+
+- https://lunaroute.com / https://www.lunaroute.com (product page: models, pricing, curl example, credit plans)
+- `curl https://api.lunaroute.com/v1/models` → 401 `{"error":"Authorization header required"}` (endpoint exists; `.ai` host does not resolve)
+- https://app.lunaroute.com (dashboard/keys)
+
+**Name collision note:** [erans/lunaroute](https://github.com/erans/lunaroute) on GitHub is an unrelated local Rust proxy for AI coding assistants — not this service.


### PR DESCRIPTION
Adds [LunaRoute](https://lunaroute.com) (hosted OpenAI-compatible inference router) as a core provider, following the openrouter pattern.

## What
- **New provider** `packages/core/src/providers/lunaroute.ts` — gateway at `https://gw.lunaroute.com/v1`, `LUNAROUTE_API_KEY` auth, `LUNAROUTE_BASE_URL` override. Live `/v1/models` listing; pricing falls back to the published per-1M table matched by model-id prefix (served IDs carry variant suffixes like `glm-5.2-nvfp4`).
- **Registry + models**: registered in `providers/index.ts`, added to `getAllModels()` gated on the key.
- **Gaia**: `LUNAROUTE_API_KEY` added to fnox `FALLBACK_SECRET_NAMES` + fnox.toml template so the master vault sweeps it from the environment; container attach-inference already derives the env name from the provider name.
- **Docs**: CLAUDE.md provider/env sections; research notes in `reports/2026-07-06-lunaroute-provider-integration.md` (including the `gw.` vs `api.` vs `.ai` host confusion, so nobody retreads it).

## Verification
- All 1440 unit tests pass (`pnpm test:run`)
- 6/6 integration tests pass against the live gateway (list, glm-5.2 pricing, generate, stream + usage)
- End-to-end CLI: `models --provider lunaroute` lists both variants with pricing/1M context; one-shot runs on both `glm-5.2-nvfp4` and `-ballast`, structured `--object` output, cost math checks out against published rates ($2.10/$6.60 per 1M)

Note: glm-5.2 emits reasoning tokens even on trivial prompts, so completion counts run higher than visible output — reported faithfully in usage, no caps anywhere (HARD RULES untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)