### PR TITLE
test: real-path CI guards for the two classes that broke prod today

### DIFF
--- a/packages/core/src/cognition/real-stream-contract.test.ts
+++ b/packages/core/src/cognition/real-stream-contract.test.ts
@@ -1,0 +1,117 @@
+/**
+ * REAL streamText contract guard.
+ *
+ * Every other runner/bridge test mocks above the AI SDK, so nothing exercises
+ * the *actual* `streamText()` call — which is where the AI SDK validates the
+ * request shape. That gap let ai@5→7 ship a fleet-wide outage: v7 rejects
+ * system-role entries inside `messages` ("System messages are not allowed in
+ * the prompt or messages fields"), and no CI test caught it because the real
+ * call never ran.
+ *
+ * This test drives the real `streamText` from `ai` with a MockLanguageModel
+ * (no API key, deterministic) over the exact options `buildRequestOptions`
+ * produces from a system-prompted Interaction. If an `ai` bump changes the
+ * request contract, this fails at merge time — not in prod.
+ */
+import { describe, it, expect } from "vitest";
+import { streamText, generateText } from "ai";
+import {
+  MockLanguageModelV3,
+  convertArrayToReadableStream,
+} from "ai/test";
+import { buildRequestOptions } from "./request-options.js";
+import { Stimulus } from "../stimulus/stimulus.js";
+import { Interaction } from "../interaction/core/interaction.js";
+import type { ModelDetails } from "./types.js";
+
+function systemPromptedInteraction(): Interaction {
+  const details: ModelDetails = { name: "mock", provider: "openrouter" };
+  // Stimulus role becomes the system prompt (messages[0], role:system) —
+  // the exact shape that broke on ai@7.
+  const i = new Interaction(details, new Stimulus({ role: "a terse assistant" }));
+  (i as any).messages.push({ role: "user", content: "say ok" });
+  return i;
+}
+
+function mockTextModel(text: string): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: "stream-start", warnings: [] },
+        { type: "text-start", id: "1" },
+        { type: "text-delta", id: "1", delta: text },
+        { type: "text-end", id: "1" },
+        {
+          type: "finish",
+          finishReason: "stop",
+          usage: { inputTokens: 5, outputTokens: 1, totalTokens: 6 },
+        },
+      ]),
+    }),
+    doGenerate: async () => ({
+      content: [{ type: "text", text }],
+      finishReason: "stop",
+      usage: { inputTokens: 5, outputTokens: 1, totalTokens: 6 },
+      warnings: [],
+    }),
+  });
+}
+
+describe("real streamText contract (no API key)", () => {
+  it("streams a system-prompted interaction without an SDK validation throw", async () => {
+    const interaction = systemPromptedInteraction();
+    const options = buildRequestOptions({
+      interaction,
+      model: mockTextModel("ok"),
+      config: {},
+      label: "test",
+      streaming: true,
+    });
+    // The regression: on ai@7 this threw here if `messages` carried a
+    // system entry. It must produce the mock's text instead.
+    const result = streamText(options as Parameters<typeof streamText>[0]);
+    let out = "";
+    for await (const delta of result.textStream) out += delta;
+    expect(out).toBe("ok");
+  });
+
+  it("generateText path accepts the same options shape", async () => {
+    const interaction = systemPromptedInteraction();
+    const options = buildRequestOptions({
+      interaction,
+      model: mockTextModel("done"),
+      config: {},
+      label: "test",
+      streaming: false,
+    });
+    const result = await generateText(options as Parameters<typeof generateText>[0]);
+    expect(result.text).toBe("done");
+  });
+
+  it("the model actually received the system prompt (hoisted, not dropped)", async () => {
+    const interaction = systemPromptedInteraction();
+    let seenSystem: string | undefined;
+    const model = new MockLanguageModelV3({
+      doStream: async (opts) => {
+        const sys = opts.prompt.find((m) => m.role === "system");
+        seenSystem = sys && typeof sys.content === "string" ? sys.content : undefined;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: "stream-start", warnings: [] },
+            { type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 0, totalTokens: 1 } },
+          ]),
+        };
+      },
+    });
+    const options = buildRequestOptions({
+      interaction,
+      model,
+      config: {},
+      label: "test",
+      streaming: true,
+    });
+    const result = streamText(options as Parameters<typeof streamText>[0]);
+    for await (const _ of result.textStream) { /* drain */ }
+    expect(seenSystem).toMatch(/terse assistant/);
+  });
+});

--- a/packages/core/src/stimulus/tools/loader.test.ts
+++ b/packages/core/src/stimulus/tools/loader.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Directory tool-loader guards. A tool directory registers ONLY when it has a
+ * TOOL.md (front-matter name+description); a handler.ts alone is silently
+ * skipped. That silent-skip shipped a Twitter tool that never registered
+ * (handler present, importable, but absent from the tool list) — these tests
+ * pin the contract so the next missing TOOL.md fails in CI, not in prod.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadToolsFromDirectory } from "./loader.js";
+
+const HANDLER = `import { tool } from "ai";
+import { z } from "zod";
+export default () => tool({
+  description: "x",
+  inputSchema: z.object({}),
+  execute: async () => ({ ok: true }),
+});
+`;
+
+let root: string;
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "loader-test-"));
+});
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+async function makeTool(name: string, opts: { md?: boolean }) {
+  const dir = join(root, "tools", name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "handler.ts"), HANDLER);
+  if (opts.md) {
+    await writeFile(
+      join(dir, "TOOL.md"),
+      `---\nname: ${name}\ndescription: "does a thing"\n---\nbody`,
+    );
+  }
+}
+
+describe("loadToolsFromDirectory", () => {
+  it("registers a tool that has TOOL.md + handler.ts", async () => {
+    await makeTool("with_md", { md: true });
+    const tools = await loadToolsFromDirectory(root, "tools", {});
+    expect(Object.keys(tools)).toContain("with_md");
+    expect(typeof (tools.with_md as { execute?: unknown }).execute).toBe("function");
+  });
+
+  it("SILENTLY SKIPS a tool with handler.ts but no TOOL.md (the trap)", async () => {
+    await makeTool("no_md", { md: false });
+    const tools = await loadToolsFromDirectory(root, "tools", {});
+    expect(Object.keys(tools)).not.toContain("no_md");
+  });
+
+  it("loads only the complete tools when a dir is mixed", async () => {
+    await makeTool("good", { md: true });
+    await makeTool("orphan", { md: false });
+    const tools = await loadToolsFromDirectory(root, "tools", {});
+    expect(Object.keys(tools).sort()).toEqual(["good"]);
+  });
+});


### PR DESCRIPTION
Every runner/bridge test mocks above the AI SDK and every real-model test
is *.integration (excluded from CI, needs keys) — so nothing exercised
the actual streamText call or tool registration. That gap shipped four
prod breaks in one day (ai@5→7 system-message rejection, provider majors,
a tool with no TOOL.md that silently never registered).

Two deterministic, key-free guards that run in the normal CI suite:

- real-stream-contract.test.ts: drives the REAL streamText/generateText
  from `ai` with a MockLanguageModelV3 over the exact options
  buildRequestOptions produces from a system-prompted Interaction.
  Verified it catches the regression: reverting the system-hoist fix
  fails it with the precise prod error (AI_InvalidPromptError: System
  messages are not allowed…). This would have blocked the ai@7 merge.

- tools/loader.test.ts: a tool dir with handler.ts but no TOOL.md must be
  skipped (the silent-skip that dropped the trends tool), and one WITH
  TOOL.md must register.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016L8wuWr5FDJRoqgJ3RGuzM
