### PR TITLE
fix(a2a): keep the verified speaker bound across streaming responses

### DIFF
--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -649,28 +649,35 @@ export async function startContainerServer(
 					}
 
 					try {
-						const result = await runWithSpeaker(speaker, () =>
-							handler.transportHandler.handle(parsedBody),
-						);
-						if (
-							result &&
-							typeof (result as any)[Symbol.asyncIterator] === "function"
-						) {
-							// Streaming response — SSE
-							res.writeHead(200, {
-								"Content-Type": "text/event-stream",
-								"Cache-Control": "no-cache",
-								Connection: "keep-alive",
-							});
-							const generator = result as AsyncGenerator<any>;
-							for await (const event of generator) {
-								res.write(`data: ${JSON.stringify(event)}\n\n`);
+						// The ENTIRE handle-and-consume must run inside runWithSpeaker:
+						// for message/stream, handle() only returns an async generator —
+						// the executor (and every tool's getCurrentUserId()) runs while
+						// the generator is consumed. Consuming it outside the ALS scope
+						// silently drops the verified speaker, so per-user credentials
+						// resolve to the shared operator on the streaming path while
+						// working fine on message/send (found in prod 2026-07-11).
+						await runWithSpeaker(speaker, async () => {
+							const result = await handler.transportHandler.handle(parsedBody);
+							if (
+								result &&
+								typeof (result as any)[Symbol.asyncIterator] === "function"
+							) {
+								// Streaming response — SSE
+								res.writeHead(200, {
+									"Content-Type": "text/event-stream",
+									"Cache-Control": "no-cache",
+									Connection: "keep-alive",
+								});
+								const generator = result as AsyncGenerator<any>;
+								for await (const event of generator) {
+									res.write(`data: ${JSON.stringify(event)}\n\n`);
+								}
+								res.end();
+							} else {
+								// Single JSON-RPC response
+								sendJson(res, result);
 							}
-							res.end();
-						} else {
-							// Single JSON-RPC response
-							sendJson(res, result);
-						}
+						});
 					} catch (error) {
 						console.error(
 							`[container] A2A error: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/habitat/src/identity/agent-speaker-context.test.ts
+++ b/packages/habitat/src/identity/agent-speaker-context.test.ts
@@ -61,4 +61,34 @@ describe("agent-speaker-context", () => {
     expect(seen.a).toBe("a");
     expect(seen.b).toBe("b");
   });
+
+  // The message/stream trap (prod, 2026-07-11): transportHandler.handle()
+  // returns an async generator whose body — where the executor and tools run —
+  // executes at CONSUMPTION time. These two tests pin the semantics: a
+  // generator consumed outside the runWithSpeaker scope loses the speaker
+  // (the bug), while wrapping the whole consumption keeps it (the fix in
+  // container-server's /a2a route).
+  it("async generator consumed OUTSIDE the scope loses the speaker (the trap)", async () => {
+    async function* tools(): AsyncGenerator<string | undefined> {
+      yield getSpeaker()?.userId;
+    }
+    // handle()-style: create the generator inside the scope…
+    const gen = runWithSpeaker({ userId: "stream-user" }, () => tools());
+    // …but consume it outside (what the /a2a route used to do).
+    const seen: (string | undefined)[] = [];
+    for await (const v of gen) seen.push(v);
+    expect(seen).toEqual([undefined]);
+  });
+
+  it("async generator consumed INSIDE the scope keeps the speaker (the fix)", async () => {
+    async function* tools(): AsyncGenerator<string | undefined> {
+      await Promise.resolve();
+      yield getSpeaker()?.userId;
+    }
+    const seen: (string | undefined)[] = [];
+    await runWithSpeaker({ userId: "stream-user" }, async () => {
+      for await (const v of tools()) seen.push(v);
+    });
+    expect(seen).toEqual(["stream-user"]);
+  });
 });


### PR DESCRIPTION
runWithSpeaker wrapped only transportHandler.handle() — but for
message/stream that returns an async generator, and the executor (and
every tool's getCurrentUserId()) runs while the generator is consumed,
which happened OUTSIDE the AsyncLocalStorage scope. The verified JWT
speaker silently vanished on the streaming path: per-user credentials
resolved to the shared operator key, so a user's freshly connected X
account read as "not connected" even though the habitat logged the
verified sub on the same request. message/send resolved inside the
callback, masking the bug in non-streaming tests.

The /a2a route now runs handle() AND the full generator consumption
inside one runWithSpeaker scope. Two regression tests pin the generator
ALS semantics (outside = lost, inside = kept).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016L8wuWr5FDJRoqgJ3RGuzM
