### PR TITLE
fix(a2a): publish artifact-updates before the terminal message

### DIFF
--- a/packages/habitat/src/a2a-handler.test.ts
+++ b/packages/habitat/src/a2a-handler.test.ts
@@ -414,6 +414,22 @@ describe("HabitatAgentExecutor — artifact URLs", () => {
 		);
 	});
 
+	it("publishes artifact-updates BEFORE the final message (terminal-event order)", async () => {
+		// The A2A transport ends the stream at the agent message — anything
+		// published after it never reaches the wire. Verified against live SSE
+		// 2026-07-11: artifacts emitted post-message were silently dropped.
+		const host = await makeHost();
+		await seedArtifact(host, "/files/artifacts/2026-x-foo.png");
+		const executor = new HabitatAgentExecutor(host, instantBridge());
+		const { bus, events } = fakeEventBus();
+		await executor.execute(requestContext(), bus);
+		const artifactIdx = events.findIndex((e) => e.kind === "artifact-update");
+		const messageIdx = events.findIndex((e) => e.kind === "message");
+		expect(artifactIdx).toBeGreaterThan(-1);
+		expect(messageIdx).toBeGreaterThan(-1);
+		expect(artifactIdx).toBeLessThan(messageIdx);
+	});
+
 	it("leaves URIs relative when no origin resolver is provided (back-compat)", async () => {
 		const host = await makeHost();
 		await seedArtifact(host, "/files/artifacts/2026-x-foo.png");

--- a/packages/habitat/src/a2a-handler.ts
+++ b/packages/habitat/src/a2a-handler.ts
@@ -314,6 +314,20 @@ export class HabitatAgentExecutor implements AgentExecutor {
                 }
               : undefined;
 
+            // Artifacts BEFORE the final message: the A2A transport treats the
+            // agent message as the stream's terminal event, so anything
+            // published after it never reaches the wire (verified against the
+            // live SSE 2026-07-11 — artifact-update frames were silently
+            // dropped and no consumer ever saw a published artifact).
+            for (const artifact of artifacts) {
+              eventBus.publish({
+                kind: "artifact-update",
+                taskId,
+                contextId,
+                artifact,
+              });
+            }
+
             eventBus.publish({
               kind: "message",
               messageId: randomUUID(),
@@ -323,15 +337,6 @@ export class HabitatAgentExecutor implements AgentExecutor {
               taskId,
               ...(usageMetadata ? { metadata: usageMetadata } : {}),
             } satisfies A2AMessage);
-
-            for (const artifact of artifacts) {
-              eventBus.publish({
-                kind: "artifact-update",
-                taskId,
-                contextId,
-                artifact,
-              });
-            }
 
             eventBus.finished();
           },


### PR DESCRIPTION
The A2A transport treats the agent message as the stream's terminal
event, so artifact-update events published after it never reached the
wire — verified against the live prod SSE 2026-07-11: a chat that
published an artifact streamed task/status/message frames and zero
artifact-update frames. No consumer (habitats SaaS included) has ever
received a published artifact over message/stream.

onDone now publishes artifact-updates first, then the final message,
then finished. New test pins the order (the existing artifact test
found the event order-agnostically, which is how this hid).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016L8wuWr5FDJRoqgJ3RGuzM
