### PR TITLE
feat(tools): room_history — pull the SaaS room's discussion on demand (#102 v2)

### DIFF
--- a/packages/habitat/src/container-server.ts
+++ b/packages/habitat/src/container-server.ts
@@ -179,6 +179,23 @@ async function serveStatic(
 	}
 }
 
+/**
+ * Best-effort `iss` from an already-VERIFIED compact JWT (auth ran first —
+ * this only reads a claim, it never trusts an unverified token for auth).
+ */
+function jwtIssuer(token: string): string | undefined {
+	try {
+		const payload = JSON.parse(
+			Buffer.from(token.split(".")[1], "base64url").toString("utf8"),
+		) as { iss?: unknown };
+		return typeof payload.iss === "string" && /^https?:\/\//.test(payload.iss)
+			? payload.iss
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 // ── Route matching ────────────────────────────────────────────────
 
 function parseRoute(url: string): {
@@ -608,12 +625,21 @@ export async function startContainerServer(
 					// unbound so the executor keeps its thread-scoped
 					// `a2a:${contextId}` fallback. Never discard a verified per-user
 					// identity by silently falling back to anonymous.
+					// The raw grant + its issuer ride along for callback tools
+					// (room_history, #102 v2): the tool presents the grant back to
+					// its issuer, so history access is authorized as the speaker.
+					const rawAuth = req.headers.authorization ?? "";
+					const rawGrant = rawAuth.startsWith("Bearer ")
+						? rawAuth.slice(7)
+						: undefined;
 					const speaker =
 						user && user.userId !== "bearer-user"
 							? {
 									userId: user.userId,
 									displayName: user.displayName,
 									email: user.email,
+									grant: rawGrant,
+									issuer: rawGrant ? jwtIssuer(rawGrant) : undefined,
 								}
 							: undefined;
 					// Ground truth for identity debugging: which credential this

--- a/packages/habitat/src/identity/agent-speaker-context.ts
+++ b/packages/habitat/src/identity/agent-speaker-context.ts
@@ -27,6 +27,14 @@ export interface Speaker {
   displayName?: string;
   /** Email, if the grant carried one. */
   email?: string;
+  /**
+   * The raw verified grant this request presented (compact JWT). Callback
+   * tools (room_history, #102 v2) present it back to its issuer so the SaaS
+   * authorizes the call as the SPEAKER — never a habitat-wide credential.
+   */
+  grant?: string;
+  /** The grant's `iss` — the SaaS origin callback tools call back to. */
+  issuer?: string;
 }
 
 const storage = new AsyncLocalStorage<Speaker>();

--- a/packages/habitat/src/tool-sets.ts
+++ b/packages/habitat/src/tool-sets.ts
@@ -25,6 +25,7 @@ import { createExecTools } from "./tools/exec-tools.js";
 import { createProvisionTools } from "./tools/provision-tools.js";
 import { createArtifactTools } from "./tools/artifact-tools.js";
 import { createUIResourceTools } from "./tools/ui-resource-tools.js";
+import { createRoomHistoryTools } from "./tools/room-history-tools.js";
 import { resolveProjectDir } from "./config.js";
 import { accessSync } from "node:fs";
 
@@ -217,6 +218,14 @@ export const inspectToolSet: ToolSet = {
 };
 
 /** All standard tool sets that a typical habitat includes (host orchestrator). */
+/** Room history (#102 v2): pull the SaaS room's recent discussion on demand. */
+export const roomHistoryToolSet: ToolSet = {
+  name: "room-history",
+  description:
+    "Fetch the recent discussion from the habitats room this conversation lives in",
+  createTools: () => createRoomHistoryTools(),
+};
+
 export const standardToolSets: ToolSet[] = [
   fileToolSet,
   timeToolSet,
@@ -230,6 +239,7 @@ export const standardToolSets: ToolSet[] = [
   selfModifyToolSet,
   inspectToolSet,
   remoteAgentToolSet,
+  roomHistoryToolSet,
 ];
 
 /**
@@ -248,6 +258,7 @@ export const containerToolSets: ToolSet[] = [
   uiResourceToolSet,
   inspectToolSet,
   remoteAgentToolSet,
+  roomHistoryToolSet,
 ];
 
 /**
@@ -266,4 +277,5 @@ export const managedContainerToolSets: ToolSet[] = [
   uiResourceToolSet,
   inspectToolSet,
   remoteAgentToolSet,
+  roomHistoryToolSet,
 ];

--- a/packages/habitat/src/tools/room-history-tools.test.ts
+++ b/packages/habitat/src/tools/room-history-tools.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { createRoomHistoryTools } from "./room-history-tools.js";
+import { runWithSpeaker } from "../identity/agent-speaker-context.js";
+
+function jsonResponse(body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+describe("room_history tool (#102 v2)", () => {
+	it("presents the speaker's grant back to its issuer and returns messages", async () => {
+		const calls: { url: string; init: RequestInit }[] = [];
+		const fetchImpl = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+			calls.push({ url: String(url), init: init ?? {} });
+			return jsonResponse({
+				habitatId: "h-1",
+				messages: [{ author: "Will", text: "ship it", at: "2026-07-11T00:00:00Z" }],
+			});
+		}) as unknown as typeof fetch;
+
+		const tools = createRoomHistoryTools({ fetchImpl });
+		const out = await runWithSpeaker(
+			{
+				userId: "u-1",
+				grant: "jwt-abc",
+				issuer: "https://habitats.example.com",
+			},
+			() =>
+				(tools.room_history as { execute: (a: { limit?: number }) => Promise<unknown> }).execute(
+					{ limit: 5 },
+				),
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].url).toBe("https://habitats.example.com/api/agent/room-history");
+		expect((calls[0].init.headers as Record<string, string>).authorization).toBe(
+			"Bearer jwt-abc",
+		);
+		expect(JSON.parse(String(calls[0].init.body))).toEqual({ limit: 5 });
+		expect(out).toMatchObject({
+			habitatId: "h-1",
+			messages: [{ author: "Will", text: "ship it" }],
+		});
+	});
+
+	it("refuses gracefully without a per-user grant (operator / dev runs)", async () => {
+		const fetchImpl = vi.fn() as unknown as typeof fetch;
+		const tools = createRoomHistoryTools({ fetchImpl });
+		// No speaker bound at all:
+		const out = await (
+			tools.room_history as { execute: (a: object) => Promise<unknown> }
+		).execute({});
+		expect(out).toMatchObject({ kind: "no_room_scope" });
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	it("surfaces HTTP failures as tool errors, never throws", async () => {
+		const fetchImpl = vi.fn(
+			async () => new Response("membership required", { status: 403 }),
+		) as unknown as typeof fetch;
+		const tools = createRoomHistoryTools({ fetchImpl });
+		const out = await runWithSpeaker(
+			{ userId: "u-1", grant: "g", issuer: "https://x.example" },
+			() =>
+				(tools.room_history as { execute: (a: object) => Promise<unknown> }).execute({}),
+		);
+		expect(out).toMatchObject({
+			error: expect.stringContaining("403"),
+		});
+	});
+});

--- a/packages/habitat/src/tools/room-history-tools.ts
+++ b/packages/habitat/src/tools/room-history-tools.ts
@@ -1,0 +1,80 @@
+/**
+ * room_history — pull the SaaS room's recent discussion on demand (#102 v2).
+ *
+ * A habitat agent's session only contains its own runs; the room's wider
+ * discussion (humans talking, other agents) lives SaaS-side. This tool
+ * presents the CURRENT SPEAKER's verified grant back to its issuer (the
+ * habitats SaaS), which authorizes the read as that user and returns the
+ * room's recent main-timeline messages as text.
+ *
+ * Only works on per-user (JWT) runs — the shared operator key carries no
+ * grant and no room scope, and dev/open runs have no issuer to call.
+ */
+
+import { tool, type Tool } from "ai";
+import { z } from "zod";
+import { getSpeaker } from "../identity/agent-speaker-context.js";
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+export type FetchLike = typeof fetch;
+
+export function createRoomHistoryTools(options?: {
+  fetchImpl?: FetchLike;
+}): Record<string, Tool> {
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  return {
+    room_history: tool({
+      description:
+        "Fetch the recent discussion from this room (the habitats app room " +
+        "this conversation lives in) — messages from all participants, not " +
+        "just ones addressed to you. Use when asked to summarize or refer " +
+        "to the recent discussion.",
+      inputSchema: z.object({
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe("How many recent messages to fetch (default 30)."),
+      }),
+      async execute({ limit }) {
+        const speaker = getSpeaker();
+        if (!speaker?.grant || !speaker.issuer) {
+          return {
+            error:
+              "Room history is only available when a signed-in habitats user " +
+              "invokes me (per-user grant); this request has no room scope.",
+            kind: "no_room_scope",
+          };
+        }
+        try {
+          const res = await fetchImpl(
+            `${speaker.issuer}/api/agent/room-history`,
+            {
+              method: "POST",
+              headers: {
+                authorization: `Bearer ${speaker.grant}`,
+                "content-type": "application/json",
+              },
+              body: JSON.stringify({ limit: limit ?? 30 }),
+              signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+            },
+          );
+          if (!res.ok) {
+            const detail = (await res.text().catch(() => "")).slice(0, 300);
+            return {
+              error: `room-history fetch failed: ${res.status}${detail ? ` — ${detail}` : ""}`,
+            };
+          }
+          return (await res.json()) as unknown;
+        } catch (err) {
+          return {
+            error: `room-history fetch threw: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      },
+    }),
+  };
+}


### PR DESCRIPTION
An agent's session only contains its own runs; the room's wider
discussion lives SaaS-side. The new room_history tool presents the
CURRENT SPEAKER's verified grant back to its issuer (the habitats SaaS
POST /api/agent/room-history, paired SaaS PR), which authorizes the
read as that user and returns recent room messages as text.

- Speaker context carries the raw verified grant + its `iss` (read from
  the already-verified token; never used for auth itself).
- Tool refuses cleanly on operator/dev runs (no grant → no room scope)
  and surfaces HTTP failures as tool errors.
- Registered in standard, container, and managed-container tool sets.

3 new tests (grant presentation, no-scope refusal, HTTP failure).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016L8wuWr5FDJRoqgJ3RGuzM
