### PR TITLE
Twitter habitat: diagnose the per-user/operator token identity mismatch + log /connect traffic

### DIFF
--- a/examples/twitter-habitat/src/token-store.test.ts
+++ b/examples/twitter-habitat/src/token-store.test.ts
@@ -264,11 +264,14 @@ describe('XTokenStore — per-subject', () => {
 
 describe('perUserTokenStores', () => {
   function habitat(initial: Record<string, string>, currentUser?: string) {
-    const secrets = fakeSecrets(initial);
+    const store = new Map(Object.entries(initial));
     return {
-      getSecret: (n: string) => secrets.get(n),
-      setSecret: (n: string, v: string) => secrets.set(n, v),
+      getSecret: (n: string) => store.get(n),
+      setSecret: async (n: string, v: string) => {
+        store.set(n, v);
+      },
       getCurrentUserId: () => currentUser,
+      listSecretNames: () => [...store.keys()],
     };
   }
 
@@ -283,5 +286,67 @@ describe('perUserTokenStores', () => {
     const reg = perUserTokenStores(habitat({}, undefined));
     expect(reg.currentSubject()).toBeUndefined();
     expect(reg.current()).toBe(reg.current());
+  });
+});
+
+describe('perUserTokenStores — connectError', () => {
+  function habitat(initial: Record<string, string>, currentUser?: string) {
+    const store = new Map(Object.entries(initial));
+    return {
+      getSecret: (n: string) => store.get(n),
+      setSecret: async (n: string, v: string) => {
+        store.set(n, v);
+      },
+      getCurrentUserId: () => currentUser,
+      listSecretNames: () => [...store.keys()],
+    };
+  }
+
+  it('tells a known speaker to connect their own account', () => {
+    const reg = perUserTokenStores(habitat({}, 'carol'));
+    const e = reg.connectError();
+    expect(e.kind).toBe('needs_x_connect');
+    expect(e.error).toMatch(/your user identity/i);
+  });
+
+  it('diagnoses the identity mismatch: no speaker but per-user tokens exist', () => {
+    const reg = perUserTokenStores(
+      habitat({ 'TWITTER_REFRESH_TOKEN:carol': 'rt-carol' }, undefined),
+    );
+    const e = reg.connectError();
+    expect(e.kind).toBe('needs_x_connect');
+    // The money hint: the account IS connected, the request just can't see it.
+    expect(e.error).toMatch(/1 X account\(s\) ARE connected/);
+    expect(e.error).toMatch(/detach and re-attach/i);
+    // Never leak the connected subject or the token.
+    expect(e.error).not.toContain('carol');
+    expect(e.error).not.toContain('rt-carol');
+  });
+
+  it('falls back to the bootstrap message when nothing is stored', () => {
+    const reg = perUserTokenStores(habitat({}, undefined));
+    const e = reg.connectError();
+    expect(e.kind).toBe('needs_x_connect');
+    expect(e.error).toMatch(/OAuth bootstrap/);
+  });
+
+  it('does not count the shared operator key as a per-user connection', () => {
+    // Shared key present but empty-string lookups aside, a *set* shared key
+    // means refresh would have been attempted — connectError is only reached
+    // when the lookup failed, so treat a lone shared key as "nothing per-user".
+    const reg = perUserTokenStores(habitat({ TWITTER_REFRESH_TOKEN: 'rt' }, undefined));
+    const e = reg.connectError();
+    expect(e.error).toMatch(/OAuth bootstrap/);
+  });
+
+  it('copes with habitats that do not expose listSecretNames', () => {
+    const reg = perUserTokenStores({
+      getSecret: () => undefined,
+      setSecret: async () => {},
+      getCurrentUserId: () => undefined,
+    });
+    const e = reg.connectError();
+    expect(e.kind).toBe('needs_x_connect');
+    expect(e.error).toMatch(/OAuth bootstrap/);
   });
 });

--- a/examples/twitter-habitat/src/token-store.ts
+++ b/examples/twitter-habitat/src/token-store.ts
@@ -58,6 +58,8 @@ interface HabitatLike {
   setSecret(name: string, value: string): Promise<void>;
   /** The verified speaking user (ADR 0003) when present — keys per-user tokens. */
   getCurrentUserId?(): string | undefined;
+  /** Secret names, no values — lets {@link perUserTokenStores} diagnose which token keys exist. */
+  listSecretNames?(): string[];
 }
 
 /** Adapt a `Habitat` (or anything with getSecret/setSecret) into a {@link SecretStore}. */
@@ -196,6 +198,58 @@ export function perUserTokenStores(habitat: HabitatLike) {
         bySubject.set(key, store);
       }
       return store;
+    },
+    /**
+     * Actionable "connect X" error for the read tools' needs_reauth catch.
+     *
+     * Looks at which token keys actually exist (names only) to tell apart the
+     * three ways a lookup comes up empty:
+     *
+     *  1. Speaker known, no token under their key → they haven't connected;
+     *     point them at the connect flow.
+     *  2. No speaker (request authenticated with the shared HABITAT_API_KEY /
+     *     off the A2A path) but per-user tokens EXIST → identity mismatch:
+     *     someone connected via the per-user flow, yet this request can only
+     *     see the shared operator token. The usual cause is an agent
+     *     attachment that predates per-user JWT dispatch — re-attaching in
+     *     the habitats app fixes it. Without this hint the habitat says
+     *     "not connected" to a user who just connected, which reads as the
+     *     OAuth silently failing.
+     *  3. Nothing stored at all → original bootstrap message.
+     */
+    connectError(): { error: string; kind: 'needs_x_connect' } {
+      const subject = habitat.getCurrentUserId?.();
+      const names = habitat.listSecretNames?.() ?? [];
+      const perUserCount = names.filter((n) =>
+        n.startsWith(`${X_REFRESH_TOKEN_SECRET}:`),
+      ).length;
+      if (subject) {
+        return {
+          error:
+            "Your X account isn't connected yet for your user identity. " +
+            'Connect it from the habitats app (the agent’s "Connect your X account" flow) and try again.',
+          kind: 'needs_x_connect',
+        };
+      }
+      if (perUserCount > 0) {
+        return {
+          error:
+            `This request arrived without a per-user identity (shared operator key), so only the ` +
+            `shared operator X token is visible — and none is set. However, ${perUserCount} X ` +
+            `account(s) ARE connected under per-user identities. This usually means the agent ` +
+            `attachment still dispatches with the legacy shared bearer while the X connect flow ` +
+            `stored the token under the connecting user’s identity. Fix: detach and re-attach ` +
+            `this agent in the habitats app so messages carry per-user identity (JWT) — the ` +
+            `already-connected account will then be found. (Alternatively, an operator can ` +
+            `connect a habitat-wide account.)`,
+          kind: 'needs_x_connect',
+        };
+      }
+      return {
+        error:
+          'Twitter is not authenticated. Connect an X account (or run the OAuth bootstrap) for this habitat.',
+        kind: 'needs_x_connect',
+      };
     },
   };
 }

