### PR TITLE
fix(cognition): hoist system prompt to `system` option — unbreak ai@7 LLM turns

### DIFF
--- a/packages/core/src/cognition/request-options.test.ts
+++ b/packages/core/src/cognition/request-options.test.ts
@@ -27,6 +27,32 @@ function makeInteractionWithMessage(stimulus: Stimulus): Interaction {
   return i;
 }
 
+describe('buildRequestOptions — system message hoisting (AI SDK v7)', () => {
+  it('hoists the stimulus system prompt into `system`, not `messages`', () => {
+    // AI SDK v7 rejects role:"system" entries inside `messages` — the
+    // Interaction stores the stimulus prompt as messages[0] (role:system),
+    // so the builder must move it to the top-level `system` option.
+    // (Regression: the ai@5→7 bump broke every habitat LLM turn with
+    // "System messages are not allowed in the prompt or messages fields".)
+    const stim = new Stimulus({ role: 'a helpful test assistant' });
+    const interaction = makeInteractionWithMessage(stim);
+
+    const opts = buildRequestOptions({
+      interaction,
+      model: {} as any,
+      config: {},
+      label: 'test',
+      streaming: true,
+    });
+
+    expect(typeof opts.system).toBe('string');
+    expect(opts.system as string).toMatch(/test assistant/);
+    const msgs = opts.messages as Array<{ role: string }>;
+    expect(msgs.every((m) => m.role !== 'system')).toBe(true);
+    expect(msgs.some((m) => m.role === 'user')).toBe(true);
+  });
+});
+
 describe('buildRequestOptions — token-cap regression guards', () => {
   it('does NOT inject maxOutputTokens when no caller/stimulus set one', () => {
     const stim = new Stimulus({ role: 'test' });

--- a/packages/core/src/cognition/request-options.ts
+++ b/packages/core/src/cognition/request-options.ts
@@ -53,6 +53,19 @@ export function buildRequestOptions(input: RequestOptionsInput): Record<string, 
     messages = ensureGoogleThoughtSignatures(messages);
   }
 
+  // AI SDK v5→v7: streamText/generateText reject `system`-role entries inside
+  // `messages` — the system prompt must be the top-level `system` option.
+  // The Interaction stores the stimulus prompt as messages[0] (role:system),
+  // so hoist every system entry out into a single joined `system` string.
+  const systemParts: string[] = [];
+  messages = messages.filter((m) => {
+    if (m.role !== "system") return true;
+    const c = m.content;
+    systemParts.push(typeof c === "string" ? c : JSON.stringify(c));
+    return false;
+  });
+  const system = systemParts.filter(Boolean).join("\n\n") || undefined;
+
   // DO NOT cap output tokens here. This runner powers benchmarks that
   // measure model quality — truncating generation silently invalidates
   // scores (especially for thinking-on models that need room to reason).
@@ -61,6 +74,7 @@ export function buildRequestOptions(input: RequestOptionsInput): Record<string, 
   // the regression guard.
   const options: Record<string, unknown> = {
     model,
+    ...(system ? { system } : {}),
     messages,
     temperature: interaction.modelDetails.temperature,
     topP: interaction.modelDetails.topP,


### PR DESCRIPTION
The ai 5→7 bump (#216) made streamText/generateText reject role:"system"
entries inside `messages` ("System messages are not allowed in the
prompt or messages fields. Use the instructions option instead"). The
Interaction stores the stimulus prompt as messages[0] (role:system), so
EVERY habitat LLM turn failed after the fleet rebuilt on ai@7 — observed
in prod: @Twitter "what are today's trending topics?" → streamText error.

buildRequestOptions (the single chokepoint for both stream + generate)
now filters system-role messages out of `messages` and joins them into
the top-level `system` option. Regression test asserts the split. The
mocked-bridge habitat tests never exercised the real streamText call, so
this slipped through the merge — the new test guards the actual builder.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016L8wuWr5FDJRoqgJ3RGuzM
