### PR TITLE
feat(a2a): log which credential each request carried

### DIFF
--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -616,6 +616,18 @@ export async function startContainerServer(
 									email: user.email,
 								}
 							: undefined;
+					// Ground truth for identity debugging: which credential this
+					// request actually carried. Sub is prefix-truncated — enough to
+					// correlate with a connect, never a full identity in the logs.
+					console.log(
+						`[${new Date().toISOString()}] a2a auth: ${
+							speaker
+								? `jwt sub=${speaker.userId.slice(0, 8)}…`
+								: user
+									? "shared bearer (operator)"
+									: "none (open)"
+						}`,
+					);
 					const addr = httpServer.address();
 					const actualPort =
 						typeof addr === "object" && addr ? addr.port : port;


### PR DESCRIPTION
One line per /a2a request — "jwt sub=<8-char prefix>…", "shared bearer
(operator)", or "none (open)" — so identity-mismatch bugs (per-user token
stored, bearer dispatch reading the shared key) are diagnosable from
container logs instead of session-transcript archaeology.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016L8wuWr5FDJRoqgJ3RGuzM