--- a/examples/twitter-habitat/tools/bookmarks/handler.ts
+++ b/examples/twitter-habitat/tools/bookmarks/handler.ts
@@ -49,13 +49,7 @@ export default (habitat: unknown) => {
         return { count: bookmarks.length, bookmarks };
       } catch (err) {
         if (err instanceof XAuthError && err.kind === 'needs_reauth') {
-          const sub = userTokens.currentSubject();
-          return {
-            error: sub
-              ? "Your X account isn't connected yet. Connect it in the habitats app to see your bookmarks."
-              : 'Twitter is not authenticated. Connect an X account (or run the OAuth bootstrap) for this habitat.',
-            kind: 'needs_x_connect',
-          };
+          return userTokens.connectError();
         }
         return { error: err instanceof Error ? err.message : String(err) };
       }

--- a/examples/twitter-habitat/tools/mentions/handler.ts
+++ b/examples/twitter-habitat/tools/mentions/handler.ts
@@ -45,13 +45,7 @@ export default (habitat: unknown) => {
         return { count: mentions.length, mentions };
       } catch (err) {
         if (err instanceof XAuthError && err.kind === 'needs_reauth') {
-          const sub = userTokens.currentSubject();
-          return {
-            error: sub
-              ? "Your X account isn't connected yet. Connect it in the habitats app to see your mentions."
-              : 'Twitter is not authenticated. Connect an X account (or run the OAuth bootstrap) for this habitat.',
-            kind: 'needs_x_connect',
-          };
+          return userTokens.connectError();
         }
         return { error: err instanceof Error ? err.message : String(err) };
       }

