### PR TITLE
Agent card: annotate declared credentials with live configured status

### DIFF
--- a/packages/habitat/src/a2a-handler.ts
+++ b/packages/habitat/src/a2a-handler.ts
@@ -83,6 +83,13 @@ export interface RequiredCredential {
   required: boolean;
   type: "secret" | "oauth";
   connectPath?: string;
+  /**
+   * Whether the habitat already holds this credential (annotated at card-serve
+   * time from the live secret store; names checked, values never exposed). An
+   * attaching client should treat a configured credential as satisfied instead
+   * of asking the operator to re-enter a value gaia already manages.
+   */
+  configured?: boolean;
 }
 
 /** An A2A AgentCard plus our `requiredCredentials` extension. */

--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -460,6 +460,23 @@ export async function startContainerServer(
 							organization: serverName,
 							url: publicBase,
 						};
+					// Annotate declared credentials with live configured status (names
+					// only — never values). Gaia seeds operator credentials into the
+					// habitat's vault; without this flag an attaching client re-asks
+					// the operator for secrets the habitat already holds. Computed at
+					// serve time (not boot) so it tracks /api/secrets writes and
+					// connect-flow token mints.
+					const declared = (
+						handler.agentCard as {
+							requiredCredentials?: Array<{ name: string }>;
+						}
+					).requiredCredentials;
+					if (declared?.length) {
+						card.requiredCredentials = declared.map((c) => ({
+							...c,
+							configured: habitat.isSecretAvailable(c.name),
+						}));
+					}
 					// Advertise the per-user connect surface as an A2A extension when a
 					// connector is registered (self-describing for the SaaS).
 					if (connectors.size > 0) {


### PR DESCRIPTION
Gaia seeds operator credentials into each habitat's vault (`secretBindings` → `seedVolume`), but the agent card declares `requiredCredentials` with no status signal. The habitats SaaS attach form renders the card verbatim, so operators get asked to re-type client ids and API keys the habitat already holds — every attach, every re-attach.

Cards now annotate each declared credential with `configured` (boolean via `isSecretAvailable`, computed at card-serve time so it stays fresh across `/api/secrets` writes and connect-flow mints; only names are checked, values never leave the habitat).

Paired SaaS change (habitats repo): the attach form renders `configured: true` credentials as "✓ already configured — managed by the habitat" instead of a required password field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016L8wuWr5FDJRoqgJ3RGuzM