### PR TITLE
fix(gaia): GitHub App token path — bare-name mints, per-habitat tokens, Gaia self-mint

### DIFF
--- a/packages/habitat/entrypoint.sh
+++ b/packages/habitat/entrypoint.sh
@@ -70,18 +70,40 @@ secret_value() {
 }
 
 # ── Private-repo git auth ──────────────────────────────────────────────
-# If the habitat has a GITHUB_TOKEN secret (vault-bound or env), route
-# github.com HTTPS git operations through it via git's env config — this
-# covers the project clone, per-agent clones, and `npx skills add`.
-# x-access-token works for classic PATs, fine-grained PATs, and app
-# installation tokens alike. The token never lands in config.json, the
-# registry, or the clone URLs persisted in git remotes.
-GITHUB_TOKEN_VALUE=$(secret_value GITHUB_TOKEN)
+# Route github.com HTTPS git operations through a token via git's env
+# config — this covers the project clone, per-agent clones, and
+# `npx skills add`. x-access-token works for classic PATs, fine-grained
+# PATs, and app installation tokens alike. The token never lands in
+# config.json, the registry, or the clone URLs persisted in git remotes.
+#
+# Token source, in order — freshest first (ADR 0004):
+#   1. GitHub App mint — only Gaia has GITHUB_APP_* env; a fresh ambient-read
+#      installation token beats any stored PAT (which can silently go stale).
+#   2. GITHUB_TOKEN env — the per-habitat boot token Gaia's token service
+#      injects into children (docker.ts). Checked BEFORE the vault so a
+#      stale vault PAT can't shadow the fresh per-boot token.
+#   3. GITHUB_TOKEN in the seeded secrets vault — legacy PATs.
+GITHUB_TOKEN_VALUE=""
+if [ -n "$GITHUB_APP_ID" ] && [ -n "$GITHUB_APP_INSTALLATION_ID" ] && [ -n "$GITHUB_APP_PRIVATE_KEY_FILE" ]; then
+	GITHUB_TOKEN_VALUE=$(pnpm exec tsx packages/habitat/src/tools/gaia/github/mint-boot-token.ts 2>/dev/null) || GITHUB_TOKEN_VALUE=""
+	if [ -n "$GITHUB_TOKEN_VALUE" ]; then
+		echo "[entrypoint] GitHub App configured — minted ambient-read token for github.com clones."
+	else
+		echo "[entrypoint] GitHub App configured but token mint failed — falling back to GITHUB_TOKEN."
+	fi
+fi
+if [ -z "$GITHUB_TOKEN_VALUE" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
+	GITHUB_TOKEN_VALUE="$GITHUB_TOKEN"
+	echo "[entrypoint] GITHUB_TOKEN env present (per-habitat boot token) — authenticated github.com clones enabled."
+fi
+if [ -z "$GITHUB_TOKEN_VALUE" ]; then
+	GITHUB_TOKEN_VALUE=$(secret_value GITHUB_TOKEN)
+	[ -n "$GITHUB_TOKEN_VALUE" ] && echo "[entrypoint] GITHUB_TOKEN present — authenticated github.com clones enabled."
+fi
 if [ -n "$GITHUB_TOKEN_VALUE" ]; then
 	export GIT_CONFIG_COUNT=1
 	export GIT_CONFIG_KEY_0="url.https://x-access-token:$GITHUB_TOKEN_VALUE@github.com/.insteadOf"
 	export GIT_CONFIG_VALUE_0="https://github.com/"
-	echo "[entrypoint] GITHUB_TOKEN present — authenticated github.com clones enabled."
 fi
 
 if [ -f "$CONFIG_FILE" ]; then

--- a/packages/habitat/src/tools/gaia/github/mint-boot-token.ts
+++ b/packages/habitat/src/tools/gaia/github/mint-boot-token.ts
@@ -1,0 +1,30 @@
+/**
+ * Boot-time CLI: mint an ambient-read installation token from the
+ * GITHUB_APP_* env and print it to stdout (ADR 0004).
+ *
+ * Run by entrypoint.sh in the one container that holds the App identity —
+ * Gaia itself — so its own skillsFromGit / project clones authenticate
+ * through the App instead of a long-lived vault PAT. Child habitats never
+ * have GITHUB_APP_* env; they receive per-habitat boot tokens minted by
+ * Gaia's token service (docker.ts).
+ *
+ * Prints nothing when the App is unconfigured; exits non-zero on a mint
+ * failure. The caller treats both as "no token" and falls back to the
+ * GITHUB_TOKEN secret. Read-only scope: boot clones never need write.
+ */
+
+import { readFile } from "node:fs/promises";
+import { mintInstallationToken } from "./app-auth.js";
+import { resolveGithubAppConfig } from "./app-config.js";
+
+const cfg = resolveGithubAppConfig();
+if (cfg) {
+	const privateKeyPem = await readFile(cfg.privateKeyFile, "utf-8");
+	const minted = await mintInstallationToken({
+		appId: cfg.appId,
+		privateKeyPem,
+		installationId: cfg.installationId,
+		permissions: { contents: "read" },
+	});
+	process.stdout.write(minted.token);
+}

--- a/packages/habitat/src/tools/gaia/github/token-service.test.ts
+++ b/packages/habitat/src/tools/gaia/github/token-service.test.ts
@@ -155,15 +155,18 @@ describe("createGithubTokenService", () => {
 		expect(readFileImpl).not.toHaveBeenCalled();
 	});
 
-	it("caches per (kind + sorted repo list) for 50 minutes", async () => {
+	it("caches per (habitat + kind + sorted repo list) for 50 minutes", async () => {
 		const clock = makeClock();
 		const mint = makeMint();
 		const service = createGithubTokenService(CFG, { mint, now: clock.now });
 
-		const entry = { github: { read: ["b", "a"] } };
+		const entry = { id: "h1", github: { read: ["b", "a"] } };
 		const first = await service.tokenFor(entry, "read");
-		// Same repo set in a different declaration order → cache hit
-		const second = await service.tokenFor({ github: { read: ["a", "b"] } }, "read");
+		// Same habitat, same repo set in a different declaration order → cache hit
+		const second = await service.tokenFor(
+			{ id: "h1", github: { read: ["a", "b"] } },
+			"read",
+		);
 		expect(second?.token).toBe(first?.token);
 		expect(mint).toHaveBeenCalledTimes(1);
 
@@ -176,6 +179,22 @@ describe("createGithubTokenService", () => {
 		clock.advanceMinutes(2);
 		const fresh = await service.tokenFor(entry, "read");
 		expect(fresh?.token).not.toBe(first?.token);
+		expect(mint).toHaveBeenCalledTimes(2);
+	});
+
+	it("never shares tokens across habitats, even with identical scopes", async () => {
+		const mint = makeMint();
+		const service = createGithubTokenService(CFG, { mint });
+
+		const a = await service.tokenFor(
+			{ id: "habitat-a", github: { read: ["standards"] } },
+			"read",
+		);
+		const b = await service.tokenFor(
+			{ id: "habitat-b", github: { read: ["standards"] } },
+			"read",
+		);
+		expect(a?.token).not.toBe(b?.token);
 		expect(mint).toHaveBeenCalledTimes(2);
 	});
 

--- a/packages/habitat/src/tools/gaia/github/token-service.test.ts
+++ b/packages/habitat/src/tools/gaia/github/token-service.test.ts
@@ -76,6 +76,31 @@ describe("deriveGithubTokenScope", () => {
 		});
 	});
 
+	it("strips owner prefixes to bare repo names and dedupes (mint API 422s on owner/name)", () => {
+		expect(
+			deriveGithubTokenScope(
+				{ github: { read: ["The-Focus-AI/standards", "standards", "The-Focus-AI/zebra"] } },
+				"read",
+			),
+		).toEqual({
+			repositories: ["standards", "zebra"],
+			permissions: { contents: "read" },
+		});
+		expect(
+			deriveGithubTokenScope(
+				{ github: { write: ["The-Focus-AI/twitter-habitat"] } },
+				"write",
+			),
+		).toEqual({
+			repositories: ["twitter-habitat"],
+			permissions: {
+				contents: "write",
+				issues: "write",
+				pull_requests: "write",
+			},
+		});
+	});
+
 	it("returns null when the entry declares no matching scope", () => {
 		expect(deriveGithubTokenScope({}, "read")).toBeNull();
 		expect(deriveGithubTokenScope({ github: {} }, "read")).toBeNull();

--- a/packages/habitat/src/tools/gaia/github/token-service.ts
+++ b/packages/habitat/src/tools/gaia/github/token-service.ts
@@ -52,6 +52,17 @@ export interface GithubTokenServiceDeps {
 const CACHE_TTL_MS = 50 * 60 * 1000;
 
 /**
+ * The mint API's `repositories` field takes bare repo names — the owner is
+ * implied by the installation — but declarations naturally arrive as
+ * `owner/name` (that's how the registry and humans write repos everywhere
+ * else). GitHub 422s on owner-prefixed names, so strip to the final path
+ * segment and dedupe before minting.
+ */
+function toBareRepoNames(repos: string[]): string[] {
+	return [...new Set(repos.map((r) => r.split("/").filter(Boolean).pop() ?? r))].sort();
+}
+
+/**
  * Derive the token scope for an entry + kind, or null when the entry
  * declares no matching capability.
  *
@@ -74,7 +85,7 @@ export function deriveGithubTokenScope(
 		}
 		if (Array.isArray(decl.read) && decl.read.length > 0) {
 			return {
-				repositories: [...decl.read].sort(),
+				repositories: toBareRepoNames(decl.read),
 				permissions: { contents: "read" },
 			};
 		}
@@ -83,7 +94,7 @@ export function deriveGithubTokenScope(
 
 	if (Array.isArray(decl.write) && decl.write.length > 0) {
 		return {
-			repositories: [...decl.write].sort(),
+			repositories: toBareRepoNames(decl.write),
 			permissions: {
 				contents: "write",
 				issues: "write",

--- a/packages/habitat/src/tools/gaia/github/token-service.ts
+++ b/packages/habitat/src/tools/gaia/github/token-service.ts
@@ -4,9 +4,11 @@
  * Derives the down-scoped repo list + permissions from a habitat entry's
  * `github` capability declaration and mints tokens via ./app-auth.ts,
  * reading the App private key from disk at mint time (never stored in the
- * vault or config). Mints are cached ~50 minutes per (kind + sorted repo
- * list) to respect the installation's pooled rate limits (blind spot #7) —
- * safely under the 1-hour token expiry.
+ * vault or config). Mints are cached ~50 minutes per (habitat + kind +
+ * sorted repo list) — safely under the 1-hour token expiry, and never
+ * shared across habitats: each workspace holds its own token even when two
+ * declare identical scopes, so one habitat's token leaking or being cycled
+ * says nothing about any other's.
  */
 
 import { readFile } from "node:fs/promises";
@@ -164,7 +166,9 @@ export function createGithubTokenService(
 		const scope = deriveGithubTokenScope(entry, kind);
 		if (!scope) return null;
 
-		const cacheKey = `${kind}|${scope.repositories?.join(",") ?? "<org>"}`;
+		// Habitat id leads the key: tokens are per-workspace, never shared
+		// across habitats with coincidentally identical scopes.
+		const cacheKey = `${entry.id ?? "<anon>"}|${kind}|${scope.repositories?.join(",") ?? "<org>"}`;
 		const cached = cache.get(cacheKey);
 		if (cached && now() - cached.mintedAt < CACHE_TTL_MS) {
 			return cached.token;


### PR DESCRIPTION
Three fixes/tightenings on the ADR 0004 GitHub App token path, verified against the live App (installation 144711468).

## 1. Scoped mints 422 on `owner/name` (bug, prod repro)

Declarations arrive as `owner/name` (`The-Focus-AI/standards` — consistent with `skillsFromGit`), but `POST /app/installations/:id/access_tokens` takes **bare repo names**, owner implied by the installation. Verified live: `repositories:["standards"]` → 201, `repositories:["The-Focus-AI/standards"]` → 422 (the exact prod error). Fix: normalize to bare names + dedupe at scope derivation.

## 2. Tokens are now unique per habitat workspace

The mint cache was keyed by `(kind, repo list)`, so habitats with identical scopes shared one token. Now keyed by `(habitat id, kind, repo list)` — each workspace holds its own credential; one habitat's token leaking or cycling says nothing about any other's.

## 3. Gaia itself now authenticates clones through the App

Gaia's own `skillsFromGit` clones relied on a vault `GITHUB_TOKEN` PAT, which has gone stale in prod ("Invalid username or token"). The entrypoint now mints an ambient-read installation token when `GITHUB_APP_*` env is present (only Gaia has it) via a small boot CLI (`mint-boot-token.ts`, smoke-tested against the real App). Token precedence is now freshest-first: App mint → `GITHUB_TOKEN` env (the per-habitat boot token Gaia injects into children — previously a stale *seeded vault* PAT would shadow it) → vault PAT (legacy).

30/30 tests pass in the github module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)