--- a/examples/twitter-habitat/tools/my_timeline/handler.ts
+++ b/examples/twitter-habitat/tools/my_timeline/handler.ts
@@ -48,13 +48,7 @@ export default (habitat: unknown) => {
         return { count: posts.length, posts };
       } catch (err) {
         if (err instanceof XAuthError && err.kind === 'needs_reauth') {
-          const sub = userTokens.currentSubject();
-          return {
-            error: sub
-              ? "Your X account isn't connected yet. Connect it in the habitats app to see your timeline."
-              : 'Twitter is not authenticated. Connect an X account (or run the OAuth bootstrap) for this habitat.',
-            kind: 'needs_x_connect',
-          };
+          return userTokens.connectError();
         }
         return { error: err instanceof Error ? err.message : String(err) };
       }

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -392,6 +392,10 @@ export async function startContainerServer(
 			const shouldLog =
 				path.startsWith("/api/") ||
 				path.startsWith("/agents/") ||
+				// The connect flow (ADR 0004 §7) must be auditable — an OAuth
+				// callback that stores a token invisibly is undebuggable.
+				path === "/connect" ||
+				path.startsWith("/connect/") ||
 				path === "/mcp" ||
 				path === "/a2a" ||
 				path === "/health";


### PR DESCRIPTION
## The incident (prod, 2026-07-10)

A user completed `/connect/x` at 17:40:24 UTC (token stored as `TWITTER_REFRESH_TOKEN:<sub>`), asked for bookmarks at 17:40:49 — and the habitat answered *"Twitter is not authenticated"*. Two compounding causes:

1. **Identity mismatch, silently misreported.** The agent attachment in the habitats SaaS predates per-user JWT dispatch (`config.audience` unset), so chats arrive on the shared `HABITAT_API_KEY` → `bearer-user` sentinel → no speaker → the token store reads the shared operator key `TWITTER_REFRESH_TOKEN`, which doesn't exist. The user's token was right there under their per-user key; the error claimed nothing was connected.
2. **The connect flow is invisible in logs.** `shouldLog` in `container-server.ts` covered `/api/*`, `/mcp`, `/a2a`, `/health` — but not `/connect/*`. The OAuth callback that writes the token left no trace, so from the logs it looked like the connect never happened.

## Changes

- `perUserTokenStores().connectError()` (token-store): builds the `needs_x_connect` error by inspecting which token **keys** exist (names only — no values, no subs leak). Three cases: speaker known but not connected → point at the connect flow; **no speaker but per-user tokens exist → explain the mismatch and advise detaching/re-attaching the agent so dispatch mints per-user JWTs**; nothing stored → original bootstrap message.
- `bookmarks` / `mentions` / `my_timeline` handlers: use `connectError()` instead of three copies of static strings.
- `container-server`: log `/connect` and `/connect/*` requests. Path only — `parseRoute` strips the query string, so authorization codes and `?jwt=` grants never reach the logs.

## Tests

- 5 new tests for `connectError()` (per-user hint, mismatch hint with leak assertions, bootstrap fallback, lone shared key, habitat without `listSecretNames`).
- `examples/twitter-habitat`: 53/53 pass. `packages/habitat` web tests: 22/22 pass.

## Not in this PR

The SaaS-side root cause (attachments created before JWT-capability detection never get `audience` backfilled; the card-refresh action only updates name/description) belongs in the habitats repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016L8wuWr5FDJRoqgJ3RGuzM