### PR TITLE
chore(types): CoreMessage→ModelMessage, target ES2022, monorepo tsc-clean + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run unit tests
         run: pnpm test:run
+      - name: Run typecheck
+        run: pnpm typecheck
       - name: Run lint
         run: pnpm lint

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docs:build": "pnpm run docs:sync-assets && vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "knip": "knip",
-    "typecheck": "tsc --noEmit -p packages/core && tsc --noEmit -p packages/protocols && tsc --noEmit -p packages/habitat && tsc --noEmit -p packages/sessions && tsc --noEmit -p packages/cli && tsc --noEmit -p packages/ui && tsc --noEmit -p packages/evaluation"
+    "typecheck": "for d in packages/*/tsconfig.json; do tsc --noEmit -p \"$d\" || exit 1; done"
   },
   "keywords": [
     "llm",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "docs:dev": "pnpm run docs:sync-assets && vitepress dev docs",
     "docs:build": "pnpm run docs:sync-assets && vitepress build docs",
     "docs:preview": "vitepress preview docs",
-    "knip": "knip"
+    "knip": "knip",
+    "typecheck": "tsc --noEmit -p packages/core && tsc --noEmit -p packages/protocols && tsc --noEmit -p packages/habitat && tsc --noEmit -p packages/sessions && tsc --noEmit -p packages/cli && tsc --noEmit -p packages/ui && tsc --noEmit -p packages/evaluation"
   },
   "keywords": [
     "llm",

--- a/packages/cli/src/models.ts
+++ b/packages/cli/src/models.ts
@@ -183,7 +183,7 @@ export const modelsCommand = new Command('models')
   .action(async (options: CommandOptions) => {
     try {
       // Handle EPIPE errors (e.g., when piping to head)
-      process.stdout.on('error', (err) => {
+      process.stdout.on('error', (err: NodeJS.ErrnoException) => {
         if (err.code === 'EPIPE') {
           process.exit(0);
         }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/packages/core/src/cognition/message-normalizer.ts
+++ b/packages/core/src/cognition/message-normalizer.ts
@@ -1,4 +1,4 @@
-import { type CoreMessage } from "ai";
+import { type ModelMessage } from "ai";
 
 /**
  * Clean provider options to remove nested structures that cause AI SDK v5 Zod validation to fail.
@@ -51,8 +51,8 @@ export function cleanProviderOptions(providerOptions: any): {
  * Outputs only schema-allowed keys for tool-call and tool-result parts to avoid strict validation failures.
  */
 export function normalizeToModelMessages(
-  messages: CoreMessage[],
-): CoreMessage[] {
+  messages: ModelMessage[],
+): ModelMessage[] {
   return messages.map((msg) => {
     if (msg.role !== "assistant" && msg.role !== "tool") return msg;
     if (!Array.isArray(msg.content)) return msg;
@@ -136,7 +136,7 @@ export function normalizeToModelMessages(
       }
       return part;
     });
-    return { ...msg, content: newContent } as unknown as CoreMessage;
+    return { ...msg, content: newContent } as unknown as ModelMessage;
   });
 }
 
@@ -146,8 +146,8 @@ export function normalizeToModelMessages(
  * accepts the request. See https://ai.google.dev/gemini-api/docs/thought-signatures
  */
 export function ensureGoogleThoughtSignatures(
-  messages: CoreMessage[],
-): CoreMessage[] {
+  messages: ModelMessage[],
+): ModelMessage[] {
   return messages.map((msg) => {
     if (msg.role !== "assistant" || !Array.isArray(msg.content)) return msg;
     const content = msg.content as unknown as Array<Record<string, unknown>>;
@@ -185,6 +185,6 @@ export function ensureGoogleThoughtSignatures(
         },
       };
     });
-    return { ...msg, content: newContent } as unknown as CoreMessage;
+    return { ...msg, content: newContent } as unknown as ModelMessage;
   });
 }

--- a/packages/core/src/cognition/observers.ts
+++ b/packages/core/src/cognition/observers.ts
@@ -182,7 +182,8 @@ export function cleanChatObserver(): StreamObserver {
 export async function createMarkdownChatObserver(): Promise<StreamObserver & { end(): void }> {
   let MarkdownStreamClass: any = null;
   try {
-    const mod = await import("streammark");
+    const streammarkPkg = "streammark"; // non-literal: optional untyped dep
+    const mod = await import(streammarkPkg);
     MarkdownStreamClass = mod.MarkdownStream;
   } catch {
     // streammark not available — fall through to raw output

--- a/packages/core/src/cognition/request-options.ts
+++ b/packages/core/src/cognition/request-options.ts
@@ -1,5 +1,5 @@
 import {
-  type CoreMessage,
+  type ModelMessage,
   type LanguageModel,
   type ToolSet,
   type JSONValue,

--- a/packages/core/src/cognition/runner.test.ts
+++ b/packages/core/src/cognition/runner.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { z } from 'zod';
-import type { CoreMessage } from 'ai';
+import type { ModelMessage } from 'ai';
 import { modelMessageSchema } from 'ai';
 import { BaseModelRunner } from './runner.js';
 import { normalizeToModelMessages } from './message-normalizer.js';
@@ -14,7 +14,7 @@ import { Stimulus } from '../stimulus/stimulus.js';
 
 const messagesArraySchema = z.array(modelMessageSchema);
 
-function normalizeViaRunner(messages: CoreMessage[]): CoreMessage[] {
+function normalizeViaRunner(messages: ModelMessage[]): ModelMessage[] {
   return normalizeToModelMessages(messages);
 }
 
@@ -38,7 +38,7 @@ afterEach(() => {
 
 describe('Runner ModelMessage normalization', () => {
   it('normalizes assistant tool-call parts (args->input, experimental_providerMetadata->providerOptions)', () => {
-    const messages: CoreMessage[] = [
+    const messages: ModelMessage[] = [
       { role: 'system', content: 'You are a helper.' },
       { role: 'user', content: 'Use the tool.' },
       {
@@ -52,7 +52,7 @@ describe('Runner ModelMessage normalization', () => {
             experimental_providerMetadata: { google: { thought_signature: 'abc' } },
           },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       {
         role: 'tool',
         content: [
@@ -64,7 +64,7 @@ describe('Runner ModelMessage normalization', () => {
             experimental_providerMetadata: {},
           },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       { role: 'user', content: 'Thanks.' },
     ];
     const normalized = normalizeViaRunner(messages);
@@ -80,7 +80,7 @@ describe('Runner ModelMessage normalization', () => {
   });
 
   it('produces messages that pass ModelMessage[] validation (tool round then follow-up)', () => {
-    const messages: CoreMessage[] = [
+    const messages: ModelMessage[] = [
       { role: 'system', content: 'You are a helpful assistant.' },
       { role: 'user', content: 'List my agents.' },
       {
@@ -93,7 +93,7 @@ describe('Runner ModelMessage normalization', () => {
             input: { path: '.' },
           },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       {
         role: 'tool',
         content: [
@@ -104,7 +104,7 @@ describe('Runner ModelMessage normalization', () => {
             output: { type: 'text' as const, value: 'config.json' },
           },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       { role: 'user', content: 'Can you create a new agent?' },
     ];
     const normalized = normalizeViaRunner(messages);
@@ -113,19 +113,19 @@ describe('Runner ModelMessage normalization', () => {
   });
 
   it('produces valid messages when tool-result output is json or error-text', () => {
-    const messages: CoreMessage[] = [
+    const messages: ModelMessage[] = [
       { role: 'system', content: 'Helper.' },
       { role: 'user', content: 'Run tool.' },
       {
         role: 'assistant',
         content: [{ type: 'tool-call', toolCallId: 'c1', toolName: 't1', input: {} }],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       {
         role: 'tool',
         content: [
           { type: 'tool-result', toolCallId: 'c1', toolName: 't1', output: { type: 'json' as const, value: { ok: true } } },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
     ];
     const normalized = normalizeViaRunner(messages);
     const parsed = messagesArraySchema.safeParse(normalized);
@@ -136,7 +136,7 @@ describe('Runner ModelMessage normalization', () => {
 
   it('multi-turn: streaming tool-call + tool-result + follow-up user message', () => {
     // Simulates what streamText produces: assistant with tool-call, tool result, assistant text, then another user turn
-    const messages: CoreMessage[] = [
+    const messages: ModelMessage[] = [
       { role: 'system', content: 'You are a helpful assistant.' },
       { role: 'user', content: 'What files are in the project?' },
       {
@@ -149,7 +149,7 @@ describe('Runner ModelMessage normalization', () => {
             input: { path: '.' },
           },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       {
         role: 'tool',
         content: [
@@ -160,7 +160,7 @@ describe('Runner ModelMessage normalization', () => {
             output: { type: 'text' as const, value: 'README.md\npackage.json\nsrc/' },
           },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       { role: 'assistant', content: 'I found README.md, package.json, and a src/ directory.' },
       { role: 'user', content: 'Now read the README.' },
     ];
@@ -171,7 +171,7 @@ describe('Runner ModelMessage normalization', () => {
 
   it('legacy args field: normalization converts args to input', () => {
     // makeResult() used to write `args` instead of `input` — verify normalization fixes it
-    const messages: CoreMessage[] = [
+    const messages: ModelMessage[] = [
       { role: 'system', content: 'Helper.' },
       { role: 'user', content: 'Read the config.' },
       {
@@ -184,7 +184,7 @@ describe('Runner ModelMessage normalization', () => {
             args: { path: 'config.json' },  // legacy field
           },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       {
         role: 'tool',
         content: [
@@ -195,7 +195,7 @@ describe('Runner ModelMessage normalization', () => {
             output: { type: 'json' as const, value: { name: 'test' } },
           },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       { role: 'user', content: 'What is the name field?' },
     ];
     const normalized = normalizeViaRunner(messages);
@@ -211,7 +211,7 @@ describe('Runner ModelMessage normalization', () => {
 
   it('multiple tool-call rounds in sequence', () => {
     // Two complete tool-call rounds followed by another user message
-    const messages: CoreMessage[] = [
+    const messages: ModelMessage[] = [
       { role: 'system', content: 'Helper.' },
       { role: 'user', content: 'List agents then show details of the first.' },
       // Round 1: list
@@ -220,26 +220,26 @@ describe('Runner ModelMessage normalization', () => {
         content: [
           { type: 'tool-call', toolCallId: 'r1', toolName: 'list_agents', input: {} },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       {
         role: 'tool',
         content: [
           { type: 'tool-result', toolCallId: 'r1', toolName: 'list_agents', output: { type: 'json' as const, value: [{ id: 'agent-1' }] } },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       // Round 2: details
       {
         role: 'assistant',
         content: [
           { type: 'tool-call', toolCallId: 'r2', toolName: 'show_agent', input: { id: 'agent-1' } },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       {
         role: 'tool',
         content: [
           { type: 'tool-result', toolCallId: 'r2', toolName: 'show_agent', output: { type: 'json' as const, value: { id: 'agent-1', name: 'Test' } } },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       { role: 'assistant', content: 'Agent agent-1 is named Test.' },
       { role: 'user', content: 'Delete it.' },
     ];
@@ -249,20 +249,20 @@ describe('Runner ModelMessage normalization', () => {
   });
 
   it('output edge case: undefined/null output is normalized to empty text', () => {
-    const messages: CoreMessage[] = [
+    const messages: ModelMessage[] = [
       { role: 'user', content: 'Do something.' },
       {
         role: 'assistant',
         content: [
           { type: 'tool-call', toolCallId: 'e1', toolName: 'noop', input: {} },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       {
         role: 'tool',
         content: [
           { type: 'tool-result', toolCallId: 'e1', toolName: 'noop', output: undefined },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
     ];
     const normalized = normalizeViaRunner(messages);
     const parsed = messagesArraySchema.safeParse(normalized);
@@ -274,20 +274,20 @@ describe('Runner ModelMessage normalization', () => {
   });
 
   it('output edge case: raw string output is wrapped in text format', () => {
-    const messages: CoreMessage[] = [
+    const messages: ModelMessage[] = [
       { role: 'user', content: 'Search.' },
       {
         role: 'assistant',
         content: [
           { type: 'tool-call', toolCallId: 's1', toolName: 'search', input: { q: 'test' } },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       {
         role: 'tool',
         content: [
           { type: 'tool-result', toolCallId: 's1', toolName: 'search', output: 'Found 3 results' },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
     ];
     const normalized = normalizeViaRunner(messages);
     const parsed = messagesArraySchema.safeParse(normalized);
@@ -299,20 +299,20 @@ describe('Runner ModelMessage normalization', () => {
   });
 
   it('output edge case: raw object without type/value is wrapped in json format', () => {
-    const messages: CoreMessage[] = [
+    const messages: ModelMessage[] = [
       { role: 'user', content: 'Get data.' },
       {
         role: 'assistant',
         content: [
           { type: 'tool-call', toolCallId: 'o1', toolName: 'fetch', input: {} },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       {
         role: 'tool',
         content: [
           { type: 'tool-result', toolCallId: 'o1', toolName: 'fetch', output: { status: 200, data: [1, 2, 3] } },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
     ];
     const normalized = normalizeViaRunner(messages);
     const parsed = messagesArraySchema.safeParse(normalized);
@@ -326,7 +326,7 @@ describe('Runner ModelMessage normalization', () => {
   it('makeResult-style messages with args + experimental_providerMetadata validate after normalization', () => {
     // Simulates messages as they would be written by makeResult() before the fix,
     // with the legacy `args` field and Google thought_signature metadata
-    const messages: CoreMessage[] = [
+    const messages: ModelMessage[] = [
       { role: 'system', content: 'You are a habitat agent.' },
       { role: 'user', content: 'Clone the repo.' },
       {
@@ -342,7 +342,7 @@ describe('Runner ModelMessage normalization', () => {
             },
           },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       {
         role: 'tool',
         content: [
@@ -354,7 +354,7 @@ describe('Runner ModelMessage normalization', () => {
             experimental_providerMetadata: {},
           },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       { role: 'assistant', content: 'The repo has been cloned.' },
       { role: 'user', content: 'Now run it.' },
     ];
@@ -373,14 +373,14 @@ describe('Runner ModelMessage normalization', () => {
 
   it('output edge case: undefined values inside output.value are stripped (SDK rejects undefined in JsonValue)', () => {
     // This is the exact crash case: agents_list returns objects with optional fields that are undefined
-    const messages: CoreMessage[] = [
+    const messages: ModelMessage[] = [
       { role: 'user', content: 'What agents exist?' },
       {
         role: 'assistant',
         content: [
           { type: 'tool-call', toolCallId: 'al1', toolName: 'agents_list', input: {} },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       {
         role: 'tool',
         content: [
@@ -402,7 +402,7 @@ describe('Runner ModelMessage normalization', () => {
             },
           },
         ],
-      } as unknown as CoreMessage,
+      } as unknown as ModelMessage,
       { role: 'assistant', content: 'You have one agent: trmnl-image-agent.' },
       { role: 'user', content: 'Run it please.' },
     ];

--- a/packages/core/src/cognition/runner.ts
+++ b/packages/core/src/cognition/runner.ts
@@ -14,7 +14,7 @@ import {
   clearRateLimitState,
 } from "../rate-limit/rate-limit.js";
 import {
-  type CoreMessage,
+  type ModelMessage,
   LanguageModel,
   generateText,
   generateObject,
@@ -317,7 +317,7 @@ export class BaseModelRunner implements ModelRunner {
                     }
                     return part;
                   }),
-                } as unknown as CoreMessage);
+                } as unknown as ModelMessage);
                 pendingToolCalls.length = 0;
                 interaction.notifyTranscriptUpdate?.();
               }
@@ -347,7 +347,7 @@ export class BaseModelRunner implements ModelRunner {
                     output,
                   },
                 ],
-              } as unknown as CoreMessage);
+              } as unknown as ModelMessage);
               interaction.notifyTranscriptUpdate?.();
               observer?.onToolResult?.({
                 toolCallId,

--- a/packages/core/src/cognition/step-assembler.ts
+++ b/packages/core/src/cognition/step-assembler.ts
@@ -1,4 +1,4 @@
-import { type CoreMessage } from "ai";
+import { type ModelMessage } from "ai";
 import type { Interaction } from "../interaction/core/interaction.js";
 
 interface ToolCallEntry {
@@ -84,7 +84,7 @@ function addToolResultMessages(
             output: toToolResultOutput(out, tr.isError ?? false),
           },
         ],
-      } as unknown as CoreMessage);
+      } as unknown as ModelMessage);
       interaction.notifyTranscriptUpdate?.();
     }
   }
@@ -195,7 +195,7 @@ export async function assembleSteps(
     interaction.addMessage({
       role: "assistant",
       content: toolCalls.map(normalizeToolCall),
-    } as unknown as CoreMessage);
+    } as unknown as ModelMessage);
     interaction.notifyTranscriptUpdate?.();
     addToolResultMessages(interaction, toolCalls, toolResults);
     if (contentString) {

--- a/packages/core/src/cognition/types.ts
+++ b/packages/core/src/cognition/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { CoreMessage, LanguageModel } from "ai";
+import type { ModelMessage, LanguageModel } from "ai";
 import { TokenUsage, TokenUsageSchema } from "../costs/costs.js";
 import { CostBreakdown, CostBreakdownSchema } from "../costs/costs.js";
 
@@ -132,15 +132,15 @@ export const ModelResponseSchema = z.object({
    * — sufficient to replay the conversation without re-running the model.
    * Cached to disk so 2-pass / multi-turn evals can pick up the thread.
    *
-   * Typed as `z.unknown()` here because `CoreMessage` is a TS-only type
+   * Typed as `z.unknown()` here because `ModelMessage` is a TS-only type
    * (not a Zod schema); the exported `ModelResponse` type narrows the
-   * field to `CoreMessage[]` for callers.
+   * field to `ModelMessage[]` for callers.
    */
   messages: z.array(z.unknown()).optional(),
 });
 
 export type ModelResponse = Omit<z.infer<typeof ModelResponseSchema>, "messages"> & {
-  messages?: CoreMessage[];
+  messages?: ModelMessage[];
 };
 
 export const ScoreSchema = z.object({

--- a/packages/core/src/context/estimate-size.ts
+++ b/packages/core/src/context/estimate-size.ts
@@ -3,12 +3,12 @@
  * Uses character-based token estimate (chars/4); tiktoken can be added later for accuracy.
  */
 
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import type { ContextSizeEstimate } from "./types.js";
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 
-function messageToText(msg: CoreMessage): string {
+function messageToText(msg: ModelMessage): string {
   const parts: string[] = [];
   parts.push(`role:${(msg as { role?: string }).role ?? "unknown"}`);
   const content = (msg as { content?: unknown }).content;
@@ -39,7 +39,7 @@ function messageToText(msg: CoreMessage): string {
  * Estimate context size from messages.
  * Uses character count and chars/4 for estimated tokens (tiktoken can be integrated later for accuracy).
  */
-export function estimateContextSize(messages: CoreMessage[]): ContextSizeEstimate {
+export function estimateContextSize(messages: ModelMessage[]): ContextSizeEstimate {
   const messageCount = messages.length;
   let characterCount = 0;
   for (const msg of messages) {

--- a/packages/core/src/context/segment.ts
+++ b/packages/core/src/context/segment.ts
@@ -3,7 +3,7 @@
  * Convention: index 0 is system; segment is [start, end] inclusive of conversation messages only.
  */
 
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import type { CompactionSegment } from "./types.js";
 
 export interface GetCompactionSegmentOptions {
@@ -19,7 +19,7 @@ export interface GetCompactionSegmentOptions {
  * Returns null if there is no assistant message in range or segment is invalid.
  */
 export function getCompactionSegment(
-  messages: CoreMessage[],
+  messages: ModelMessage[],
   options: GetCompactionSegmentOptions = {}
 ): CompactionSegment | null {
   const { fromCheckpoint = false, checkpointIndex } = options;

--- a/packages/core/src/context/serialize-messages.ts
+++ b/packages/core/src/context/serialize-messages.ts
@@ -1,9 +1,9 @@
 /**
- * Serialize a slice of CoreMessage[] to text for compaction prompts.
+ * Serialize a slice of ModelMessage[] to text for compaction prompts.
  * Shortens or omits large tool outputs to keep the summarizer input bounded.
  */
 
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 
 const MAX_TOOL_RESULT_CHARS = 500;
 
@@ -36,7 +36,7 @@ function stringifyContent(content: unknown): string {
   return parts.join("\n");
 }
 
-export function serializeSegment(messages: CoreMessage[], start: number, end: number): string {
+export function serializeSegment(messages: ModelMessage[], start: number, end: number): string {
   const lines: string[] = [];
   for (let i = start; i <= end; i++) {
     const msg = messages[i] as { role?: string; content?: unknown; toolInvocations?: unknown[] };

--- a/packages/core/src/context/strategies/through-line-and-facts.ts
+++ b/packages/core/src/context/strategies/through-line-and-facts.ts
@@ -3,7 +3,7 @@
  * Omit in-call details (full tool outputs, step-by-step).
  */
 
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import { Stimulus } from "../../stimulus/stimulus.js";
 import { Interaction } from "../../interaction/core/interaction.js";
 import { serializeSegment } from "../serialize-messages.js";
@@ -52,7 +52,7 @@ export const throughLineAndFactsStrategy: CompactionStrategy = {
     const summary =
       typeof response.content === "string" ? response.content : String(response.content ?? "");
 
-    const replacementMessages: CoreMessage[] = [
+    const replacementMessages: ModelMessage[] = [
       {
         role: "system",
         content: `Previous context (condensed):\n${summary}`,

--- a/packages/core/src/context/strategies/truncate.ts
+++ b/packages/core/src/context/strategies/truncate.ts
@@ -2,7 +2,7 @@
  * Truncate: non-LLM strategy that replaces the segment with a short placeholder.
  */
 
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import type { CompactionInput, CompactionResult, CompactionStrategy } from "../types.js";
 
 export const truncateStrategy: CompactionStrategy = {
@@ -11,7 +11,7 @@ export const truncateStrategy: CompactionStrategy = {
   description: "Replace segment with a one-line placeholder; no LLM.",
   async compact(input: CompactionInput): Promise<CompactionResult> {
     const keepTurns = (input.options?.keepTurns as number) ?? 2;
-    const replacementMessages: CoreMessage[] = [
+    const replacementMessages: ModelMessage[] = [
       {
         role: "system",
         content: `(Earlier conversation omitted; last ${keepTurns} turns retained.)`,

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -2,12 +2,12 @@
  * Compaction types: input to strategies, result, and strategy interface.
  */
 
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import type { ModelDetails, ModelRunner } from "../cognition/types.js";
 
 export interface CompactionInput {
   /** Full context (strategy can see system if needed). */
-  messages: CoreMessage[];
+  messages: ModelMessage[];
   /** Index of first message to condense (1 = first message after system). */
   segmentStart: number;
   /** Index of last message to condense (inclusive). */
@@ -22,7 +22,7 @@ export interface CompactionInput {
 
 export interface CompactionResult {
   /** Messages to replace the segment (often a single summary message). */
-  replacementMessages: CoreMessage[];
+  replacementMessages: ModelMessage[];
 }
 
 export interface CompactionStrategy {

--- a/packages/core/src/dialogue/persist.ts
+++ b/packages/core/src/dialogue/persist.ts
@@ -11,7 +11,7 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import { writeSessionTranscript } from "../session-record/transcript-write.js";
 import { renderEventLine } from "./render.js";
 import type {
@@ -33,7 +33,7 @@ export interface DialogueMeta {
 export function dialogueEventsToCoreMessages(
   events: ReadonlyArray<DialogueEvent>,
   participants: ReadonlyArray<ParticipantInfo>,
-): CoreMessage[] {
+): ModelMessage[] {
   const kinds = new Map(participants.map((p) => [p.id, p.kind]));
   return events
     .filter((e) => e.content.trim())

--- a/packages/core/src/interaction/adapters/load-interaction.test.ts
+++ b/packages/core/src/interaction/adapters/load-interaction.test.ts
@@ -198,7 +198,7 @@ describe("interactionFromNormalizedSession", () => {
 				role: "assistant",
 				content: "[tool bash] {cmd:'ls'}",
 			}),
-			// This one is schema-invalid as a v5 CoreMessage (tool content must
+			// This one is schema-invalid as a v5 ModelMessage (tool content must
 			// be Array<ToolResultPart>, not a string) and must be dropped.
 			makeMessage({
 				id: "m3",

--- a/packages/core/src/interaction/adapters/load-interaction.ts
+++ b/packages/core/src/interaction/adapters/load-interaction.ts
@@ -12,7 +12,7 @@
  * See reports/2026-05-24-session-types-inventory.md for the full type lineage.
  */
 
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import type { ModelDetails } from "../../cognition/types.js";
 import type { Stimulus } from "../../stimulus/stimulus.js";
 import { calculateCost, type TokenUsage } from "../../costs/costs.js";
@@ -70,10 +70,10 @@ export function detectSourceFromSessionId(
  */
 function toCleanCoreMessages(
 	messages: NormalizedMessage[],
-): CoreMessage[] {
+): ModelMessage[] {
 	return messages
 		.filter((m) => m.role !== "tool")
-		.map((m) => ({ role: m.role, content: m.content }) as CoreMessage);
+		.map((m) => ({ role: m.role, content: m.content }) as ModelMessage);
 }
 
 /**
@@ -132,7 +132,7 @@ export function interactionFromNormalizedSession(
 		modelDetails,
 		stimulus,
 	);
-	// fromNormalizedSession's CoreMessage cast is { role, content }; we
+	// fromNormalizedSession's ModelMessage cast is { role, content }; we
 	// already filtered out tool-role messages above so what lands on
 	// interaction.messages is schema-clean for v5's ModelMessage union.
 	return interaction;

--- a/packages/core/src/interaction/analysis/digest.test.ts
+++ b/packages/core/src/interaction/analysis/digest.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, readFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { CoreMessage } from 'ai';
+import type { ModelMessage } from 'ai';
 
 // ─── Test parseCompactionResponse ───────────────────────────────────────────
 
@@ -16,12 +16,12 @@ import type { CoreMessage } from 'ai';
 // This is a unit test of the algorithm; the real function is identical.
 const MAX_SEGMENT_CHARS = 50_000;
 
-function estimateMessageSize(msg: CoreMessage): number {
+function estimateMessageSize(msg: ModelMessage): number {
   const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
   return content.length + 20;
 }
 
-function splitIntoSegments(messages: CoreMessage[]): { start: number; end: number }[] {
+function splitIntoSegments(messages: ModelMessage[]): { start: number; end: number }[] {
   if (messages.length === 0) return [];
   const segments: { start: number; end: number }[] = [];
   let segStart = 0;
@@ -47,7 +47,7 @@ describe('splitIntoSegments', () => {
   });
 
   it('returns single segment for small conversations', () => {
-    const msgs: CoreMessage[] = [
+    const msgs: ModelMessage[] = [
       { role: 'user', content: 'Hello' },
       { role: 'assistant', content: 'Hi there' },
     ];
@@ -58,7 +58,7 @@ describe('splitIntoSegments', () => {
   it('splits by content size, not message count', () => {
     // Create messages that together exceed MAX_SEGMENT_CHARS
     const bigContent = 'x'.repeat(30_000);
-    const msgs: CoreMessage[] = [
+    const msgs: ModelMessage[] = [
       { role: 'user', content: bigContent },
       { role: 'assistant', content: bigContent },
       { role: 'user', content: 'small' },
@@ -72,7 +72,7 @@ describe('splitIntoSegments', () => {
   });
 
   it('every message appears in exactly one segment', () => {
-    const msgs: CoreMessage[] = Array.from({ length: 100 }, (_, i) => ({
+    const msgs: ModelMessage[] = Array.from({ length: 100 }, (_, i) => ({
       role: i % 2 === 0 ? 'user' as const : 'assistant' as const,
       content: 'x'.repeat(1000),
     }));
@@ -87,7 +87,7 @@ describe('splitIntoSegments', () => {
   });
 
   it('handles single huge message', () => {
-    const msgs: CoreMessage[] = [
+    const msgs: ModelMessage[] = [
       { role: 'user', content: 'x'.repeat(100_000) },
     ];
     const segs = splitIntoSegments(msgs);

--- a/packages/core/src/interaction/analysis/session-digester.ts
+++ b/packages/core/src/interaction/analysis/session-digester.ts
@@ -6,7 +6,7 @@
  * discovery on top.
  */
 
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import type { ModelDetails } from "../../cognition/types.js";
 import type { SessionIndexEntry } from "../types/types.js";
 import type {
@@ -231,7 +231,7 @@ async function compactViaStrategy(
 	const runner = new BaseModelRunner();
 
 	if (strategy) {
-		const messages: CoreMessage[] = [
+		const messages: ModelMessage[] = [
 			{ role: "user", content: "placeholder" },
 			{ role: "user", content: text },
 			{ role: "assistant", content: "Acknowledged." },

--- a/packages/core/src/interaction/core/attachments.ts
+++ b/packages/core/src/interaction/core/attachments.ts
@@ -1,12 +1,12 @@
 import path from "path";
 import fs from "fs/promises";
 import { fileTypeFromBuffer } from "file-type";
-import { CoreMessage } from "ai";
+import { ModelMessage } from "ai";
 
 export async function buildAttachmentMessage(
   filePath: string,
   mimeType?: string,
-): Promise<CoreMessage> {
+): Promise<ModelMessage> {
   const filename = path.basename(filePath);
   console.log("Creating attachment for", filename);
   const fileBuffer = await fs.readFile(filePath);

--- a/packages/core/src/interaction/core/interaction.ts
+++ b/packages/core/src/interaction/core/interaction.ts
@@ -1,4 +1,4 @@
-import { CoreMessage } from "ai";
+import { ModelMessage } from "ai";
 import {
   ModelDetails,
   ModelOptions,
@@ -34,7 +34,7 @@ export class Interaction {
     sourceData?: Record<string, unknown>;
   };
 
-  public messages: CoreMessage[] = [];
+  public messages: ModelMessage[] = [];
   protected runner: ModelRunner;
   public userId: string = "default";
   public modelDetails: ModelDetails;
@@ -149,13 +149,13 @@ export class Interaction {
   }
 
   /** Optional callback invoked whenever messages change (e.g. so CLI can append transcript). */
-  onTranscriptUpdate?: (messages: CoreMessage[]) => void;
+  onTranscriptUpdate?: (messages: ModelMessage[]) => void;
 
-  setOnTranscriptUpdate(callback: (messages: CoreMessage[]) => void): void {
+  setOnTranscriptUpdate(callback: (messages: ModelMessage[]) => void): void {
     this.onTranscriptUpdate = callback;
   }
 
-  addMessage(message: CoreMessage): void {
+  addMessage(message: ModelMessage): void {
     this.messages.push(message);
     this.metadata.updated = new Date();
   }
@@ -236,7 +236,7 @@ export class Interaction {
     return this.tools !== undefined && Object.keys(this.tools).length > 0;
   }
 
-  getMessages(): CoreMessage[] {
+  getMessages(): ModelMessage[] {
     return this.messages;
   }
 

--- a/packages/core/src/interaction/core/normalize.ts
+++ b/packages/core/src/interaction/core/normalize.ts
@@ -1,4 +1,4 @@
-import { CoreMessage } from "ai";
+import { ModelMessage } from "ai";
 import type {
   NormalizedSession,
   NormalizedMessage,
@@ -17,7 +17,7 @@ interface InteractionMetadata {
  */
 export function interactionToNormalizedSession(
   id: string,
-  messages: CoreMessage[],
+  messages: ModelMessage[],
   metadata: InteractionMetadata,
 ): NormalizedSession {
   const normalizedMessages: NormalizedMessage[] = [];
@@ -231,7 +231,7 @@ export function normalizedSessionToMessages(
   updated: Date;
   source: SessionSource;
   sourceId: string;
-  messages: CoreMessage[];
+  messages: ModelMessage[];
   systemContent?: string;
 } {
   const systemMsg = session.messages.find((m) => m.role === "system");
@@ -245,7 +245,7 @@ export function normalizedSessionToMessages(
     messages: session.messages.map((m) => ({
       role: m.role,
       content: m.content,
-    })) as CoreMessage[],
+    })) as ModelMessage[],
     systemContent: systemMsg?.content,
   };
 }

--- a/packages/core/src/interaction/reflection/reflection.ts
+++ b/packages/core/src/interaction/reflection/reflection.ts
@@ -9,7 +9,7 @@
  * Interaction constructed to ask questions about other Interactions or
  * Explorations and executed with the existing model runner."
  */
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import { Stimulus } from "../../stimulus/stimulus.js";
 import { Interaction } from "../core/interaction.js";
 import type { Exploration } from "../types/domain-types.js";
@@ -108,14 +108,14 @@ export interface BuildContextOptions {
 /**
  * Build context messages describing one or more Explorations.
  *
- * Returns CoreMessage[] that can be injected into any Interaction's
+ * Returns ModelMessage[] that can be injected into any Interaction's
  * message list. Deterministic and testable — no LLM calls involved.
  */
 export function buildReflectionContext(
 	explorations: Exploration[],
 	options?: BuildContextOptions,
-): CoreMessage[] {
-	const messages: CoreMessage[] = [];
+): ModelMessage[] {
+	const messages: ModelMessage[] = [];
 
 	// System-level context
 	if (options?.systemContext) {

--- a/packages/core/src/interaction/search/ripgrep-scanner.ts
+++ b/packages/core/src/interaction/search/ripgrep-scanner.ts
@@ -178,7 +178,9 @@ function recordToHit(record: any): RawScanHit | null {
 			}
 			return { start: sm.start, end: sm.end, text };
 		})
-		.filter((x): x is { start: number; end: number; text: string } => x !== null);
+		.filter(
+			(x: { start: number; end: number; text: string } | null): x is { start: number; end: number; text: string } => x !== null,
+		);
 
 	return { filePath, lineNumber, matchedLine, submatches };
 }

--- a/packages/core/src/session-record/context-merge.ts
+++ b/packages/core/src/session-record/context-merge.ts
@@ -4,7 +4,7 @@
  */
 
 import { readFile } from "node:fs/promises";
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 
 import type { CompactionEventV1, LearningKind } from "./types.js";
 import { LEARNING_KINDS } from "./types.js";
@@ -54,7 +54,7 @@ export async function buildHabitatIntrospectionContextMessages(options: {
   maxCompactionBlocks?: number;
   maxLearningsChars?: number;
   maxTotalChars?: number;
-}): Promise<CoreMessage[]> {
+}): Promise<ModelMessage[]> {
   const learningsRoot = options.learningsRoot ?? options.sessionDir;
   const maxCompaction = options.maxCompactionBlocks ?? 12;
   const maxLearnings = options.maxLearningsChars ?? 24_000;
@@ -64,7 +64,7 @@ export async function buildHabitatIntrospectionContextMessages(options: {
   const store = new FileLearningsStore(learningsRoot);
   const learnings = await store.readAll();
 
-  const parts: CoreMessage[] = [];
+  const parts: ModelMessage[] = [];
 
   const slice = events.slice(-maxCompaction);
   if (slice.length > 0) {

--- a/packages/core/src/session-record/habitat-transcript-load.ts
+++ b/packages/core/src/session-record/habitat-transcript-load.ts
@@ -2,7 +2,7 @@
  * Load full Habitat session transcript: frozen `transcript.*.jsonl` segments then live `transcript.jsonl`.
  */
 
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import type { SessionMessage } from "../interaction/types/types.js";
 import type { UserMessageEntry, AssistantMessageEntry } from "../interaction/types/types.js";
 import { parseSessionFile } from "../interaction/persistence/session-parser.js";
@@ -48,9 +48,9 @@ export async function loadHabitatSessionTranscriptMessages(
 export async function loadRecentHabitatTranscriptCoreMessages(
   sessionDir: string,
   maxMessages: number,
-): Promise<CoreMessage[]> {
+): Promise<ModelMessage[]> {
   const raw = await loadHabitatSessionTranscriptMessages(sessionDir);
-  const messages: CoreMessage[] = [];
+  const messages: ModelMessage[] = [];
   for (const entry of raw) {
     if (entry.type === "user") {
       const content = (entry as UserMessageEntry).message.content;

--- a/packages/core/src/session-record/transcript-write.ts
+++ b/packages/core/src/session-record/transcript-write.ts
@@ -1,5 +1,5 @@
 /**
- * Convert CoreMessage[] to Claude-style JSONL for session transcript persistence.
+ * Convert ModelMessage[] to Claude-style JSONL for session transcript persistence.
  * Handles user messages, assistant messages with tool_use blocks, and tool results.
  *
  * Moved from src/habitat/transcript.ts to break the habitat ↔ ui circular
@@ -9,7 +9,7 @@
 import { randomUUID } from 'node:crypto';
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { CoreMessage } from 'ai';
+import type { ModelMessage } from 'ai';
 import type {
   UserMessageEntry,
   AssistantMessageEntry,
@@ -39,11 +39,11 @@ type VercelToolInvocation = {
   result?: unknown;
 };
 
-type ExtendedCoreMessage = CoreMessage & {
+type ExtendedCoreMessage = ModelMessage & {
   toolInvocations?: VercelToolInvocation[];
 };
 
-function extractContentBlocks(content: CoreMessage['content']): ContentBlock[] {
+function extractContentBlocks(content: ModelMessage['content']): ContentBlock[] {
   if (typeof content === 'string') {
     return content ? [{ type: 'text', text: content }] : [];
   }
@@ -136,11 +136,11 @@ function extractToolResultsFromInvocations(
 }
 
 /**
- * Convert CoreMessage[] to Claude-style JSONL (one JSON object per line).
+ * Convert ModelMessage[] to Claude-style JSONL (one JSON object per line).
  * @param reasoningForLastAssistant - When set, attach reasoning to the last assistant entry.
  */
 export function coreMessagesToJSONL(
-  messages: CoreMessage[],
+  messages: ModelMessage[],
   _sessionId?: string,
   reasoningForLastAssistant?: string
 ): string {
@@ -253,7 +253,7 @@ export function coreMessagesToJSONL(
  */
 export async function writeSessionTranscript(
   sessionDir: string,
-  messages: CoreMessage[],
+  messages: ModelMessage[],
   reasoningForLastAssistant?: string
 ): Promise<void> {
   const jsonl = coreMessagesToJSONL(messages, undefined, reasoningForLastAssistant);

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/packages/evaluation/src/evaluation/replay.ts
+++ b/packages/evaluation/src/evaluation/replay.ts
@@ -14,7 +14,7 @@
  */
 
 import fs from 'fs';
-import type { CoreMessage } from 'ai';
+import type { ModelMessage } from 'ai';
 import { Stimulus, type StimulusOptions } from '@umwelten/core/stimulus/stimulus.js';
 import { Interaction } from '@umwelten/core/interaction/core/interaction.js';
 import type { ModelDetails } from '@umwelten/core/cognition/types.js';
@@ -25,7 +25,7 @@ export interface TranscriptFile {
   provider: string;
   prompt: string;
   stimulusOptions: Omit<StimulusOptions, 'tools' | 'runnerType'>;
-  messages: CoreMessage[];
+  messages: ModelMessage[];
 }
 
 export interface ReplayOptions {

--- a/packages/evaluation/src/evaluation/suite.ts
+++ b/packages/evaluation/src/evaluation/suite.ts
@@ -24,7 +24,7 @@
 import fs from 'fs';
 import path from 'path';
 import { z } from 'zod';
-import type { CoreMessage } from 'ai';
+import type { ModelMessage } from 'ai';
 import { Stimulus, type StimulusOptions } from '@umwelten/core/stimulus/stimulus.js';
 import { SimpleEvaluation } from './strategies/simple-evaluation.js';
 import { EvaluationCache } from './caching/cache-service.js';
@@ -148,7 +148,7 @@ export interface TaskResultRecord {
    * it. Untruncated. Sidecar transcript file is written next to the
    * task result so the main JSON stays small for report consumers.
    */
-  messages?: CoreMessage[];
+  messages?: ModelMessage[];
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/packages/evaluation/tsconfig.json
+++ b/packages/evaluation/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/packages/habitat/src/beat-replay.ts
+++ b/packages/habitat/src/beat-replay.ts
@@ -3,7 +3,7 @@
  */
 
 import { readFile } from "node:fs/promises";
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import type { NormalizedMessage } from "@umwelten/core/interaction/types/normalized-types.js";
 import { Interaction } from "@umwelten/core/interaction/core/interaction.js";
 import { Habitat } from "./habitat.js";
@@ -20,14 +20,14 @@ export interface PulledBeatPayload {
 }
 
 /**
- * Convert NormalizedMessage[] to CoreMessage[] for replay.
+ * Convert NormalizedMessage[] to ModelMessage[] for replay.
  * When dropLastAssistant is true, the last message is removed if it's assistant (so the model regenerates it).
  */
 export function normalizedMessagesToCoreForReplay(
   normalized: NormalizedMessage[],
   dropLastAssistant: boolean,
-): CoreMessage[] {
-  const out: CoreMessage[] = [];
+): ModelMessage[] {
+  const out: ModelMessage[] = [];
   const toDrop =
     dropLastAssistant &&
     normalized.length > 0 &&
@@ -86,7 +86,7 @@ export function normalizedMessagesToCoreForReplay(
                 output,
               },
             ],
-          } as CoreMessage);
+          } as ModelMessage);
         }
         i = j;
       } else {
@@ -114,7 +114,7 @@ export function normalizedMessagesToCoreForReplay(
             output,
           },
         ],
-      } as CoreMessage);
+      } as ModelMessage);
       i++;
     } else {
       i++;
@@ -126,7 +126,7 @@ export function normalizedMessagesToCoreForReplay(
 function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    process.stdin.on("data", (chunk) => chunks.push(chunk));
+    process.stdin.on("data", (chunk: Buffer) => chunks.push(chunk));
     process.stdin.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
     process.stdin.on("error", reject);
   });

--- a/packages/habitat/src/bridge/channel-bridge.ts
+++ b/packages/habitat/src/bridge/channel-bridge.ts
@@ -12,7 +12,7 @@
  * Platform adapters become thin: receive message → call bridge → format + send.
  */
 
-import type { CoreMessage } from 'ai';
+import type { ModelMessage } from 'ai';
 import type { AgentHost } from '../types.js';
 import { Interaction } from '@umwelten/core/interaction/core/interaction.js';
 import { Stimulus } from '@umwelten/core/stimulus/stimulus.js';

--- a/packages/habitat/src/bridge/types.ts
+++ b/packages/habitat/src/bridge/types.ts
@@ -4,7 +4,7 @@
  * Slack, Teams, Web) and the Habitat core.
  */
 
-import type { CoreMessage } from 'ai';
+import type { ModelMessage } from 'ai';
 import type { ModelResponse } from '@umwelten/core/cognition/types.js';
 import type { AgentEntry, NativeSessionRef } from '../types.js';
 

--- a/packages/habitat/src/slash-commands.ts
+++ b/packages/habitat/src/slash-commands.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Interaction } from "@umwelten/core/interaction/core/interaction.js";
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import {
 	estimateContextSize,
 	listCompactionStrategies,
@@ -30,7 +30,7 @@ export interface SlashCommand {
 	run(args: string, ctx: SlashCommandContext): Promise<void> | void;
 }
 
-function formatContextSize(messages: CoreMessage[]): string {
+function formatContextSize(messages: ModelMessage[]): string {
 	const size = estimateContextSize(messages);
 	const kTokens =
 		size.estimatedTokens >= 1000

--- a/packages/habitat/src/tools/external-interaction-tools.ts
+++ b/packages/habitat/src/tools/external-interaction-tools.ts
@@ -230,7 +230,7 @@ export function createExternalInteractionTools(
 
       const out: { role: string; content: string }[] = [];
       const max = limit ?? 1e9;
-      // Interaction.messages is CoreMessage[]. We filtered out tool-role
+      // Interaction.messages is ModelMessage[]. We filtered out tool-role
       // messages in interactionFromNormalizedSession, and the runner's
       // role union is "user" | "assistant" | "system" | "tool" — so we
       // only surface user/assistant turns here for the conversation view.

--- a/packages/habitat/tsconfig.json
+++ b/packages/habitat/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/packages/protocols/tsconfig.json
+++ b/packages/protocols/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/packages/sessions/tsconfig.json
+++ b/packages/sessions/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/packages/ui/src/cli/repl.ts
+++ b/packages/ui/src/cli/repl.ts
@@ -22,7 +22,7 @@ import type { Interaction } from "@umwelten/core/interaction/core/interaction.js
 import type { InteractionStore } from "@umwelten/core/interaction/persistence/interaction-store.js";
 import { cliStdoutObserver } from "@umwelten/core/cognition/observers.js";
 import { estimateContextSize } from "@umwelten/core/context/index.js";
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 
 export interface ReplOptions {
 	interaction: Interaction;
@@ -34,7 +34,7 @@ export interface ReplOptions {
 	assistantLabel?: string;
 }
 
-function formatContextSize(messages: CoreMessage[]): string {
+function formatContextSize(messages: ModelMessage[]): string {
 	const size = estimateContextSize(messages);
 	const kTokens =
 		size.estimatedTokens >= 1000

--- a/packages/ui/src/discord/DiscordAdapter.tsx
+++ b/packages/ui/src/discord/DiscordAdapter.tsx
@@ -17,7 +17,7 @@ import {
   type NewsChannel,
   type ThreadChannel,
 } from "discord.js";
-import type { CoreMessage } from "ai";
+import type { ModelMessage } from "ai";
 import { loadRecentHabitatTranscriptCoreMessages } from "@umwelten/core/session-record/habitat-transcript-load.js";
 import path from "node:path";
 import fs from "node:fs/promises";
@@ -83,7 +83,7 @@ export interface DiscordAdapterConfig {
   ) => Promise<{ sessionId: string; sessionDir: string }>;
   writeTranscript?: (
     sessionDir: string,
-    messages: CoreMessage[],
+    messages: ModelMessage[],
     reasoning?: string,
   ) => Promise<void>;
   startNewThread?: (

--- a/packages/ui/src/telegram/TelegramAdapter.tsx
+++ b/packages/ui/src/telegram/TelegramAdapter.tsx
@@ -1,6 +1,6 @@
 import { Bot, Context } from "grammy";
 import { hydrateFiles, FileFlavor } from "@grammyjs/files";
-import { type CoreMessage } from "ai";
+import { type ModelMessage } from "ai";
 import { Interaction } from "@umwelten/core/interaction/core/interaction.js";
 import { Stimulus } from "@umwelten/core/stimulus/stimulus.js";
 import { ModelDetails } from "@umwelten/core/cognition/types.js";
@@ -20,7 +20,7 @@ export interface TelegramAdapterConfig {
   mediaDir?: string; // Deprecated: Directory where media files will be stored (use getSessionMediaDir instead)
   getSessionMediaDir?: (chatId: number) => Promise<string>; // Function to get session-specific media directory
   getSessionDir?: (chatId: number) => Promise<{ sessionId: string; sessionDir: string }>; // For transcript persistence
-  writeTranscript?: (sessionDir: string, messages: import("ai").CoreMessage[], reasoning?: string) => Promise<void>;
+  writeTranscript?: (sessionDir: string, messages: import("ai").ModelMessage[], reasoning?: string) => Promise<void>;
   /** Called when user sends /reset or /start so a new session directory is created for the next messages */
   startNewThread?: (chatId: number) => Promise<void>;
   /** Number of recent user+assistant message pairs to restore from transcript on restart (default 4) */

--- a/packages/ui/src/tui/introspect/DashboardApp.test.tsx
+++ b/packages/ui/src/tui/introspect/DashboardApp.test.tsx
@@ -118,8 +118,6 @@ function makeEntry(
 		sourceSession: session,
 		modifiedMs:
 			overrides.modifiedMs ?? new Date(session.modified).getTime(),
-		createdMs:
-			overrides.createdMs ?? new Date(session.created).getTime(),
 		filePath: undefined,
 		digest: overrides.digest ?? null,
 		analyzedIn: overrides.analyzedIn ?? [],

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/packages/umwelten/package.json
+++ b/packages/umwelten/package.json
@@ -35,5 +35,8 @@
     "@umwelten/evaluation": "workspace:*",
     "@umwelten/ui": "workspace:*",
     "@umwelten/cli": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1"
   }
 }

--- a/packages/umwelten/tsconfig.json
+++ b/packages/umwelten/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,10 @@ importers:
       '@umwelten/ui':
         specifier: workspace:*
         version: link:../ui
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
 
 packages:
 


### PR DESCRIPTION
ai@7 renamed the CoreMessage type to ModelMessage and removed the old
export — leaving ~44 tsc errors across the monorepo that nothing caught,
because CI ran tests + lint but never typecheck. This is the cleanup +
the guard so it can't recur.

- CoreMessage → ModelMessage: word-boundary rename across 38 .ts + the
  .tsx adapters (Discord/Telegram). Type-only, same shape; our own
  plural identifiers (dialogueEventsToCoreMessages, …) untouched.
  Verified no runtime change: the 2 pre-existing flaky session/JSON test
  failures are identical before and after.
- target ES2020 → ES2022 in all package tsconfigs — the code already
  uses `new Error(msg, { cause })` (ES2022), which the old target
  rejected (7 errors).
- residual drift: beat-replay stdin chunk typed Buffer; cli EPIPE handler
  typed NodeJS.ErrnoException; streammark (optional untyped dep) imported
  via a non-literal specifier; a stale createdMs test fixture field.
- new `typecheck` script (tsc --noEmit across all 7 packages) wired into
  CI before lint. Monorepo now 0 tsc errors; 670 affected tests pass.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016L8wuWr5FDJRoqgJ3RGuzM
