### PR TITLE
Operations as a habitat fleet: durable A2A tasks, SDK client, derived scopes, cross-hop call chain

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,32 @@ _Avoid_: Playbook, procedure finding
 A dated output produced from an **Exploration** for human use or publication.
 _Avoid_: Report when referring to the general category
 
+### Fleet & provisioning
+
+Terms for the habitat runtime and the fleet it runs in. The product-facing
+vocabulary (Habitat, Agent, Run, Attach, Provisioned resource) is defined in
+the habitats repo's `CONTEXT.md`; these are the terms umwelten itself owns.
+
+**Owned repo**:
+The single git repository a habitat writes to — its own working material. Provisioned, and the only source of a habitat's write scope.
+_Avoid_: Project repo, main repo, habitat repo
+
+**Mounted repo**:
+A repository a habitat reads but never writes, cloned in for reference. A habitat may have many.
+_Avoid_: Attached repo, sub-agent, submodule, linked repo
+
+**Directory**:
+The fleet's registry of record, used to resolve a habitat by id at call time and to wake it. Names and starts habitats; does not carry their conversations.
+_Avoid_: Router, proxy, gateway, service mesh
+
+**Task**:
+The durable lifecycle record of one agent invocation, owned by the habitat that ran it. Distinct from a **Run** (the SaaS's cost and attribution record) and a **Source Session** (what was actually said).
+_Avoid_: Job, run, request, invocation
+
+**Dormant habitat**:
+A habitat whose container is stopped but whose state is intact, reachable by waking it first.
+_Avoid_: Stopped, cold, asleep, idle, offline
+
 ## Relationships
 
 - Every **Source Session** belongs to at least one **Exploration**.
@@ -95,6 +121,12 @@ _Avoid_: Report when referring to the general category
 - **Session Search** operates on every **Source Session** the registered adapters can discover, not just those rooted in the current project. It returns **Source Sessions**, not **Explorations** — promotion to an **Exploration** happens when the user opens a hit in the **Exploration Browser**.
 - A **Dialogue** owns one canonical, speaker-attributed event log; each model **Participant** keeps its own private **Interaction** as a view of that log (its own turns as assistant, others' turns as labeled user messages). Besides spoken turns the log carries ambient `event` entries — world input nobody said — rendered unattributed as `(text)`.
 - A **Dialogue**'s canonical log persists as a **Source Session** (`transcript.jsonl` + `meta.json` with the participant roster), so the session tooling and **Exploration Browser** read it like any other session.
+
+- A habitat has at most one **Owned repo** and any number of **Mounted repos**.
+- A habitat's read scope is derived from its **Mounted repos**; its write scope comes only from its **Owned repo** and is never derived.
+- A **Task**, a **Run**, and a **Source Session** are three records of one invocation, kept separate and correlated rather than merged.
+- A **Dormant habitat** answers nothing until woken; the **Directory** is what wakes it.
+- Habitats call each other in one direction only, so the fleet's call graph stays acyclic.
 
 ## Example dialogue
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,6 +90,14 @@ _Avoid_: Job, run, request, invocation
 A habitat whose container is stopped but whose state is intact, reachable by waking it first.
 _Avoid_: Stopped, cold, asleep, idle, offline
 
+**Habitat vault**:
+The vault holding one habitat's operator-provided secrets, belonging to that habitat alone.
+_Avoid_: Master vault, project vault, secret store, keychain
+
+**Credential contract**:
+A habitat's declaration of what credentials it needs and how each one is obtained — supplied by an operator, authorized by a user, or created while building the environment.
+_Avoid_: Required secrets, env manifest, secret list
+
 ## Relationships
 
 - Every **Source Session** belongs to at least one **Exploration**.
@@ -126,6 +134,8 @@ _Avoid_: Stopped, cold, asleep, idle, offline
 - A habitat's read scope is derived from its **Mounted repos**; its write scope comes only from its **Owned repo** and is never derived.
 - A **Task**, a **Run**, and a **Source Session** are three records of one invocation, kept separate and correlated rather than merged.
 - A **Dormant habitat** answers nothing until woken; the **Directory** is what wakes it.
+- A habitat's operator-provided secrets come from its own **Habitat vault**, resolved and injected on its behalf — a habitat never holds the credential that opens a vault.
+- Credentials a user authorizes, and credentials created while building the environment, never appear in a **Habitat vault**; the **Credential contract** is what says which kind each one is.
 - Habitats call each other in one direction only, so the fleet's call graph stays acyclic.
 
 ## Example dialogue

--- a/docs/adr/0006-owned-and-mounted-repos.md
+++ b/docs/adr/0006-owned-and-mounted-repos.md
@@ -1,0 +1,69 @@
+# 0006 — Owned and mounted repos: repo access is a role, not a count
+
+Status: Accepted
+Date: 2026-07-25
+Related: [0004 — Gaia as a GitHub App](./0004-gaia-github-app.md), habitats
+ADR 0005 (backing storage) §5, which deferred this question.
+
+## Context
+
+habitats ADR 0005 named the distinction that matters — a **provisioned
+resource** (repo, secrets, storage: habitat-scoped, Gaia-credentialed)
+versus an **attachment** (an A2A/MCP server: per-user, per-message) — and
+then declared provisioned resources singular: *"at most one backing
+storage… declaration mirrors git exactly… multi-folder support waits for a
+real habitat that needs it."*
+
+Restructuring operations into per-habitat repos produces that habitat
+immediately. A client habitat holds its own notes, scopes and task state
+while reading four or five of the client's code repos; a cross-project
+rollup habitat reads fifteen and owns none.
+
+Meanwhile umwelten already had two repo mechanisms that nobody had
+reconciled: the habitat's `gitUrl` (provisioned, credentialed, read-write)
+and per-agent clones declared in `config.agents[]` (plural, already
+carrying a `mode: "read" | "write"` that forces a read-only tool subset).
+Repo access was in turn encoded in four places — `gitUrl`, the mount list,
+the registry's `github: { read, write }` mint boundary, and the App
+installation list — with nothing deriving any of them from any other.
+Mounting a repo without widening the read scope fails at boot with a
+GitHub 404 that reads exactly like "that repo does not exist."
+
+## Decision
+
+Provisioned repos do not go plural. They split by **role**:
+
+- A habitat has **at most one owned repo** — its `gitUrl`, read-write, the
+  material it is responsible for.
+- A habitat has **any number of mounted repos** — read-only, reference
+  material, declared as agent entries with `mode: "read"`.
+
+Scope derivation follows the same asymmetry, and this is the point of the
+decision:
+
+- **`github.read` is derived** from the declared mounts plus the owned
+  repo. Mechanical, always in sync, no separate list to forget.
+- **`github.write` is never derived.** It covers the owned repo only, and
+  stays an explicit, human-approved declaration.
+
+The habitat's own repo is the source of truth for both, so adding a mount
+is a pull request against that repo rather than a Gaia tool call.
+
+## Considered options
+
+Pluralising provisioned resources (`repos: [...]`) was the obvious
+alternative and was rejected: it makes every repo equally writable by
+default, which is exactly the property that has to stay scarce.
+
+## Consequences
+
+- Closes ADR 0004's blind spot #1 by construction. Automatic derivation
+  can only ever widen *read*; the exfiltration-laundering path needs write
+  to a public repo, which no derivation can grant.
+- Reconfiguring a habitat becomes a pull request rather than a tool call —
+  better provenance, worse ergonomics. Accepted deliberately.
+- Bootstrapping is circular: Gaia must clone a habitat's repo to learn the
+  scopes it needs a token to clone with. Resolved by cloning the owned repo
+  under ambient read, then narrowing to the derived list.
+- A habitat that needs to write to a second repo is telling you it should
+  be two habitats.

--- a/docs/adr/0007-a2a-tasks-as-the-wake-contract.md
+++ b/docs/adr/0007-a2a-tasks-as-the-wake-contract.md
@@ -1,0 +1,82 @@
+# 0007 — A2A tasks are the wake contract, and habitats own their task state
+
+Status: Accepted
+Date: 2026-07-25
+Related: [0003 — Per-user A2A identity](./0003-per-user-a2a-identity.md),
+[0008 — Fleet topology](./0008-fleet-topology.md)
+
+## Context
+
+A fleet of roughly twenty habitats cannot keep every container running: the
+runtime plane is one `e2-standard-4` (16 GB, no swap) that moved off a
+7.6 GB box precisely because of OOM kills. Habitats must go dormant when
+idle and wake when asked.
+
+Waking is slow. `entrypoint.sh` runs, on every start, a pull of the owned
+repo, `mise install`, `pnpm install --prod`, a clone plus `mise install`
+per mounted repo, and a skills restore — so wake time scales with mount
+count, and the rollup habitat is the slowest waker in the fleet. A
+synchronous ask cannot absorb that.
+
+Nor is wake the only slow thing. A changelog rolled up across every client
+habitat and reconciled against its statement of work is inherently long —
+many A2A calls, each an LLM turn, plus a synthesis pass — and exceeds any
+sane HTTP timeout with every container already warm. Token caps are not
+available as a mitigation; capping output is forbidden by the project's
+hard rules because it silently corrupts results.
+
+A2A already models all of this. `message/send` returns a **Task** in a
+non-terminal state; `returnImmediately` hands control back at once;
+progress arrives by polling `tasks/get`, subscribing, or a webhook. The
+habitat executor already emits a correct lifecycle, and the SDK's request
+handler already serves `tasks/get`, `tasks/list` and `tasks/cancel`.
+
+Two things blocked using any of it. The task store was in-memory, so state
+died with the container — fatal when the reaper is the thing stopping it.
+And every A2A client in the estate hand-rolled its JSON-RPC: two senders in
+umwelten built on raw `fetch` and `node:http`, a third path using the SDK
+for streaming only, and a fourth, entirely separate implementation in the
+SaaS with no SDK dependency at all. None could poll a task.
+
+## Decision
+
+1. **A task is the unit of asking.** Callers use `returnImmediately` and
+   track progress through the task lifecycle. A dormant habitat is not a
+   special case — it is a task that takes longer to reach `working`.
+2. **Task state is durable and lives on the habitat's volume.** The
+   habitat serving `tasks/get` is the one that must be able to read it, and
+   habitat-to-habitat traffic never involves the SaaS.
+3. **Task, Run and Source Session stay separate**, correlated by
+   `contextId` and `taskId`. The SaaS's `runs` table is a projection for
+   cost, attribution and audit — not the task store — even though its
+   shape is nearly identical.
+4. **Clients standardise on `@a2a-js/sdk/client`.** No Focus-owned client
+   package: the SaaS's client is Clerk- and Postgres-shaped and must stay
+   on its side of ADR 0003. What is genuinely shared is the wire protocol,
+   which the SDK already implements. A **conformance suite** running both
+   clients against a live habitat is the shared artifact instead.
+
+## Considered options
+
+Holding the HTTP request at Gaia's proxy while the container boots was
+simpler and needed no protocol change. Rejected because it solves only
+wake, not long work — the rollup would still time out — and would have to
+be unwound as soon as it did.
+
+Reusing the SaaS `runs` table as the task store was tempting given how
+closely it already matches. Rejected: it inverts the dependency (habitats
+are downstream of the SaaS by design) and leaves habitat-to-habitat calls
+with no durable task state at all.
+
+## Consequences
+
+- A reaped container can run a crash-recovery sweep on next boot and mark
+  abandoned tasks failed with a real reason. Only possible because the
+  state is where the habitat can see it.
+- The reaper must refuse to stop a habitat holding non-terminal tasks.
+- There is no fleet-wide "what is running now" view without fanning out,
+  and dormant habitats cannot answer. That view comes from the SaaS's
+  projection, which makes habitat-to-SaaS reporting load-bearing for
+  observability — or the view is quietly incomplete.
+- `auth-required` becomes available as a first-class parking state for work
+  that needs a specific person's credentials, rather than a failure.

--- a/docs/adr/0008-fleet-topology.md
+++ b/docs/adr/0008-fleet-topology.md
@@ -1,0 +1,59 @@
+# 0008 — Fleet topology: a directed tree, with Gaia as directory rather than router
+
+Status: Accepted
+Date: 2026-07-25
+Related: [0004 — Gaia as a GitHub App](./0004-gaia-github-app.md),
+[0007 — A2A tasks as the wake contract](./0007-a2a-tasks-as-the-wake-contract.md)
+
+## Context
+
+Splitting operations into per-habitat repos produces a fleet where one
+operations habitat needs to ask fifteen client habitats what is happening,
+and where a client habitat needs to ask about the code repos beneath it.
+Something has to decide how those calls are routed.
+
+Two facts constrain the answer. Gaia holds the @habitats GitHub App private
+key and can create and destroy containers, so putting it on the path of
+every business question maximises the blast radius of the most privileged
+component in the system. And the existing recursion guard does not survive
+a hop: `withAgentCall` tracks a call chain with a depth limit and cycle
+detection, but it is process-local and neither `ask_remote_agent` nor
+Gaia's `ask_habitat` enters it, so a cycle across containers starts fresh
+at every hop. With LLM agents on both ends and no permitted output cap,
+an unbounded cycle is unbounded spend.
+
+Remote peers are also frozen configuration today: a habitat registers no
+peer tooling at all unless peers were declared before it started, so
+onboarding a new client would require editing and restarting the
+operations habitat.
+
+## Decision
+
+**The call graph is a directed tree** — operations calls clients, clients
+call their projects, and nothing calls upward. Cycles become impossible by
+construction rather than by guard.
+
+**Gaia is the directory, not the router.** It owns discovery (which
+habitats exist, what each can do) and lifecycle (wake, per ADR 0007), and
+stays off the path of the ask itself. Callers resolve a peer through the
+directory and then talk to it directly, one hop.
+
+Peers therefore **resolve at call time** rather than from frozen config, so
+a newly created habitat is reachable without restarting anything that might
+want to talk to it.
+
+The call chain is **propagated across A2A** and rehydrated into the
+existing guard on receipt. The tree makes cycles structurally impossible;
+the guard is defence in depth for the case where one prompt-injected agent
+ignores the convention.
+
+## Consequences
+
+- A habitat cannot answer a question that requires calling back up the
+  tree. Cross-cutting work is orchestrated from the top: the caller
+  gathers what a lower habitat would have needed and passes it down in the
+  question.
+- Rollups are therefore always orchestrated by the parent, never assembled
+  by children self-reporting.
+- Gaia stops being a bottleneck and a privileged proxy, at the cost of
+  every caller needing directory access.

--- a/docs/adr/0009-per-habitat-vaults.md
+++ b/docs/adr/0009-per-habitat-vaults.md
@@ -1,0 +1,82 @@
+# 0009 — One vault per habitat, resolved by Gaia
+
+Status: Accepted
+Date: 2026-07-25
+Related: [0006 — Owned and mounted repos](./0006-owned-and-mounted-repos.md),
+[0004 — Gaia as a GitHub App](./0004-gaia-github-app.md), habitats ADR 0005
+(backing storage)
+
+## Context
+
+A habitat's secrets arrive in three distinct ways, and only one of them was
+modelled badly.
+
+**Operator-provided values** reach a container through Gaia's master vault
+plus `secretBindings`, a list of *names* filtered out of one flat global
+namespace. **User-authorized values** never enter a vault at all — the
+habitat runs its own OAuth at a declared `connectPath`, mints the token
+into its own store, and rotates it there. **The contract** between them is
+already declared per habitat, in `config.json.requiredSecrets[]`: name,
+label, whether it is required, and `type: "secret" | "oauth"`.
+
+The flat global namespace is the broken part. Because Gaia's vault is one
+name-to-value map, and because the capability resolver welds the env var
+name to the vault key (`capability-resolver.ts`: *"the credential name
+doubles as the vault key and env var name"*), two habitats cannot both see
+`DATABASE_URL` with different values. The Twitter habitat already declares
+`DATABASE_URL` in its `requiredSecrets`, so the collision is not
+hypothetical — it arrives with the second habitat that needs a database.
+
+Every other repo in the organization already solved this. `fnox.toml`
+declares a 1Password vault per project and maps env var names to items
+within it, with profile blocks that swap the vault for dev, preview and
+prod. Namespacing is by vault, not by key prefix.
+
+## Decision
+
+**Each habitat gets its own 1Password vault**, declared by a `fnox.toml` in
+its own repo alongside `config.json` (ADR 0006 already makes that repo the
+source of truth for the habitat's environment). `DATABASE_URL` in one
+habitat's vault and in another's are different items with the same name.
+No aliases, no prefixes, no global namespace.
+
+**Gaia resolves it.** Gaia holds the service account that reads habitat
+vaults, executes each habitat's `fnox.toml` on the host, and injects the
+resolved values. The existing invariant stands: habitats never call fnox,
+and no container holds a vault credential.
+
+The two manifests stay separate because they describe different things:
+`fnox.toml` says *where an operator-provided value comes from*;
+`requiredSecrets[]` says *what this habitat needs and how each item is
+obtained* — including items that have no vault entry at all because a user
+mints them by authorizing.
+
+## Considered options
+
+Aliasing the env var name to a globally-unique vault key
+(`DATABASE_URL` ← `upperhand-database-url`) was considered and rejected:
+it reimplements namespacing in a naming convention when the tooling
+already namespaces by vault.
+
+Per-habitat 1Password service-account tokens injected into containers were
+the better-looking isolation story and were rejected on threat model. It
+places a live vault credential inside a container running LLM-driven tools
+against untrusted input, where a prompt injection can enumerate and dump
+the vault. Gaia reading habitat vaults adds nothing to its blast radius —
+it already holds the GitHub App private key and writes every child's
+secrets file, so it can already read everything those vaults contain. It
+also keeps rotation to one credential rather than N, and keeps the vault
+reachable when a habitat is dormant.
+
+## Consequences
+
+- Creating a habitat now includes creating its vault. Provisioning is a
+  fleet operation, not a text edit.
+- Gaia's service account becomes a rotation-critical credential covering
+  every habitat vault. It belongs in the same tier as the App private key.
+- Profiles give dev/preview/prod isolation per habitat by swapping vaults,
+  the mechanism already stubbed in the habitats repo.
+- Still open: a third `type: "provisioned"` on `requiredSecrets`, for
+  values that are neither pasted nor user-authorized but created while
+  building the environment — a Neon branch, a picked Drive folder. Proposed,
+  not decided.

--- a/docs/agents/fleet-restructure-runbook.md
+++ b/docs/agents/fleet-restructure-runbook.md
@@ -1,0 +1,190 @@
+# Runbook — implementing the operations fleet restructure
+
+You are an agent picking up work on the operations fleet restructure. Read
+this file, then go to the tracker. **This file is a protocol, not a task
+list** — it tells you how to claim work, do it, and hand it back. What is
+left to do lives in GitHub issues, which are the only source of truth for
+state.
+
+Do not update this file to record progress. It goes stale the moment two
+agents work at once.
+
+## Where the work is
+
+| Repo | Spec | Tickets |
+|---|---|---|
+| umwelten (this one) | [#266](https://github.com/The-Focus-AI/umwelten/issues/266) | #267–#285 |
+| habitats | [#117](https://github.com/The-Focus-AI/habitats/issues/117) | #118–#123 |
+| operations | [#3](https://github.com/The-Focus-AI/operations/issues/3) | #4–#12 |
+
+Each spec issue carries a comment with the full dependency graph. Each
+ticket names its blockers under **Blocked by**.
+
+Design decisions are ADRs [0006](../adr/0006-owned-and-mounted-repos.md),
+[0007](../adr/0007-a2a-tasks-as-the-wake-contract.md),
+[0008](../adr/0008-fleet-topology.md) and
+[0009](../adr/0009-per-habitat-vaults.md). The build list with current
+status is `../architecture/operations-fleet-restructure.md`. **Read the ADR
+that governs your ticket before writing code** — several decisions are
+deliberately counter-intuitive and the reasoning is recorded there, not in
+the ticket.
+
+Vocabulary — Owned repo, Mounted repo, Directory, Task, Dormant habitat,
+Habitat vault, Credential contract — is defined in `CONTEXT.md` at the repo
+root. Use those words; do not invent synonyms.
+
+## Claiming a ticket
+
+Several agents may be working at once. Claim before you code.
+
+1. **Find candidates.** In the target repo, list open issues labelled
+   `ready-for-agent` and not labelled `in-progress`.
+2. **Check the blockers.** Every issue in its **Blocked by** section must be
+   closed. If any is open, skip this ticket — do not start blocked work and
+   do not "just also do" the blocker inside your ticket.
+3. **Claim it.** Add the `in-progress` label and post a comment saying you
+   have started and roughly what you intend to change. The comment is how a
+   human sees who is on what.
+4. **Re-read the issue after claiming.** If someone labelled it in the
+   seconds you took to decide, drop it and pick another. Label claiming is
+   racy; the comment timestamps break ties — earliest comment wins, the
+   later agent backs off.
+
+Take the **lowest-numbered** unblocked ticket unless you have a reason not
+to. That keeps agents off each other's files, because the numbering follows
+the dependency order.
+
+## Doing the work
+
+- Branch from the current default branch. One ticket per branch, named for
+  the ticket.
+- The acceptance criteria are the contract. Implement all of them, or say in
+  a comment which one you could not meet and why.
+- **Write the tests the ticket asks for.** Every ticket names its seam. The
+  two existing seams are the A2A transport handler and the Gaia tool
+  context; both already take injected fakes, so no test needs real Docker,
+  real 1Password, or the network.
+- Run `pnpm test:run` before committing. It must be green — not "green
+  except for a pre-existing failure". If you find a genuinely pre-existing
+  failure, say so in your comment with the evidence.
+- Run `npx tsc --noEmit -p packages/<pkg>/tsconfig.json` for every package
+  you touched.
+- Commit with the ticket number in the message body (`Closes #NNN`).
+- Push. Do not merge to the default branch yourself.
+
+### When you change existing behaviour
+
+Several of these tickets replace something that already works. When a test
+you did not write starts failing, **find out why before you touch it.** A
+failing test is a claim about behaviour; changing the assertion to match
+your code is only correct once you know the old assertion was wrong.
+
+If the behaviour change is real and intended, say so in the commit body —
+what changed, what depended on it, why the new behaviour is right. If it is
+not intended, fix your code.
+
+### Hard rules
+
+`CLAUDE.md` has them in full. The one that bites this work: **never
+introduce a `maxTokens` / `maxOutputTokens` cap** in a runner, request
+builder, or shared default. Some of this work makes long agent runs
+possible for the first time; that is the point, not a problem to cap your
+way out of. Cost control here is topological — see ADR 0008.
+
+## Finishing
+
+1. Push your branch.
+2. Comment on the issue: what you built, which acceptance criteria are met,
+   anything you deliberately left, and the branch name.
+3. Remove `in-progress`. **Leave the issue open** — a human closes it on
+   merge. `Closes #NNN` in the commit does that automatically when the
+   branch lands on the default branch.
+
+## If you get stuck or run out of context
+
+Do not leave a ticket claimed and silent. Before you stop:
+
+1. Push whatever is working, even if partial. A branch with three of six
+   criteria met and a green suite is useful; an uncommitted working tree is
+   not.
+2. Comment with exactly where you got to, what you learned, and what the
+   next agent should do differently.
+3. Remove `in-progress` so someone else can pick it up.
+
+An unfinished ticket handed back cleanly is a good outcome. A ticket held
+hostage by a dead context is not.
+
+## What you cannot verify here
+
+Some tickets cannot be finished in a sandbox, and you should not pretend
+otherwise:
+
+- **#283–#285** (per-habitat vaults) need real 1Password vaults and a
+  service account. You can build and unit-test the resolution path against
+  a fake; you cannot verify a real mint.
+- **habitats #118–#123** need the SaaS with Clerk and Neon.
+- **operations #4–#12** need client repos that do not exist yet, a Granola
+  credential, and the GCE fleet.
+
+If your ticket needs infrastructure you do not have: build and test what
+you can behind an injected seam, and say plainly in your closing comment
+which criteria are unverified and what would verify them. Do not mark
+something done because it compiles.
+
+## Findings that will save you time
+
+These cost real effort to establish. Do not re-derive them.
+
+**The pinned A2A SDK is 0.3.14, and it is smaller than the published docs
+describe.** The docs on `main` describe a much later API. In 0.3.14:
+
+- `TaskStore` is `save` / `load` only — no `list`, no tenant or owner
+  scoping.
+- There is **no `tasks/list`**. Served methods are `message/send`,
+  `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe`, and
+  the four `tasks/pushNotificationConfig/*` methods.
+- Non-blocking send is `configuration.blocking: false`, **not**
+  `returnImmediately`.
+- `InMemoryTaskStore` stores the caller's object **by reference**. A
+  persisted store cannot reproduce that aliasing and should not try; every
+  SDK mutation is followed by an explicit `save()`, so nothing depends on
+  it.
+- Push-notification config methods are gated on
+  `agentCard.capabilities.pushNotifications`, which the habitat card does
+  not yet declare. Declaring it makes the SDK's sender available (#275).
+
+Spec #266 asserts `tasks/list` exists. It is wrong; the tickets are right.
+
+**The A2A server's task store is now durable** (`FileTaskStore`, on the
+habitat volume) and the boot sweep runs before the transport accepts
+requests. If you are adding lifecycle behaviour, that is the seam.
+
+**Registry entries already carry their `config`**, so anything deriving
+from a habitat's declaration gets it without a call-site change.
+
+**Known gap, not yet ticketed:** the agent-call chain uses the caller's
+`entry.id` on the way out and the receiver's `config.name` on the way back
+in. If a habitat is addressed under a different id than it calls itself,
+the chain holds two labels for one habitat and cycle detection misses it.
+Harmless while the tree topology of ADR 0008 holds. If you touch the chain,
+consider keying it on registry id and file a ticket.
+
+## Landmines
+
+- **Do not widen a write scope by derivation.** ADR 0006 derives read only,
+  on purpose. Org-wide read plus write to a public repo is how private
+  content gets laundered out (ADR 0004 blind spot #1). If a change seems to
+  need derived write, stop and say so.
+- **Do not put the durable Task store in the control plane.** It looks
+  tempting because the SaaS `runs` table is nearly identical. ADR 0007
+  rejects it: the process serving `tasks/get` must be able to read it, and
+  habitat-to-habitat traffic never reaches the SaaS.
+- **Do not make Gaia a router.** It holds the GitHub App private key and can
+  destroy containers. It is the Directory and the lifecycle owner; the ask
+  goes direct (ADR 0008).
+- **Do not let a habitat resolve its own vault.** Containers run agent tools
+  against untrusted input; a live 1Password token inside one is exactly the
+  thing ADR 0009 avoids.
+- **Do not sweep interrupted Tasks.** `input-required` and `auth-required`
+  are legitimately waiting, not abandoned. Killing them destroys resumable
+  work.

--- a/docs/architecture/operations-fleet-restructure.md
+++ b/docs/architecture/operations-fleet-restructure.md
@@ -28,8 +28,18 @@ Gaia                      directory + lifecycle · off the ask path
 
 ## What must be built
 
-Ordered by what blocks what. Items 1–3 are on the critical path: nothing
-else works until a caller can hold a task open across a wake.
+Ordered by what blocks what. Items 1–3 were the critical path: nothing else
+worked until a caller could hold a task open across a wake.
+
+**Status lives in GitHub issues, not here.** Tickets are umwelten #267–#285;
+the dependency graph is a comment on #266. Agents picking this up should
+read [the runbook](../agents/fleet-restructure-runbook.md) first — it covers
+claiming, testing seams, and the SDK findings that are expensive to
+rediscover.
+
+Landed so far: the durable task store and boot sweep (#267, #273), the SDK
+client and task surface (#268), derived read scopes (#272), and the
+cross-hop call chain (#271).
 
 ### 1. Durable task state
 

--- a/docs/architecture/operations-fleet-restructure.md
+++ b/docs/architecture/operations-fleet-restructure.md
@@ -1,0 +1,153 @@
+# Operations as a fleet — what umwelten has to change
+
+> Status: design settled in a grilling session, 2026-07-25. Decisions are
+> recorded in ADRs [0006](../adr/0006-owned-and-mounted-repos.md),
+> [0007](../adr/0007-a2a-tasks-as-the-wake-contract.md) and
+> [0008](../adr/0008-fleet-topology.md); this is the build list that follows
+> from them. Companion to `production-topology.md`, which describes the
+> plane this runs on.
+
+## The target
+
+The operations repo becomes a fleet. Each client gets a habitat that owns
+its own repo — meeting notes, scopes, outstanding work — and mounts the
+client's code repos read-only. A prospect can be given a habitat at first
+contact, to hold mockups and demos before there is any code. An operations
+habitat sits above them and answers cross-cutting questions by asking each
+client habitat directly. Most of the fleet is asleep most of the time.
+
+Shape, in the vocabulary of `CONTEXT.md`:
+
+```
+operations habitat        owns operations-core · classifies and dispatches
+  ├── client habitat      owns client-<name> · mounts that client's repos
+  │     └── project       code-repo habitats beneath a client
+  └── …
+Gaia                      directory + lifecycle · off the ask path
+```
+
+## What must be built
+
+Ordered by what blocks what. Items 1–3 are on the critical path: nothing
+else works until a caller can hold a task open across a wake.
+
+### 1. Durable task state
+
+`packages/protocols/src/a2a/server.ts` constructs `new InMemoryTaskStore()`,
+so task state dies with the container — fatal once a reaper is the thing
+stopping it. Needs a volume-backed store, plus a crash-recovery sweep at
+boot that marks abandoned non-terminal tasks failed with a reason.
+
+### 2. A real A2A client
+
+`packages/protocols/src/a2a/client.ts` hand-rolls JSON-RPC in two of its
+three senders (`sendA2AMessage` over `node:http`, `sendA2AMessageToUrl`
+over `fetch`); only `streamA2AMessage` uses the SDK transport. None can
+poll a task. Standardise on `@a2a-js/sdk/client`, and add what the wake
+contract needs: `returnImmediately`, `tasks/get`, a poll helper.
+
+The habitats SaaS keeps its own client (`src/lib/a2a/`) — it is Clerk- and
+Postgres-shaped and belongs on its side of ADR 0003. Both sides adopt the
+SDK separately.
+
+### 3. Conformance suite
+
+One fixture suite running both clients against a live habitat, asserting
+the task lifecycle end to end. This is the shared artifact instead of a
+shared client package, and it is the regression net for item 1.
+
+### 4. Sleep and wake
+
+Nothing exists today — no idle tracking, no auto-stop. Gaia needs an idle
+reaper that **refuses to stop a habitat holding non-terminal tasks**, and a
+wake path. `ask_habitat` currently returns `"Habitat X is not running"`
+(`gaia-tools/habitats.ts:293`) rather than waking anything.
+
+### 5. Split fast-start from refresh
+
+`packages/habitat/entrypoint.sh` does the same expensive work on every
+start: pull the owned repo, `mise install`, `pnpm install --prod`, then a
+clone plus `mise install` per mounted repo, then a skills restore. Wake
+time therefore scales with mount count, and the rollup habitat is the
+slowest waker in the fleet.
+
+A warm volume already has all of it. Starting must be cheap; refreshing
+must be a separate, explicitly triggered operation — driven by the SaaS's
+GitHub webhook hub, which refreshes an awake habitat and marks a dormant
+one dirty.
+
+**Every answer must carry the checkout's commit and age.** A rollup
+assembled from habitats that were quietly three weeks stale is wrong in a
+way nobody notices.
+
+### 6. A directory that works while asleep
+
+`discoverHabitats` filters to `entries.filter(e => e.containerPort)`
+(`gaia-tools/context.ts:94`) — it discovers by fetching each agent card
+live, so it sees only running habitats. In a fleet that is dormant by
+design it would report almost nothing. Agent cards must be cached on the
+registry entry and refreshed while a habitat is awake.
+
+### 7. Peers that resolve at call time
+
+`packages/habitat/src/tools/remote-agent-tools.ts` registers no tooling at
+all unless peers were declared before start, so adding a client habitat
+today means restarting the operations habitat. Peers must resolve through
+the directory at call time.
+
+### 8. Call chain across the hop
+
+`packages/habitat/src/identity/agent-call-context.ts` tracks depth and
+cycles in `AsyncLocalStorage` — process-local. Neither `ask_remote_agent`
+nor `ask_habitat` enters it, and the chain is never serialised into the A2A
+request, so a cross-container cycle starts fresh at every hop. Propagate
+the chain and rehydrate it on receipt.
+
+### 9. Derive read scopes from mounts
+
+Per ADR 0006. Repo access is currently encoded in four places that nothing
+reconciles: the owned repo, the mount list, the registry's
+`github: { read, write }` mint boundary, and the App installation list.
+Derive `github.read` from the owned repo plus declared mounts; leave
+`github.write` explicit and singular.
+
+### 10. Provisioning that includes mounts
+
+`create_habitat` takes `id, name, gitUrl, gitBranch, provider, model,
+secretBindings, capabilities[]` — but not mounts. Standing up a client
+habitat today is five or more calls with no atomicity, repeated per client.
+`export_habitat` / `import_habitat` is portability, not templating: it
+refuses an existing id and carries no variables.
+
+Near term, a provisioning script that makes the calls in a fixed order and
+is the only sanctioned way to create a client habitat. Target, per ADR
+0006, is the habitat's own repo as the source of truth, instantiated from a
+template repo — which also resolves the bootstrap circularity by cloning
+the owned repo under ambient read before narrowing to the derived list.
+
+## What changes outside umwelten
+
+`/sync` is a single writer: it reads Granola, pattern-matches each meeting
+against a table of client aliases, and writes into fifteen client
+directories. Those become fifteen repos, and ADR 0006 forbids any habitat
+holding write scope across them.
+
+It splits: the operations habitat keeps the classification table and
+dispatches each meeting to the owning client habitat over A2A; the client
+habitat writes its own repo and dedupes on its own side. Meetings that
+match no client stay with operations, which is also where a prospect lives
+until they have a habitat.
+
+## Deliberately not decided yet
+
+- The habitat roster at launch — whether finance, sales and marketing get
+  their own agents or stay repos under one operations habitat. ADR 0006
+  makes this cheap to defer: they are mounts either way.
+- How a statement of work is represented well enough that a rollup can
+  reconcile activity against it. This is the one open item that could
+  change the shape of a client repo.
+- Identity propagation across an agent-to-agent hop. Still unimplemented
+  (habitats `CONTEXT.md` flags it), and still fine while every caller is
+  the same person. It stops being fine the moment a client sees a habitat.
+- Prospect-to-client-to-closed lifecycle: what provisioning happens at
+  first contact, and what happens to a habitat when an engagement ends.

--- a/docs/architecture/operations-fleet-restructure.md
+++ b/docs/architecture/operations-fleet-restructure.md
@@ -125,6 +125,26 @@ is the only sanctioned way to create a client habitat. Target, per ADR
 template repo — which also resolves the bootstrap circularity by cloning
 the owned repo under ambient read before narrowing to the derived list.
 
+### 11. Per-habitat vaults
+
+Per ADR 0009. Gaia's master vault is one flat name-to-value map, and
+`capability-resolver.ts` welds the env var name to the vault key — so two
+habitats cannot both see `DATABASE_URL` with different values. The Twitter
+habitat already declares `DATABASE_URL` in its `requiredSecrets`, so this
+lands with the second habitat that needs a database.
+
+Each habitat gets its own vault, declared by a `fnox.toml` in its own repo
+next to `config.json`. Gaia executes that manifest on the host and injects
+the result; containers still never call fnox. `secretBindings` and the
+capability-to-credential binding both need reworking against per-habitat
+vaults rather than the shared namespace.
+
+The three tiers stay distinct and only the first changes: operator-provided
+values (vault), user-authorized values (the habitat's own OAuth at
+`connectPath`, rotated in its own store — the Twitter habitat is the
+reference implementation), and — proposed, not decided — values provisioned
+while building the environment.
+
 ## What changes outside umwelten
 
 `/sync` is a single writer: it reads Granola, pattern-matches each meeting

--- a/packages/habitat/src/a2a-handler.ts
+++ b/packages/habitat/src/a2a-handler.ts
@@ -47,6 +47,11 @@ import {
   UI_OUTPUT_MODE,
 } from "./ui-resources.js";
 import { getSpeaker } from "./identity/agent-speaker-context.js";
+import { withInboundAgentCallChain } from "./identity/agent-call-context.js";
+import {
+  decodeAgentChain,
+  extendAgentChain,
+} from "./identity/agent-call-wire.js";
 
 // ── Agent card builder ────────────────────────────────────────────
 
@@ -338,8 +343,19 @@ export class HabitatAgentExecutor implements AgentExecutor {
     const controller = new AbortController();
     this.activeTasks.set(taskId, { controller, contextId });
 
+    // Rehydrate the caller's agent-call chain (ADR 0008). The in-process
+    // guard follows the async call tree and stops at the container boundary,
+    // so without this a cross-container cycle starts fresh at every hop and
+    // runs forever — and output caps are not an available mitigation here.
+    // The chain is untrusted: it can only ever cause work to be refused.
+    const inboundChain = extendAgentChain(
+      decodeAgentChain(userMessage.metadata as Record<string, unknown> | undefined),
+      this.habitat.getConfig?.()?.name,
+    );
+
     try {
-      await this.bridge.handleMessage(
+      await withInboundAgentCallChain(inboundChain, async () =>
+        this.bridge.handleMessage(
         { channelKey, text, userId, displayName: speaker?.displayName },
         {
           onText: (delta) => {
@@ -438,6 +454,7 @@ export class HabitatAgentExecutor implements AgentExecutor {
           },
         },
         controller.signal,
+      ),
       );
     } finally {
       this.activeTasks.delete(taskId);

--- a/packages/habitat/src/a2a-handler.ts
+++ b/packages/habitat/src/a2a-handler.ts
@@ -24,8 +24,11 @@ import type {
   Artifact as A2AArtifact,
   TaskState,
 } from "@a2a-js/sdk";
+import { join } from "node:path";
 import {
   createA2AServer,
+  FileTaskStore,
+  sweepAbandonedTasks,
   type A2AServer,
   type AgentExecutor,
   type RequestContext,
@@ -545,5 +548,21 @@ export async function createA2AHandler(
     options.resolvePublicOrigin,
   );
 
-  return createA2AServer({ agentCard, executor });
+  // Tasks live on the habitat's volume, not in memory, so they survive the
+  // container being stopped — which is routine once habitats sleep while idle
+  // (ADR 0007). Then clear out anything the previous container generation left
+  // mid-flight, BEFORE the transport starts accepting requests, so no caller
+  // can observe a task that is about to be moved.
+  const taskStore = new FileTaskStore({
+    dir: join(options.habitat.getWorkDir(), "tasks"),
+  });
+
+  const recovered = await sweepAbandonedTasks(taskStore);
+  if (recovered.swept.length > 0) {
+    console.log(
+      `[a2a] Recovered ${recovered.swept.length} task(s) abandoned when the habitat last stopped: ${recovered.swept.join(", ")}`,
+    );
+  }
+
+  return createA2AServer({ agentCard, executor, taskStore });
 }

--- a/packages/habitat/src/identity/agent-call-context.ts
+++ b/packages/habitat/src/identity/agent-call-context.ts
@@ -78,6 +78,32 @@ export async function withAgentCall<T>(
 }
 
 /**
+ * Run `fn` with a chain that arrived from another container over A2A.
+ *
+ * The in-process guard follows the async call tree and stops at the container
+ * boundary, so a cross-container cycle would otherwise start fresh at every
+ * hop. Seeding the inbound chain here is what makes the depth and cycle
+ * checks mean anything across the fleet (ADR 0008).
+ *
+ * The chain is untrusted — it is only ever used to refuse work, never to
+ * grant it, so a peer that strips it gains nothing beyond the depth budget it
+ * would have had anyway.
+ */
+export async function withInboundAgentCallChain<T>(
+  chain: string[],
+  fn: () => Promise<T>,
+  options?: { maxDepth?: number },
+): Promise<T> {
+  return storage.run(
+    {
+      chain: [...chain],
+      maxDepth: options?.maxDepth ?? DEFAULT_AGENT_CALL_DEPTH,
+    },
+    fn,
+  );
+}
+
+/**
  * Reset the call context — used by tests and by isolated entry points
  * (top-level Habitat.createInteraction calls happen outside any chain).
  */

--- a/packages/habitat/src/identity/agent-call-wire.test.ts
+++ b/packages/habitat/src/identity/agent-call-wire.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+	AGENT_CHAIN_METADATA_KEY,
+	MAX_WIRE_AGENT_ID_LENGTH,
+	MAX_WIRE_CHAIN_LENGTH,
+	decodeAgentChain,
+	encodeAgentChain,
+	extendAgentChain,
+} from "./agent-call-wire.js";
+import {
+	checkAgentCall,
+	withInboundAgentCallChain,
+	withAgentCall,
+} from "./agent-call-context.js";
+
+describe("encode/decode round trip", () => {
+	it("carries a chain across the wire unchanged", () => {
+		const chain = ["ops", "upperhand"];
+		expect(decodeAgentChain(encodeAgentChain(chain))).toEqual(chain);
+	});
+
+	it("uses a namespaced metadata key so it cannot collide", () => {
+		expect(Object.keys(encodeAgentChain([]))).toEqual([AGENT_CHAIN_METADATA_KEY]);
+	});
+});
+
+describe("decodeAgentChain — untrusted input", () => {
+	it.each([
+		["no metadata", undefined],
+		["empty metadata", {}],
+		["a non-array value", { [AGENT_CHAIN_METADATA_KEY]: "ops" }],
+		["a null value", { [AGENT_CHAIN_METADATA_KEY]: null }],
+		["a number", { [AGENT_CHAIN_METADATA_KEY]: 7 }],
+	])("returns an empty chain for %s rather than throwing", (_label, metadata) => {
+		expect(decodeAgentChain(metadata as Record<string, unknown> | undefined)).toEqual(
+			[],
+		);
+	});
+
+	it("drops non-string and blank entries", () => {
+		expect(
+			decodeAgentChain({ [AGENT_CHAIN_METADATA_KEY]: ["ops", 1, "", "  ", null, "uh"] }),
+		).toEqual(["ops", "uh"]);
+	});
+
+	it("trims surrounding whitespace", () => {
+		expect(decodeAgentChain({ [AGENT_CHAIN_METADATA_KEY]: ["  ops  "] })).toEqual([
+			"ops",
+		]);
+	});
+
+	it("truncates an oversized agent id", () => {
+		const long = "x".repeat(MAX_WIRE_AGENT_ID_LENGTH + 50);
+		expect(decodeAgentChain({ [AGENT_CHAIN_METADATA_KEY]: [long] })[0]).toHaveLength(
+			MAX_WIRE_AGENT_ID_LENGTH,
+		);
+	});
+
+	it("caps an oversized chain instead of rejecting the whole request", () => {
+		const huge = Array.from({ length: MAX_WIRE_CHAIN_LENGTH + 20 }, (_, i) => `a${i}`);
+		expect(
+			decodeAgentChain({ [AGENT_CHAIN_METADATA_KEY]: huge }),
+		).toHaveLength(MAX_WIRE_CHAIN_LENGTH);
+	});
+});
+
+describe("extendAgentChain", () => {
+	it("appends the receiving habitat so the next hop sees the full path", () => {
+		expect(extendAgentChain(["ops"], "upperhand")).toEqual(["ops", "upperhand"]);
+	});
+
+	it("leaves the chain alone when the habitat has no name", () => {
+		expect(extendAgentChain(["ops"], undefined)).toEqual(["ops"]);
+	});
+});
+
+describe("the guard across a simulated hop", () => {
+	it("detects a cycle that would otherwise restart at every container", async () => {
+		// ops → upperhand, and upperhand is now asked to call ops back.
+		const wire = encodeAgentChain(["ops"]);
+		const inbound = extendAgentChain(decodeAgentChain(wire), "upperhand");
+
+		await withInboundAgentCallChain(inbound, async () => {
+			expect(checkAgentCall("ops")).toMatchObject({ ok: false, reason: "CYCLE" });
+		});
+	});
+
+	it("allows a downward call that is not a cycle", async () => {
+		const inbound = extendAgentChain(decodeAgentChain(encodeAgentChain(["ops"])), "upperhand");
+		await withInboundAgentCallChain(inbound, async () => {
+			expect(checkAgentCall("uh-api").ok).toBe(true);
+		});
+	});
+
+	it("refuses once the chain reaches the depth limit", async () => {
+		await withInboundAgentCallChain(["a", "b", "c"], async () => {
+			expect(checkAgentCall("d")).toMatchObject({ ok: false, reason: "MAX_DEPTH" });
+		});
+	});
+
+	it("without the inbound chain the same cycle looks fine — the bug this closes", async () => {
+		// Simulates the old behaviour: the receiving habitat started empty.
+		await withInboundAgentCallChain([], async () => {
+			expect(checkAgentCall("ops").ok).toBe(true);
+		});
+	});
+
+	it("keeps counting depth across a nested in-process call", async () => {
+		await withInboundAgentCallChain(["ops"], async () => {
+			await withAgentCall("upperhand", async () => {
+				expect(checkAgentCall("ops")).toMatchObject({ ok: false, reason: "CYCLE" });
+			});
+		});
+	});
+});

--- a/packages/habitat/src/identity/agent-call-wire.ts
+++ b/packages/habitat/src/identity/agent-call-wire.ts
@@ -1,0 +1,76 @@
+/**
+ * Carrying the agent-call chain across an A2A hop.
+ *
+ * The recursion guard in `agent-call-context.ts` tracks depth and cycles in
+ * AsyncLocalStorage, which follows the async call tree inside one process and
+ * stops dead at the container boundary. Neither `ask_remote_agent` nor Gaia's
+ * `ask_habitat` enters it, and the chain has never been put on the wire — so
+ * an A2A cycle (operations → client → operations) starts fresh at every hop
+ * and runs forever. With LLM agents on both ends and output caps forbidden by
+ * this repo's hard rules, forever means unbounded spend.
+ *
+ * ADR 0008 makes cycles structurally impossible by keeping the call graph a
+ * directed tree. This module is the defence in depth for the case where one
+ * prompt-injected agent ignores the convention: serialise the chain into
+ * outgoing A2A message metadata, rehydrate it on receipt, and let the
+ * existing guard do its job.
+ *
+ * The chain is untrusted input — it arrives from another container. It is
+ * only ever used to *refuse* work, never to grant it, so a caller who strips
+ * it gains nothing beyond the depth budget they would have had anyway.
+ * Malformed and oversized chains are rejected rather than trusted.
+ */
+
+/** Metadata key carrying the chain on an A2A message. */
+export const AGENT_CHAIN_METADATA_KEY = "umwelten.agentChain";
+
+/** Hard ceiling on a wire chain, well above any legitimate depth. */
+export const MAX_WIRE_CHAIN_LENGTH = 32;
+/** Hard ceiling on one agent id, to bound the metadata a peer can inject. */
+export const MAX_WIRE_AGENT_ID_LENGTH = 128;
+
+/** Serialise the current chain for an outgoing A2A message. */
+export function encodeAgentChain(chain: string[]): Record<string, unknown> {
+	return { [AGENT_CHAIN_METADATA_KEY]: chain };
+}
+
+/**
+ * Read a chain out of inbound A2A message metadata.
+ *
+ * Returns an empty chain for anything malformed — a peer sending nonsense
+ * gets the same treatment as a peer sending nothing, rather than crashing the
+ * receiver. Oversized chains are truncated to the ceiling rather than
+ * rejected outright, so a hostile peer cannot use a huge chain to make the
+ * receiver refuse legitimate work.
+ */
+export function decodeAgentChain(
+	metadata: Record<string, unknown> | undefined,
+): string[] {
+	const raw = metadata?.[AGENT_CHAIN_METADATA_KEY];
+	if (!Array.isArray(raw)) return [];
+
+	const chain: string[] = [];
+	for (const entry of raw) {
+		if (typeof entry !== "string") continue;
+		const trimmed = entry.trim();
+		if (!trimmed) continue;
+		chain.push(trimmed.slice(0, MAX_WIRE_AGENT_ID_LENGTH));
+		if (chain.length >= MAX_WIRE_CHAIN_LENGTH) break;
+	}
+	return chain;
+}
+
+/**
+ * Merge an inbound chain with this habitat's own identity.
+ *
+ * The receiving habitat appends itself, so the next hop sees the full path.
+ * A chain that already contains this habitat is a cycle, which the guard
+ * catches when the next call is attempted.
+ */
+export function extendAgentChain(
+	inbound: string[],
+	selfId: string | undefined,
+): string[] {
+	if (!selfId) return inbound;
+	return [...inbound, selfId];
+}

--- a/packages/habitat/src/tools/gaia/github/token-service.test.ts
+++ b/packages/habitat/src/tools/gaia/github/token-service.test.ts
@@ -265,3 +265,74 @@ describe("createGithubTokenService", () => {
 		expect(await service.bootTokensFor({ id: "plain" })).toBeUndefined();
 	});
 });
+
+/**
+ * ADR 0006: mounting a repo must widen the read scope on its own. Without
+ * this, a mount whose repo was never added to the declaration fails at boot
+ * with a GitHub 404 that reads exactly like "that repo does not exist".
+ */
+describe("deriveGithubTokenScope — read scope derived from declared repos", () => {
+	const mounted = {
+		name: "t",
+		gitUrl: "https://github.com/x/owned.git",
+		agents: [
+			{
+				id: "m",
+				name: "M",
+				projectPath: "m",
+				kind: "repo" as const,
+				mode: "read" as const,
+				gitRemote: "https://github.com/x/mounted.git",
+			},
+		],
+	};
+
+	it("includes the Owned repo and Mounted repos without a separate declaration", () => {
+		const scope = deriveGithubTokenScope(
+			{ id: "h", github: { read: [] }, config: mounted as never },
+			"read",
+		);
+		expect(scope?.repositories).toEqual(["mounted", "owned"]);
+	});
+
+	it("keeps explicitly declared repos alongside the derived ones", () => {
+		const scope = deriveGithubTokenScope(
+			{ id: "h", github: { read: ["standards"] }, config: mounted as never },
+			"read",
+		);
+		expect(scope?.repositories).toEqual(["mounted", "owned", "standards"]);
+	});
+
+	it("still honours an org-wide read without pinning a list", () => {
+		const scope = deriveGithubTokenScope(
+			{ id: "h", github: { read: "org" }, config: mounted as never },
+			"read",
+		);
+		expect(scope?.repositories).toBeUndefined();
+	});
+
+	it("never lets a mount widen the WRITE scope", () => {
+		const scope = deriveGithubTokenScope(
+			{ id: "h", github: { write: ["owned"] }, config: mounted as never },
+			"write",
+		);
+		expect(scope?.repositories).toEqual(["owned"]);
+	});
+
+	it("grants no write at all when none is declared, however many repos are mounted", () => {
+		expect(
+			deriveGithubTokenScope(
+				{ id: "h", github: { read: [] }, config: mounted as never },
+				"write",
+			),
+		).toBeNull();
+	});
+
+	it("behaves as before for an entry carrying no config", () => {
+		const scope = deriveGithubTokenScope(
+			{ id: "h", github: { read: ["only"] } },
+			"read",
+		);
+		expect(scope?.repositories).toEqual(["only"]);
+	});
+});

--- a/packages/habitat/src/tools/gaia/github/token-service.ts
+++ b/packages/habitat/src/tools/gaia/github/token-service.ts
@@ -12,6 +12,8 @@
  */
 
 import { readFile } from "node:fs/promises";
+import type { HabitatConfig } from "../../../types.js";
+import { deriveRepoScopes, mergeDerivedReadScope } from "../repo-scopes.js";
 import {
 	mintInstallationToken,
 	type InstallationToken,
@@ -30,6 +32,13 @@ export interface GithubCapabilityDecl {
 export interface GithubScopedEntry {
 	id?: string;
 	github?: GithubCapabilityDecl;
+	/**
+	 * The habitat's own declaration. When present, its Owned repo and Mounted
+	 * repos widen the READ scope automatically (ADR 0006), so mounting a repo
+	 * cannot fail at boot with a GitHub 404 that reads like "no such repo".
+	 * Write is never derived from this — see `repo-scopes.ts`.
+	 */
+	config?: HabitatConfig;
 }
 
 /** Down-scope request derived from an entry's declaration. */
@@ -85,9 +94,16 @@ export function deriveGithubTokenScope(
 		if (decl.read === "org") {
 			return { permissions: { contents: "read" } };
 		}
-		if (Array.isArray(decl.read) && decl.read.length > 0) {
+		// Widen the declared read list with the repos this habitat will actually
+		// clone (ADR 0006). Derivation only ever adds to READ; it can never
+		// touch write, which is what keeps ADR 0004's blind spot #1 closed.
+		const effectiveRead = entry.config
+			? mergeDerivedReadScope(decl, deriveRepoScopes(entry.config)).read
+			: decl.read;
+
+		if (Array.isArray(effectiveRead) && effectiveRead.length > 0) {
 			return {
-				repositories: toBareRepoNames(decl.read),
+				repositories: toBareRepoNames(effectiveRead),
 				permissions: { contents: "read" },
 			};
 		}

--- a/packages/habitat/src/tools/gaia/repo-scopes.test.ts
+++ b/packages/habitat/src/tools/gaia/repo-scopes.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import type { HabitatConfig } from "../../types.js";
+import {
+	bareRepoName,
+	deriveRepoScopes,
+	mergeDerivedReadScope,
+	repoNameFromGitUrl,
+} from "./repo-scopes.js";
+
+function config(overrides: Partial<HabitatConfig> = {}): HabitatConfig {
+	return { name: "test", agents: [], ...overrides } as HabitatConfig;
+}
+
+describe("repoNameFromGitUrl", () => {
+	it.each([
+		["https://github.com/The-Focus-AI/umwelten.git", "The-Focus-AI/umwelten"],
+		["https://github.com/The-Focus-AI/umwelten", "The-Focus-AI/umwelten"],
+		["git@github.com:The-Focus-AI/umwelten.git", "The-Focus-AI/umwelten"],
+		["git@github.com:The-Focus-AI/umwelten", "The-Focus-AI/umwelten"],
+		["ssh://git@github.com/The-Focus-AI/umwelten.git", "The-Focus-AI/umwelten"],
+	])("parses %s", (url, expected) => {
+		expect(repoNameFromGitUrl(url)).toBe(expected);
+	});
+
+	it.each([undefined, "", "   ", "not-a-url", "https://github.com/onlyowner"])(
+		"returns undefined for %s rather than guessing",
+		(url) => {
+			expect(repoNameFromGitUrl(url as string | undefined)).toBeUndefined();
+		},
+	);
+});
+
+describe("bareRepoName", () => {
+	it("drops the owner", () => {
+		expect(bareRepoName("The-Focus-AI/umwelten")).toBe("umwelten");
+	});
+
+	it("passes through a name that has no owner", () => {
+		expect(bareRepoName("umwelten")).toBe("umwelten");
+	});
+
+	it("returns undefined for nothing", () => {
+		expect(bareRepoName(undefined)).toBeUndefined();
+	});
+});
+
+describe("deriveRepoScopes", () => {
+	it("derives nothing from an empty habitat", () => {
+		expect(deriveRepoScopes(config())).toEqual({
+			read: [],
+			mounted: [],
+			unresolved: [],
+		});
+	});
+
+	it("includes the Owned repo in the read scope", () => {
+		const derived = deriveRepoScopes(
+			config({ gitUrl: "https://github.com/The-Focus-AI/client-upperhand.git" }),
+		);
+		expect(derived.owned).toBe("client-upperhand");
+		expect(derived.read).toEqual(["client-upperhand"]);
+	});
+
+	it("widens the read scope for each Mounted repo", () => {
+		const derived = deriveRepoScopes(
+			config({
+				gitUrl: "https://github.com/The-Focus-AI/client-upperhand.git",
+				agents: [
+					{ id: "a", name: "A", projectPath: "a", kind: "repo", mode: "read", gitRemote: "https://github.com/The-Focus-AI/uh-api.git" },
+					{ id: "b", name: "B", projectPath: "b", kind: "repo", mode: "read", gitRemote: "git@github.com:The-Focus-AI/uh-web.git" },
+				],
+			}),
+		);
+		expect(derived.read).toEqual(["client-upperhand", "uh-api", "uh-web"]);
+		expect(derived.mounted).toEqual(["uh-api", "uh-web"]);
+	});
+
+	it("narrows again when a mount is removed", () => {
+		const withMount = deriveRepoScopes(
+			config({
+				agents: [
+					{ id: "a", name: "A", projectPath: "a", kind: "repo", gitRemote: "https://github.com/x/one.git" },
+				],
+			}),
+		);
+		const without = deriveRepoScopes(config());
+		expect(withMount.read).toEqual(["one"]);
+		expect(without.read).toEqual([]);
+	});
+
+	it("does not duplicate a repo that is both owned and mounted", () => {
+		const derived = deriveRepoScopes(
+			config({
+				gitUrl: "https://github.com/x/same.git",
+				agents: [
+					{ id: "a", name: "A", projectPath: "a", kind: "repo", gitRemote: "https://github.com/x/same.git" },
+				],
+			}),
+		);
+		expect(derived.read).toEqual(["same"]);
+	});
+
+	it("includes mcp-agent mounts, which are also cloned at boot", () => {
+		const derived = deriveRepoScopes(
+			config({
+				agents: [
+					{ id: "m", name: "M", projectPath: "m", kind: "mcp-agent", gitRemote: "https://github.com/x/tool.git" },
+				],
+			}),
+		);
+		expect(derived.read).toEqual(["tool"]);
+	});
+
+	it("ignores agents that are not code-bearing", () => {
+		const derived = deriveRepoScopes(
+			config({
+				agents: [
+					{ id: "r", name: "R", projectPath: "r", kind: "remote-habitat", a2aUrl: "http://peer/a2a" },
+					{ id: "c", name: "C", projectPath: "c", kind: "credential-only" },
+				],
+			}),
+		);
+		expect(derived.read).toEqual([]);
+	});
+
+	it("ignores a repo agent with no remote", () => {
+		const derived = deriveRepoScopes(
+			config({
+				agents: [{ id: "a", name: "A", projectPath: "a", kind: "repo" }],
+			}),
+		);
+		expect(derived.read).toEqual([]);
+		expect(derived.unresolved).toEqual([]);
+	});
+
+	it("reports an unparseable remote instead of silently dropping it", () => {
+		const derived = deriveRepoScopes(
+			config({
+				agents: [
+					{ id: "a", name: "A", projectPath: "a", kind: "repo", gitRemote: "wat" },
+				],
+			}),
+		);
+		expect(derived.read).toEqual([]);
+		expect(derived.unresolved).toEqual(["wat"]);
+	});
+
+	it("never derives an org-wide read", () => {
+		const derived = deriveRepoScopes(
+			config({
+				gitUrl: "https://github.com/x/a.git",
+				agents: Array.from({ length: 5 }, (_, i) => ({
+					id: `m${i}`,
+					name: `M${i}`,
+					projectPath: `m${i}`,
+					kind: "repo" as const,
+					gitRemote: `https://github.com/x/m${i}.git`,
+				})),
+			}),
+		);
+		expect(Array.isArray(derived.read)).toBe(true);
+		expect(derived.read).toHaveLength(6);
+	});
+
+	it("does not produce a write scope — write is never derived", () => {
+		const derived = deriveRepoScopes(
+			config({ gitUrl: "https://github.com/x/owned.git" }),
+		);
+		expect(derived).not.toHaveProperty("write");
+	});
+});
+
+describe("mergeDerivedReadScope", () => {
+	const derived = deriveRepoScopes(
+		config({
+			gitUrl: "https://github.com/x/owned.git",
+			agents: [
+				{ id: "a", name: "A", projectPath: "a", kind: "repo", gitRemote: "https://github.com/x/mounted.git" },
+			],
+		}),
+	);
+
+	it("produces the derived list when nothing was declared", () => {
+		expect(mergeDerivedReadScope(undefined, derived).read).toEqual([
+			"owned",
+			"mounted",
+		]);
+	});
+
+	it("keeps explicitly declared repos the habitat does not mount", () => {
+		const merged = mergeDerivedReadScope({ read: ["standards"] }, derived);
+		expect(merged.read).toEqual(["standards", "owned", "mounted"]);
+	});
+
+	it("does not duplicate a repo that was already declared", () => {
+		const merged = mergeDerivedReadScope({ read: ["owned"] }, derived);
+		expect(merged.read).toEqual(["owned", "mounted"]);
+	});
+
+	it("preserves an existing org-wide read rather than narrowing it", () => {
+		const merged = mergeDerivedReadScope({ read: "org" }, derived);
+		expect(merged.read).toBe("org");
+	});
+
+	it("never touches the write scope", () => {
+		const merged = mergeDerivedReadScope(
+			{ read: [], write: ["owned"] },
+			derived,
+		);
+		expect(merged.write).toEqual(["owned"]);
+	});
+
+	it("leaves write absent when none was declared, even though a repo is owned", () => {
+		expect(mergeDerivedReadScope({ read: [] }, derived).write).toBeUndefined();
+	});
+});

--- a/packages/habitat/src/tools/gaia/repo-scopes.ts
+++ b/packages/habitat/src/tools/gaia/repo-scopes.ts
@@ -1,0 +1,144 @@
+/**
+ * Derive a habitat's GitHub read scope from the repos it actually declares.
+ *
+ * Repo access is currently encoded in four places that nothing reconciles:
+ * the habitat's Owned repo (`config.gitUrl`), its Mounted repos (agent
+ * entries with `kind: "repo"`), the registry's `github: { read, write }` mint
+ * boundary, and the App installation list. Mount a repo without widening the
+ * read scope and the boot clone fails with a GitHub 404 that reads exactly
+ * like "that repo does not exist" — a bad afternoon once, the default state
+ * across twenty habitats.
+ *
+ * Per ADR 0006 the fix is asymmetric, and the asymmetry is the point:
+ *
+ * - **Read is derived.** Owned repo plus Mounted repos, computed, so it can
+ *   never drift from what the habitat will try to clone.
+ * - **Write is never derived.** It covers the Owned repo only and stays an
+ *   explicit, human-approved declaration.
+ *
+ * That asymmetry is what keeps ADR 0004's blind spot #1 closed: automatic
+ * derivation can only ever widen *read*, and laundering private content into
+ * a public repo needs *write*. Derivation also always produces an explicit
+ * list, never `"org"` — org-wide read is a deliberate act, not something a
+ * mount list can grant you by accident.
+ */
+
+import type { AgentEntry, HabitatConfig } from "../../types.js";
+
+/**
+ * Extract `owner/name` from a git remote. Handles the HTTPS and SSH forms
+ * plus an optional `.git` suffix. Returns undefined for anything else, so an
+ * unparseable remote widens no scope rather than guessing.
+ */
+export function repoNameFromGitUrl(gitUrl: string | undefined): string | undefined {
+	if (!gitUrl) return undefined;
+	const trimmed = gitUrl.trim();
+	if (!trimmed) return undefined;
+
+	// git@host:owner/name(.git)
+	const ssh = /^[^@\s]+@[^:\s]+:(?<path>[^\s]+)$/.exec(trimmed);
+	const rawPath = ssh?.groups?.path ?? extractHttpPath(trimmed);
+	if (!rawPath) return undefined;
+
+	const segments = rawPath
+		.replace(/\.git$/i, "")
+		.split("/")
+		.filter(Boolean);
+	if (segments.length < 2) return undefined;
+
+	// Take the LAST two segments: GitHub URLs are owner/name, but a host with
+	// a path prefix would otherwise yield the prefix instead of the owner.
+	return segments.slice(-2).join("/");
+}
+
+function extractHttpPath(gitUrl: string): string | undefined {
+	try {
+		const url = new URL(gitUrl);
+		return url.pathname;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Just the repo name, without the owner — the form the mint boundary uses. */
+export function bareRepoName(fullName: string | undefined): string | undefined {
+	if (!fullName) return undefined;
+	const segments = fullName.split("/").filter(Boolean);
+	return segments.length > 0 ? segments[segments.length - 1] : undefined;
+}
+
+/** Agent entries that cause a clone at boot. */
+function isCodeBearing(agent: AgentEntry): boolean {
+	const kind = agent.kind ?? "repo";
+	return (kind === "repo" || kind === "mcp-agent") && Boolean(agent.gitRemote);
+}
+
+export interface DerivedRepoScopes {
+	/** Repo names the habitat must be able to read. Always an explicit list. */
+	read: string[];
+	/** The Owned repo's name, if it has one. Never derived into `write`. */
+	owned?: string;
+	/** Mounted repo names, in declaration order. */
+	mounted: string[];
+	/** Remotes that could not be parsed, so a caller can surface them. */
+	unresolved: string[];
+}
+
+/**
+ * Compute the read scope a habitat needs from its own declaration.
+ *
+ * Deliberately does NOT return a `write` list. Write is the Owned repo only
+ * and is declared by a human; see the module comment.
+ */
+export function deriveRepoScopes(config: HabitatConfig): DerivedRepoScopes {
+	const unresolved: string[] = [];
+
+	const owned = bareRepoName(repoNameFromGitUrl(config.gitUrl));
+	if (config.gitUrl && !owned) unresolved.push(config.gitUrl);
+
+	const mounted: string[] = [];
+	for (const agent of config.agents ?? []) {
+		if (!isCodeBearing(agent)) continue;
+		const name = bareRepoName(repoNameFromGitUrl(agent.gitRemote));
+		if (!name) {
+			unresolved.push(agent.gitRemote as string);
+			continue;
+		}
+		if (!mounted.includes(name)) mounted.push(name);
+	}
+
+	const read: string[] = [];
+	for (const name of [owned, ...mounted]) {
+		if (name && !read.includes(name)) read.push(name);
+	}
+
+	return { read, mounted, unresolved, ...(owned ? { owned } : {}) };
+}
+
+/**
+ * Merge a derived read scope into an existing declaration.
+ *
+ * An existing `"org"` read is preserved rather than narrowed to a list —
+ * whoever set it did so deliberately, and silently replacing it here would be
+ * a scope change nobody asked for. Explicitly declared extra repos are kept,
+ * so a habitat that needs to read something it does not mount (a standards
+ * corpus, say) does not lose it every time scopes are recomputed.
+ */
+export function mergeDerivedReadScope(
+	existing: { read?: "org" | string[]; write?: string[] } | undefined,
+	derived: DerivedRepoScopes,
+): { read: "org" | string[]; write?: string[] } {
+	if (existing?.read === "org") {
+		return { read: "org", ...(existing.write ? { write: existing.write } : {}) };
+	}
+
+	const merged = [...(existing?.read ?? [])];
+	for (const name of derived.read) {
+		if (!merged.includes(name)) merged.push(name);
+	}
+
+	return {
+		read: merged,
+		...(existing?.write ? { write: existing.write } : {}),
+	};
+}

--- a/packages/habitat/src/tools/remote-agent-tools.test.ts
+++ b/packages/habitat/src/tools/remote-agent-tools.test.ts
@@ -70,11 +70,12 @@ describe("createRemoteAgentTools", () => {
 			agentId: "gaia",
 			message: "what's running?",
 		});
-		expect(send).toHaveBeenCalledWith({
+		expect(send).toHaveBeenCalledWith(
+			expect.objectContaining({
 			endpoint: "https://gaia.example.com",
 			text: "what's running?",
-			apiKey: "tok-123",
-		});
+			apiKey: "tok-123",}),
+		);
 		expect(out).toEqual({ agentId: "gaia", response: "3 habitats running" });
 	});
 
@@ -87,10 +88,17 @@ describe("createRemoteAgentTools", () => {
 			}),
 		);
 		const out = await callAsk(tools, { agentId: "GAIA", message: "hi" });
-		expect(send).toHaveBeenCalledWith({
-			endpoint: "http://172.17.0.1:7420",
-			text: "hi",
-			apiKey: undefined,
+		expect(send).toHaveBeenCalledWith(
+			expect.objectContaining({
+				endpoint: "http://172.17.0.1:7420",
+				text: "hi",
+				apiKey: undefined,
+			}),
+		);
+		// The call now carries the agent-call chain so the receiving habitat
+		// extends it instead of starting fresh (ADR 0008).
+		expect(send.mock.calls[0][0].metadata).toEqual({
+			"umwelten.agentChain": ["gaia"],
 		});
 		expect(out.agentId).toBe("gaia");
 	});

--- a/packages/habitat/src/tools/remote-agent-tools.ts
+++ b/packages/habitat/src/tools/remote-agent-tools.ts
@@ -27,6 +27,12 @@ import type { Tool } from "ai";
 import { sendA2AMessageToUrl } from "@umwelten/protocols";
 import type { A2AMessageResponse } from "@umwelten/protocols";
 import type { AgentEntry, HabitatConfig } from "../types.js";
+import {
+	checkAgentCall,
+	getAgentCallContext,
+	withAgentCall,
+} from "../identity/agent-call-context.js";
+import { encodeAgentChain } from "../identity/agent-call-wire.js";
 
 /** Narrow habitat surface so tests don't need a full Habitat. */
 export interface RemoteAgentToolsContext {
@@ -116,12 +122,33 @@ export function createRemoteAgentTools(
 				? ctx.getSecret(entry.a2aTokenSecret)
 				: undefined;
 
+			// Depth and cycle guard, now that it survives the hop (ADR 0008).
+			// Refuse before spending anything: with LLM agents on both ends and
+			// output caps forbidden, an unbounded cycle is unbounded spend.
+			const check = checkAgentCall(entry.id);
+			if (!check.ok) {
+				return {
+					error: check.reason === "CYCLE" ? "AGENT_CYCLE" : "AGENT_MAX_DEPTH",
+					message: check.message,
+					chain: check.chain,
+				};
+			}
+
 			try {
-				const response: A2AMessageResponse = await send({
-					endpoint,
-					text: message,
-					apiKey,
-				});
+				const response: A2AMessageResponse = await withAgentCall(
+					entry.id,
+					async () =>
+						send({
+							endpoint,
+							text: message,
+							apiKey,
+							// Carry the chain so the receiving habitat can extend it
+							// rather than starting fresh.
+							metadata: encodeAgentChain(
+								getAgentCallContext()?.chain ?? [entry.id],
+							),
+						}),
+				);
 				return {
 					agentId: entry.id,
 					response: response.text,

--- a/packages/protocols/src/a2a/client.test.ts
+++ b/packages/protocols/src/a2a/client.test.ts
@@ -56,12 +56,33 @@ describe("decodeA2ASendPayload", () => {
 describe("sendA2AMessageToUrl", () => {
 	afterEach(() => vi.unstubAllGlobals());
 
+	/**
+	 * Returns a real `Response`. The previous stub was a bare
+	 * `{ status, text() }` object — enough for the hand-rolled sender that read
+	 * only those two, but not something `fetch` ever actually produces, and the
+	 * SDK transport reads `ok` and the headers too.
+	 */
 	function stubFetch(status: number, body: unknown) {
-		const fetchMock = vi.fn().mockResolvedValue({
-			status,
-			text: async () =>
-				typeof body === "string" ? body : JSON.stringify(body),
-		});
+		const fetchMock = vi.fn().mockImplementation(
+			async (_url: string, init?: RequestInit) => {
+				let payload = body;
+				// Echo the request's JSON-RPC id, as a real server does. The SDK
+				// checks that ids match — a fixture with a hardcoded id fails that
+				// check, which the hand-rolled sender never performed.
+				if (typeof payload === "object" && payload !== null && "id" in payload) {
+					try {
+						const request = JSON.parse(String(init?.body ?? "{}"));
+						payload = { ...(payload as object), id: request.id };
+					} catch {
+						/* leave the fixture's id alone */
+					}
+				}
+				return new Response(
+					typeof payload === "string" ? payload : JSON.stringify(payload),
+					{ status, headers: { "content-type": "application/json" } },
+				);
+			},
+		);
 		vi.stubGlobal("fetch", fetchMock);
 		return fetchMock;
 	}
@@ -88,17 +109,43 @@ describe("sendA2AMessageToUrl", () => {
 		expect(fetchMock.mock.calls[0][0]).toBe("http://172.17.0.1:7420/a2a");
 	});
 
-	it("throws on HTTP error status with the body excerpt", async () => {
+	// The SDK transport words transport failures differently from the
+	// hand-rolled sender it replaced, so these assert on the substance an
+	// operator needs — which agent, what status, what came back — rather than
+	// on an exact phrase.
+	it("throws on HTTP error status, naming the endpoint, the status and the body", async () => {
 		stubFetch(401, "nope");
-		await expect(
-			sendA2AMessageToUrl({ endpoint: "https://gaia.example.com", text: "x" }),
-		).rejects.toThrow(/HTTP 401/);
+		const err = await sendA2AMessageToUrl({
+			endpoint: "https://gaia.example.com",
+			text: "x",
+		}).catch((e: unknown) => e as Error);
+
+		expect(err).toBeInstanceOf(Error);
+		expect(err.message).toContain("https://gaia.example.com");
+		expect(err.message).toContain("401");
+		expect(err.message).toContain("nope");
 	});
 
-	it("throws on invalid JSON", async () => {
+	it("throws on a non-JSON response, surfacing what came back instead", async () => {
 		stubFetch(200, "<html>not json</html>");
+		const err = await sendA2AMessageToUrl({
+			endpoint: "https://gaia.example.com",
+			text: "x",
+		}).catch((e: unknown) => e as Error);
+
+		expect(err).toBeInstanceOf(Error);
+		expect(err.message).toContain("https://gaia.example.com");
+		expect(err.message).toContain("not json");
+	});
+
+	it("surfaces a JSON-RPC error returned by the agent", async () => {
+		stubFetch(200, {
+			jsonrpc: "2.0",
+			id: "1",
+			error: { code: -32603, message: "agent exploded" },
+		});
 		await expect(
 			sendA2AMessageToUrl({ endpoint: "https://gaia.example.com", text: "x" }),
-		).rejects.toThrow(/Invalid A2A response/);
+		).rejects.toThrow(/agent exploded/);
 	});
 });

--- a/packages/protocols/src/a2a/client.ts
+++ b/packages/protocols/src/a2a/client.ts
@@ -8,7 +8,6 @@
  * pass a plain {@link A2AEndpoint} describing where the agent lives.
  */
 
-import http from "node:http";
 import { JsonRpcTransport } from "@a2a-js/sdk/client";
 import type {
   Message,
@@ -16,6 +15,12 @@ import type {
   TaskStatusUpdateEvent,
   TaskArtifactUpdateEvent,
 } from "@a2a-js/sdk";
+import { createA2ATransport, resolveA2AEndpointUrl } from "./task-client.js";
+
+/** Message ids are opaque; one generator keeps them consistent across senders. */
+function newA2AMessageId(): string {
+  return `a2a-msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
 
 /**
  * Events yielded by `streamA2AMessage` — re-exposed here because the SDK's
@@ -129,51 +134,66 @@ export async function sendA2AMessageToUrl(
   options: SendA2AMessageToUrlOptions,
 ): Promise<A2AMessageResponse> {
   const { endpoint, text, apiKey, contextId, timeoutMs } = options;
-  const url = new URL(endpoint);
-  if (!url.pathname.replace(/\/+$/, "").endsWith("/a2a")) {
-    url.pathname = `${url.pathname.replace(/\/+$/, "")}/a2a`;
-  }
+  const url = new URL(resolveA2AEndpointUrl(endpoint));
 
-  const messageId = `a2a-msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const rpcBody = JSON.stringify({
-    jsonrpc: "2.0",
-    id: `a2a-${Date.now()}`,
-    method: "message/send",
-    params: {
-      message: {
-        messageId,
-        role: "user",
-        parts: [{ kind: "text", text }],
-        ...(contextId ? { contextId } : {}),
-      },
-    },
-  });
-
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
+  // Blocking send: this function's contract is "give me the answer". Callers
+  // who need to survive a cold start or long work want the task surface in
+  // `task-client.ts` instead.
+  //
+  // The transport's own parse errors truncate the response to a few
+  // characters, which loses the single most useful clue when an agent is
+  // fronted by a proxy: that what came back was an HTML error page, not JSON.
+  // Tee the body so the excerpt survives into the thrown error.
+  let lastBody: string | undefined;
+  const teeingFetch: typeof fetch = async (input, init) => {
+    const res = await fetch(input, init);
+    lastBody = await res.clone().text();
+    return res;
   };
-  if (apiKey) headers.authorization = `Bearer ${apiKey}`;
 
-  const res = await fetch(url.toString(), {
-    method: "POST",
-    headers,
-    body: rpcBody,
-    signal: AbortSignal.timeout(timeoutMs ?? MESSAGE_TIMEOUT_MS),
+  const transport = new JsonRpcTransport({
+    endpoint: url.toString(),
+    fetchImpl: apiKey
+      ? (input, init) =>
+          teeingFetch(input, {
+            ...init,
+            headers: {
+              ...(init?.headers as Record<string, string> | undefined),
+              authorization: `Bearer ${apiKey}`,
+            },
+          })
+      : teeingFetch,
   });
-  const data = await res.text();
-  if (res.status >= 400) {
-    throw new Error(
-      `A2A request to ${url.origin} returned HTTP ${res.status}: ${data.slice(0, 300)}`,
+  const timeout = AbortSignal.timeout(timeoutMs ?? MESSAGE_TIMEOUT_MS);
+
+  let result: unknown;
+  try {
+    result = await transport.sendMessage(
+      {
+        message: {
+          kind: "message",
+          messageId: newA2AMessageId(),
+          role: "user",
+          parts: [{ kind: "text", text }],
+          ...(contextId ? { contextId } : {}),
+        },
+      },
+      { signal: timeout } as never,
     );
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    // Only append the body when the transport did not already quote it.
+    const excerpt =
+      lastBody && !reason.includes(lastBody.slice(0, 40))
+        ? ` Response body: ${lastBody.slice(0, 300)}`
+        : "";
+    throw new Error(`A2A error from ${url.origin}: ${reason}${excerpt}`, {
+      cause: err,
+    });
   }
-  let parsed: unknown;
+
   try {
-    parsed = JSON.parse(data);
-  } catch {
-    throw new Error(`Invalid A2A response from ${url.origin}: ${data.slice(0, 300)}`);
-  }
-  try {
-    return decodeA2ASendPayload(parsed, url.origin);
+    return decodeA2ASendPayload(result, url.origin);
   } catch (err) {
     throw new Error(
       `A2A error from ${url.origin}: ${err instanceof Error ? err.message : String(err)}`,
@@ -191,42 +211,36 @@ export async function fetchAgentCard(
   endpoint: A2AEndpoint,
 ): Promise<AgentCardSummary> {
   const where = describe(endpoint);
+  const origin = `http://${endpoint.host ?? DEFAULT_HOST}:${endpoint.port}`;
+  const url = new URL("/.well-known/agent-card.json", origin);
 
-  return new Promise<AgentCardSummary>((resolve, reject) => {
-    const req = http.request(
-      {
-        hostname: endpoint.host ?? DEFAULT_HOST,
-        port: endpoint.port,
-        path: "/.well-known/agent-card.json",
-        method: "GET",
-        headers: { accept: "application/json" },
-      },
-      (res) => {
-        let data = "";
-        res.on("data", (chunk) => (data += chunk));
-        res.on("end", () => {
-          if (res.statusCode && res.statusCode >= 400) {
-            reject(
-              new Error(
-                `Agent card request to ${where} returned HTTP ${res.statusCode}: ${data.slice(0, 200)}`,
-              ),
-            );
-            return;
-          }
-          try {
-            resolve(JSON.parse(data) as AgentCardSummary);
-          } catch {
-            reject(new Error(`Invalid agent card from ${where}`));
-          }
-        });
-      },
-    );
-    req.on("error", reject);
-    req.setTimeout(AGENT_CARD_TIMEOUT_MS, () => {
-      req.destroy(new Error(`Timeout fetching agent card from ${where}`));
+  const headers: Record<string, string> = { accept: "application/json" };
+  if (endpoint.apiKey) headers.authorization = `Bearer ${endpoint.apiKey}`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(AGENT_CARD_TIMEOUT_MS),
     });
-    req.end();
-  });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`Agent card request to ${where} failed: ${reason}`, {
+      cause: err,
+    });
+  }
+
+  const body = await res.text();
+  if (res.status >= 400) {
+    throw new Error(
+      `Agent card request to ${where} returned HTTP ${res.status}: ${body.slice(0, 200)}`,
+    );
+  }
+  try {
+    return JSON.parse(body) as AgentCardSummary;
+  } catch {
+    throw new Error(`Invalid agent card from ${where}`);
+  }
 }
 
 /**
@@ -239,80 +253,25 @@ export async function sendA2AMessage(
   text: string,
 ): Promise<A2AMessageResponse> {
   const where = describe(endpoint);
-  const messageId = `a2a-msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const rpcBody = JSON.stringify({
-    jsonrpc: "2.0",
-    id: `a2a-${Date.now()}`,
-    method: "message/send",
-    params: {
-      message: {
-        messageId,
-        role: "user",
-        parts: [{ kind: "text", text }],
-      },
-    },
-  });
+  // A container addressed by host and port is still reachable by URL, so this
+  // goes through the same SDK transport as everything else rather than a
+  // hand-rolled node:http request.
+  const origin = `http://${endpoint.host ?? DEFAULT_HOST}:${endpoint.port}`;
 
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-  };
-  if (endpoint.apiKey) {
-    headers.authorization = `Bearer ${endpoint.apiKey}`;
-  }
-
-  return new Promise<A2AMessageResponse>((resolve, reject) => {
-    const req = http.request(
-      {
-        hostname: endpoint.host ?? DEFAULT_HOST,
-        port: endpoint.port,
-        path: "/a2a",
-        method: "POST",
-        headers,
-      },
-      (res) => {
-        let data = "";
-        res.on("data", (chunk) => (data += chunk));
-        res.on("end", () => {
-          if (res.statusCode && res.statusCode >= 400) {
-            reject(
-              new Error(
-                `A2A request to ${where} returned HTTP ${res.statusCode}: ${data.slice(0, 300)}`,
-              ),
-            );
-            return;
-          }
-          let parsed: unknown;
-          try {
-            parsed = JSON.parse(data);
-          } catch {
-            reject(
-              new Error(`Invalid A2A response from ${where}: ${data.slice(0, 300)}`),
-            );
-            return;
-          }
-          try {
-            // Defensive base-join (#194): habitats mint absolute artifact URIs,
-            // but tolerate a relative `/files/...` from older/other agents by
-            // resolving it against this endpoint's origin.
-            const origin = `http://${endpoint.host ?? DEFAULT_HOST}:${endpoint.port}`;
-            resolve(decodeA2ASendPayload(parsed, origin));
-          } catch (err) {
-            reject(
-              new Error(
-                `A2A error from ${where}: ${err instanceof Error ? err.message : String(err)}`,
-              ),
-            );
-          }
-        });
-      },
-    );
-    req.on("error", reject);
-    req.setTimeout(MESSAGE_TIMEOUT_MS, () => {
-      req.destroy(new Error(`Timeout waiting for A2A response from ${where}`));
+  try {
+    return await sendA2AMessageToUrl({
+      endpoint: origin,
+      text,
+      apiKey: endpoint.apiKey,
+      timeoutMs: MESSAGE_TIMEOUT_MS,
     });
-    req.write(rpcBody);
-    req.end();
-  });
+  } catch (err) {
+    // Preserve the endpoint label callers rely on in error messages.
+    throw new Error(
+      `A2A error from ${where}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
 }
 
 /** Options for {@link streamA2AMessage}. */

--- a/packages/protocols/src/a2a/client.ts
+++ b/packages/protocols/src/a2a/client.ts
@@ -122,6 +122,12 @@ export interface SendA2AMessageToUrlOptions {
   contextId?: string;
   /** Abort the request after this many ms (default 120s). */
   timeoutMs?: number;
+  /**
+   * Extra metadata attached to the outgoing message. Habitats use this to
+   * carry the agent-call chain across the hop so the recursion guard survives
+   * a container boundary.
+   */
+  metadata?: Record<string, unknown>;
 }
 
 /**
@@ -133,7 +139,7 @@ export interface SendA2AMessageToUrlOptions {
 export async function sendA2AMessageToUrl(
   options: SendA2AMessageToUrlOptions,
 ): Promise<A2AMessageResponse> {
-  const { endpoint, text, apiKey, contextId, timeoutMs } = options;
+  const { endpoint, text, apiKey, contextId, timeoutMs, metadata } = options;
   const url = new URL(resolveA2AEndpointUrl(endpoint));
 
   // Blocking send: this function's contract is "give me the answer". Callers
@@ -176,6 +182,7 @@ export async function sendA2AMessageToUrl(
           role: "user",
           parts: [{ kind: "text", text }],
           ...(contextId ? { contextId } : {}),
+          ...(metadata ? { metadata } : {}),
         },
       },
       { signal: timeout } as never,

--- a/packages/protocols/src/a2a/file-task-store.test.ts
+++ b/packages/protocols/src/a2a/file-task-store.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Task, TaskState } from "@a2a-js/sdk";
+import { InMemoryTaskStore, type TaskStore } from "@a2a-js/sdk/server";
+import {
+	FileTaskStore,
+	INTERRUPTED_TASK_STATES,
+	TERMINAL_TASK_STATES,
+	isAbandonableTaskState,
+	isInterruptedTaskState,
+	isTerminalTaskState,
+} from "./file-task-store.js";
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+	return {
+		kind: "task",
+		id: "task-1",
+		contextId: "ctx-1",
+		status: { state: "working", timestamp: "2026-07-25T00:00:00.000Z" },
+		...overrides,
+	} as Task;
+}
+
+let dir: string;
+
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "umwelten-task-store-"));
+});
+
+afterEach(async () => {
+	await rm(dir, { recursive: true, force: true });
+});
+
+/**
+ * The substitution is only safe if the durable store behaves like the one it
+ * replaces, so the same contract runs against both. A divergence here means
+ * swapping the store changes behaviour, which is exactly what must not happen.
+ */
+describe.each([
+	["InMemoryTaskStore", () => new InMemoryTaskStore() as TaskStore],
+	["FileTaskStore", () => new FileTaskStore({ dir }) as TaskStore],
+])("TaskStore contract — %s", (_name, create) => {
+	it("returns undefined for a task that was never saved", async () => {
+		await expect(create().load("nope")).resolves.toBeUndefined();
+	});
+
+	it("round-trips a saved task", async () => {
+		const store = create();
+		const task = makeTask();
+		await store.save(task);
+		expect(await store.load(task.id)).toEqual(task);
+	});
+
+	it("overwrites an existing task with the same id", async () => {
+		const store = create();
+		await store.save(makeTask());
+		await store.save(makeTask({ status: { state: "completed" } }));
+		expect((await store.load("task-1"))?.status.state).toBe("completed");
+	});
+
+	it("keeps tasks with different ids independent", async () => {
+		const store = create();
+		await store.save(makeTask({ id: "a" }));
+		await store.save(makeTask({ id: "b", status: { state: "failed" } }));
+		expect((await store.load("a"))?.status.state).toBe("working");
+		expect((await store.load("b"))?.status.state).toBe("failed");
+	});
+
+	it("preserves artifacts and history", async () => {
+		const store = create();
+		const task = makeTask({
+			artifacts: [{ artifactId: "a1", parts: [{ kind: "text", text: "hi" }] }],
+			history: [
+				{
+					kind: "message",
+					role: "user",
+					messageId: "m1",
+					parts: [{ kind: "text", text: "question" }],
+				},
+			],
+		} as Partial<Task>);
+		await store.save(task);
+		expect(await store.load(task.id)).toEqual(task);
+	});
+});
+
+describe("FileTaskStore durability", () => {
+	/**
+	 * A deliberate divergence from this SDK version's `InMemoryTaskStore`,
+	 * which keeps the caller's object by reference — mutate it afterwards and
+	 * the store changes under you. A persisted store cannot reproduce that
+	 * aliasing, and should not: every mutation in the SDK is followed by an
+	 * explicit `save()`, so nothing depends on it, and later SDK versions
+	 * deep-clone on the way in for exactly this reason. Isolation is the
+	 * safer behaviour, so the durable store is stricter here rather than
+	 * bug-compatible.
+	 */
+	it("does not let a caller mutate stored state through the object it saved", async () => {
+		const store = new FileTaskStore({ dir });
+		const task = makeTask();
+		await store.save(task);
+		task.status.state = "canceled";
+		expect((await store.load("task-1"))?.status.state).toBe("working");
+	});
+
+	it("returns a task saved by a previous store instance", async () => {
+		await new FileTaskStore({ dir }).save(makeTask());
+
+		// A new instance stands in for a new container generation: same volume,
+		// no shared memory.
+		const restarted = new FileTaskStore({ dir });
+		expect((await restarted.load("task-1"))?.status.state).toBe("working");
+	});
+
+	it("survives a restart with artifacts and status history intact", async () => {
+		const task = makeTask({
+			status: {
+				state: "input-required",
+				timestamp: "2026-07-25T01:00:00.000Z",
+				message: {
+					kind: "message",
+					role: "agent",
+					messageId: "m9",
+					parts: [{ kind: "text", text: "which repo?" }],
+				},
+			},
+			artifacts: [{ artifactId: "a1", parts: [{ kind: "text", text: "report" }] }],
+		} as Partial<Task>);
+		await new FileTaskStore({ dir }).save(task);
+
+		expect(await new FileTaskStore({ dir }).load(task.id)).toEqual(task);
+	});
+
+	it("writes one file per task and reuses it on overwrite", async () => {
+		const store = new FileTaskStore({ dir });
+		await store.save(makeTask());
+		await store.save(makeTask({ status: { state: "completed" } }));
+		const files = (await readdir(dir)).filter((f) => f.endsWith(".task.json"));
+		expect(files).toHaveLength(1);
+	});
+
+	it("leaves no temp files behind after writing", async () => {
+		const store = new FileTaskStore({ dir });
+		await store.save(makeTask());
+		expect((await readdir(dir)).filter((f) => f.endsWith(".tmp"))).toEqual([]);
+	});
+
+	it("handles task ids that are not safe filenames", async () => {
+		const store = new FileTaskStore({ dir });
+		const nasty = "../../etc/passwd";
+		await store.save(makeTask({ id: nasty }));
+
+		expect((await new FileTaskStore({ dir }).load(nasty))?.id).toBe(nasty);
+		// The traversal must not have escaped the directory.
+		expect((await readdir(dir)).filter((f) => f.endsWith(".task.json"))).toHaveLength(1);
+	});
+
+	it("serialises concurrent saves of the same task without corrupting it", async () => {
+		const store = new FileTaskStore({ dir });
+		const states: TaskState[] = ["submitted", "working", "completed"];
+		await Promise.all(
+			states.map((state) => store.save(makeTask({ status: { state } }))),
+		);
+
+		const persisted = await new FileTaskStore({ dir }).load("task-1");
+		// Whichever write landed last, the record must be a whole valid Task.
+		expect(persisted).toBeDefined();
+		expect(states).toContain(persisted?.status.state);
+	});
+
+	it("creates its directory on demand", async () => {
+		const nested = join(dir, "deep", "tasks");
+		await new FileTaskStore({ dir: nested }).save(makeTask());
+		expect((await readdir(nested)).length).toBeGreaterThan(0);
+	});
+
+	describe("listAll", () => {
+		it("is empty for a directory that does not exist yet", async () => {
+			expect(await new FileTaskStore({ dir: join(dir, "absent") }).listAll()).toEqual([]);
+		});
+
+		it("returns every persisted task", async () => {
+			const store = new FileTaskStore({ dir });
+			await store.save(makeTask({ id: "a" }));
+			await store.save(makeTask({ id: "b" }));
+			const ids = (await new FileTaskStore({ dir }).listAll()).map((t) => t.id).sort();
+			expect(ids).toEqual(["a", "b"]);
+		});
+
+		it("skips unreadable files rather than failing the whole sweep", async () => {
+			const store = new FileTaskStore({ dir });
+			await store.save(makeTask({ id: "good" }));
+			await writeFile(join(dir, "broken.task.json"), "{ not json", "utf-8");
+
+			const tasks = await new FileTaskStore({ dir }).listAll();
+			expect(tasks.map((t) => t.id)).toEqual(["good"]);
+		});
+
+		it("ignores files that are not task records", async () => {
+			await new FileTaskStore({ dir }).save(makeTask());
+			await writeFile(join(dir, "notes.txt"), "unrelated", "utf-8");
+			expect(await new FileTaskStore({ dir }).listAll()).toHaveLength(1);
+		});
+	});
+});
+
+describe("task state classification", () => {
+	it.each(TERMINAL_TASK_STATES)("treats %s as terminal", (state) => {
+		expect(isTerminalTaskState(state)).toBe(true);
+		expect(isAbandonableTaskState(state)).toBe(false);
+	});
+
+	it.each(INTERRUPTED_TASK_STATES)("treats %s as interrupted, not abandonable", (state) => {
+		expect(isInterruptedTaskState(state)).toBe(true);
+		expect(isAbandonableTaskState(state)).toBe(false);
+	});
+
+	it.each(["submitted", "working", "unknown"] as TaskState[])(
+		"treats %s as abandonable",
+		(state) => {
+			expect(isAbandonableTaskState(state)).toBe(true);
+		},
+	);
+
+	it("treats a missing state as abandonable", () => {
+		expect(isAbandonableTaskState(undefined)).toBe(true);
+	});
+});

--- a/packages/protocols/src/a2a/file-task-store.ts
+++ b/packages/protocols/src/a2a/file-task-store.ts
@@ -1,0 +1,197 @@
+/**
+ * Durable A2A {@link TaskStore} backed by the filesystem.
+ *
+ * The SDK ships `InMemoryTaskStore`, which loses every Task when its process
+ * exits. That is fine for a server that only stops when someone stops it, and
+ * fatal once an idle reaper is the thing doing the stopping: a caller polling
+ * `tasks/get` after a restart would be told the Task never existed.
+ *
+ * This store persists each Task as one JSON file so a habitat's Tasks survive
+ * its container. Per ADR 0007 the durable Task lives on the habitat's own
+ * volume — the process serving `tasks/get` is the one that has to read it, and
+ * habitat-to-habitat traffic never reaches the control plane, so the store
+ * cannot live there.
+ *
+ * Files are named by a hash of the task id rather than the id itself, so no
+ * id can escape the directory or exceed a filename limit; the real id is
+ * recorded inside. Writes go to a temp file and are renamed into place, so a
+ * crash mid-write leaves the previous record intact rather than a truncated
+ * one. Saves for the same task are serialised, so two concurrent writers
+ * cannot interleave into a corrupt record.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, readdir, rename, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Task, TaskState } from "@a2a-js/sdk";
+import type { TaskStore } from "@a2a-js/sdk/server";
+
+/** States from which a Task will never move again. */
+export const TERMINAL_TASK_STATES: readonly TaskState[] = [
+	"completed",
+	"canceled",
+	"failed",
+	"rejected",
+];
+
+/**
+ * Non-terminal states in which a Task is legitimately waiting on something
+ * outside the agent — a follow-up message, or a credential the caller must
+ * authorize. These are NOT abandoned work and must never be swept.
+ */
+export const INTERRUPTED_TASK_STATES: readonly TaskState[] = [
+	"input-required",
+	"auth-required",
+];
+
+export function isTerminalTaskState(state: TaskState | undefined): boolean {
+	return state !== undefined && TERMINAL_TASK_STATES.includes(state);
+}
+
+export function isInterruptedTaskState(state: TaskState | undefined): boolean {
+	return state !== undefined && INTERRUPTED_TASK_STATES.includes(state);
+}
+
+/**
+ * True when a Task is neither finished nor deliberately waiting — i.e. it was
+ * mid-flight. After a restart these are the Tasks nothing is working on any
+ * more; see `sweepAbandonedTasks`.
+ */
+export function isAbandonableTaskState(state: TaskState | undefined): boolean {
+	return !isTerminalTaskState(state) && !isInterruptedTaskState(state);
+}
+
+/** File extension for persisted task records. */
+const TASK_FILE_SUFFIX = ".task.json";
+
+/** Envelope written to disk. The id is stored because the filename is a hash. */
+interface PersistedTask {
+	version: 1;
+	id: string;
+	task: Task;
+}
+
+function fileNameFor(taskId: string): string {
+	const digest = createHash("sha256").update(taskId).digest("hex");
+	return `${digest}${TASK_FILE_SUFFIX}`;
+}
+
+export interface FileTaskStoreOptions {
+	/** Directory holding the task files. Created on demand. */
+	dir: string;
+}
+
+export class FileTaskStore implements TaskStore {
+	private readonly dir: string;
+	/** Write-through cache, so a hot Task does not hit the disk on every read. */
+	private readonly cache = new Map<string, Task>();
+	/** Per-task write chains, so concurrent saves for one id serialise. */
+	private readonly writes = new Map<string, Promise<void>>();
+	private ensured = false;
+
+	constructor(options: FileTaskStoreOptions) {
+		this.dir = options.dir;
+	}
+
+	private async ensureDir(): Promise<void> {
+		if (this.ensured) return;
+		await mkdir(this.dir, { recursive: true });
+		this.ensured = true;
+	}
+
+	private pathFor(taskId: string): string {
+		return join(this.dir, fileNameFor(taskId));
+	}
+
+	async save(task: Task): Promise<void> {
+		// Copy on the way in so a caller mutating its Task afterwards cannot
+		// drift what we hold or what we are about to write.
+		const snapshot = structuredClone(task);
+		this.cache.set(snapshot.id, snapshot);
+
+		const previous = this.writes.get(snapshot.id) ?? Promise.resolve();
+		const next = previous
+			.catch(() => {
+				/* a failed earlier write must not cancel this one */
+			})
+			.then(() => this.writeFileAtomic(snapshot));
+
+		this.writes.set(snapshot.id, next);
+		try {
+			await next;
+		} finally {
+			if (this.writes.get(snapshot.id) === next) {
+				this.writes.delete(snapshot.id);
+			}
+		}
+	}
+
+	private async writeFileAtomic(task: Task): Promise<void> {
+		await this.ensureDir();
+		const target = this.pathFor(task.id);
+		// Unique temp name: two writers for *different* tasks may run at once.
+		const tmp = `${target}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+		const payload: PersistedTask = { version: 1, id: task.id, task };
+		try {
+			await writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, "utf-8");
+			await rename(tmp, target);
+		} catch (err) {
+			await unlink(tmp).catch(() => {
+				/* best effort */
+			});
+			throw err;
+		}
+	}
+
+	async load(taskId: string): Promise<Task | undefined> {
+		const cached = this.cache.get(taskId);
+		if (cached) return structuredClone(cached);
+
+		const record = await this.readRecord(this.pathFor(taskId));
+		if (!record) return undefined;
+		this.cache.set(record.id, record.task);
+		return structuredClone(record.task);
+	}
+
+	private async readRecord(path: string): Promise<PersistedTask | undefined> {
+		let raw: string;
+		try {
+			raw = await readFile(path, "utf-8");
+		} catch {
+			return undefined;
+		}
+		try {
+			const parsed = JSON.parse(raw) as PersistedTask;
+			// A record without a task is corrupt; treat it as absent rather than
+			// letting `undefined` masquerade as a Task downstream.
+			if (!parsed?.task?.id) return undefined;
+			return parsed;
+		} catch {
+			return undefined;
+		}
+	}
+
+	/**
+	 * Every persisted Task. Used by the boot recovery sweep; the A2A surface
+	 * itself has no list method in this protocol version.
+	 */
+	async listAll(): Promise<Task[]> {
+		await this.ensureDir();
+		let entries: string[];
+		try {
+			entries = await readdir(this.dir);
+		} catch {
+			return [];
+		}
+
+		const tasks: Task[] = [];
+		for (const entry of entries) {
+			if (!entry.endsWith(TASK_FILE_SUFFIX)) continue;
+			const record = await this.readRecord(join(this.dir, entry));
+			// Unreadable or half-written files are skipped rather than throwing —
+			// one bad file must not make the whole fleet's recovery fail.
+			if (record) tasks.push(record.task);
+		}
+		return tasks;
+	}
+}

--- a/packages/protocols/src/a2a/index.ts
+++ b/packages/protocols/src/a2a/index.ts
@@ -34,6 +34,25 @@ export {
   DEFAULT_ABANDONED_REASON,
 } from "./task-recovery.js";
 export type { SweepOptions, SweepResult } from "./task-recovery.js";
+export {
+  resolveA2AEndpointUrl,
+  createA2ATransport,
+  sendA2ATask,
+  getA2ATask,
+  cancelA2ATask,
+  pollA2ATask,
+  sendAndAwaitA2ATask,
+  isA2ATask,
+  isSettledTaskState,
+  A2APollTimeoutError,
+} from "./task-client.js";
+export type {
+  A2ATaskTarget,
+  SendA2ATaskOptions,
+  GetA2ATaskOptions,
+  PollA2ATaskOptions,
+  SendAndAwaitOptions,
+} from "./task-client.js";
 export type {
   A2AServer,
   A2AServerOptions,

--- a/packages/protocols/src/a2a/index.ts
+++ b/packages/protocols/src/a2a/index.ts
@@ -19,6 +19,21 @@ export type {
 } from "./client.js";
 
 export { createA2AServer } from "./server.js";
+export {
+  FileTaskStore,
+  TERMINAL_TASK_STATES,
+  INTERRUPTED_TASK_STATES,
+  isTerminalTaskState,
+  isInterruptedTaskState,
+  isAbandonableTaskState,
+} from "./file-task-store.js";
+export type { FileTaskStoreOptions } from "./file-task-store.js";
+export {
+  sweepAbandonedTasks,
+  ABANDONED_TASK_MARKER,
+  DEFAULT_ABANDONED_REASON,
+} from "./task-recovery.js";
+export type { SweepOptions, SweepResult } from "./task-recovery.js";
 export type {
   A2AServer,
   A2AServerOptions,

--- a/packages/protocols/src/a2a/server.ts
+++ b/packages/protocols/src/a2a/server.ts
@@ -16,6 +16,7 @@ import {
   DefaultExecutionEventBusManager,
   JsonRpcTransportHandler,
   type AgentExecutor,
+  type TaskStore,
 } from "@a2a-js/sdk/server";
 import type { AgentCard } from "@a2a-js/sdk";
 
@@ -24,6 +25,13 @@ export interface A2AServerOptions {
   agentCard: AgentCard;
   /** Executor that runs the agent for each incoming request. */
   executor: AgentExecutor;
+  /**
+   * Where Tasks are kept. Defaults to the SDK's in-memory store, which loses
+   * every Task when the process exits — fine for tests and one-shot servers,
+   * wrong for any habitat that can be stopped while idle. Long-lived hosts
+   * should pass a `FileTaskStore` on the habitat's volume (ADR 0007).
+   */
+  taskStore?: TaskStore;
 }
 
 export interface A2AServer {
@@ -43,7 +51,7 @@ export interface A2AServer {
 export function createA2AServer(options: A2AServerOptions): A2AServer {
   const { agentCard, executor } = options;
 
-  const taskStore = new InMemoryTaskStore();
+  const taskStore = options.taskStore ?? new InMemoryTaskStore();
   const eventBusManager = new DefaultExecutionEventBusManager();
   const requestHandler = new DefaultRequestHandler(
     agentCard,

--- a/packages/protocols/src/a2a/task-client.test.ts
+++ b/packages/protocols/src/a2a/task-client.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { Task, TaskState } from "@a2a-js/sdk";
+import {
+	A2APollTimeoutError,
+	cancelA2ATask,
+	getA2ATask,
+	isA2ATask,
+	isSettledTaskState,
+	pollA2ATask,
+	resolveA2AEndpointUrl,
+	sendA2ATask,
+	sendAndAwaitA2ATask,
+} from "./task-client.js";
+
+const ENDPOINT = "http://127.0.0.1:7440";
+
+function task(state: TaskState, id = "t1"): Task {
+	return {
+		kind: "task",
+		id,
+		contextId: "ctx",
+		status: { state, timestamp: "2026-07-25T00:00:00.000Z" },
+	} as Task;
+}
+
+interface Call {
+	url: string;
+	method: string;
+	params: Record<string, unknown>;
+	headers: Record<string, string>;
+}
+
+let calls: Call[];
+let originalFetch: typeof fetch;
+
+/** Stubs fetch with a queue of JSON-RPC results, one per request. */
+function stubRpc(results: unknown[]): void {
+	let i = 0;
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const body = JSON.parse(String(init?.body ?? "{}"));
+		calls.push({
+			url: String(input),
+			method: body.method,
+			params: body.params ?? {},
+			headers: (init?.headers ?? {}) as Record<string, string>,
+		});
+		const result = results[Math.min(i, results.length - 1)];
+		i += 1;
+		return new Response(
+			JSON.stringify({ jsonrpc: "2.0", id: body.id, result }),
+			{ status: 200, headers: { "content-type": "application/json" } },
+		);
+	}) as typeof fetch;
+}
+
+beforeEach(() => {
+	calls = [];
+	originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+const noSleep = async () => {};
+
+describe("resolveA2AEndpointUrl", () => {
+	it("appends /a2a to a bare origin", () => {
+		expect(resolveA2AEndpointUrl("http://host:7440")).toBe("http://host:7440/a2a");
+	});
+
+	it("leaves an endpoint that already targets /a2a alone", () => {
+		expect(resolveA2AEndpointUrl("http://host:7440/a2a")).toBe("http://host:7440/a2a");
+	});
+
+	it("tolerates a trailing slash", () => {
+		expect(resolveA2AEndpointUrl("http://host:7440/")).toBe("http://host:7440/a2a");
+	});
+
+	it("appends beneath a base path", () => {
+		expect(resolveA2AEndpointUrl("https://x.dev/agents/bot")).toBe(
+			"https://x.dev/agents/bot/a2a",
+		);
+	});
+
+	it("treats a loopback host:port origin as an ordinary URL", () => {
+		expect(resolveA2AEndpointUrl("http://127.0.0.1:7440")).toBe(
+			"http://127.0.0.1:7440/a2a",
+		);
+	});
+});
+
+describe("sendA2ATask", () => {
+	it("does not block by default, so a cold start is not a timeout", async () => {
+		stubRpc([task("submitted")]);
+		await sendA2ATask({ endpoint: ENDPOINT, text: "hi" });
+		expect(calls[0].method).toBe("message/send");
+		expect((calls[0].params as any).configuration.blocking).toBe(false);
+	});
+
+	it("can block when a caller explicitly wants the answer", async () => {
+		stubRpc([task("completed")]);
+		await sendA2ATask({ endpoint: ENDPOINT, text: "hi", blocking: true });
+		expect((calls[0].params as any).configuration.blocking).toBe(true);
+	});
+
+	it("returns the Task the agent opened", async () => {
+		stubRpc([task("working")]);
+		const result = await sendA2ATask({ endpoint: ENDPOINT, text: "hi" });
+		expect(isA2ATask(result)).toBe(true);
+		expect((result as Task).id).toBe("t1");
+	});
+
+	it("returns a Message when the agent answers immediately instead", async () => {
+		stubRpc([
+			{ kind: "message", role: "agent", messageId: "m1", parts: [{ kind: "text", text: "hi" }] },
+		]);
+		const result = await sendA2ATask({ endpoint: ENDPOINT, text: "hi" });
+		expect(isA2ATask(result)).toBe(false);
+	});
+
+	it("threads into an existing conversation when given a contextId", async () => {
+		stubRpc([task("submitted")]);
+		await sendA2ATask({ endpoint: ENDPOINT, text: "hi", contextId: "ctx-9" });
+		expect((calls[0].params as any).message.contextId).toBe("ctx-9");
+	});
+
+	it("sends a bearer token when one is configured", async () => {
+		stubRpc([task("submitted")]);
+		await sendA2ATask({ endpoint: ENDPOINT, text: "hi", apiKey: "secret" });
+		expect(calls[0].headers.authorization).toBe("Bearer secret");
+	});
+
+	it("sends no authorization header when no token is configured", async () => {
+		stubRpc([task("submitted")]);
+		await sendA2ATask({ endpoint: ENDPOINT, text: "hi" });
+		expect(calls[0].headers.authorization).toBeUndefined();
+	});
+
+	it("registers a push notification target when asked", async () => {
+		stubRpc([task("submitted")]);
+		await sendA2ATask({
+			endpoint: ENDPOINT,
+			text: "hi",
+			pushNotificationUrl: "https://hook.example/1",
+		});
+		expect((calls[0].params as any).configuration.pushNotificationConfig.url).toBe(
+			"https://hook.example/1",
+		);
+	});
+});
+
+describe("getA2ATask / cancelA2ATask", () => {
+	it("fetches a task by id", async () => {
+		stubRpc([task("working")]);
+		const result = await getA2ATask({ endpoint: ENDPOINT, taskId: "t1" });
+		expect(calls[0].method).toBe("tasks/get");
+		expect((calls[0].params as any).id).toBe("t1");
+		expect(result.status.state).toBe("working");
+	});
+
+	it("cancels a task by id", async () => {
+		stubRpc([task("canceled")]);
+		const result = await cancelA2ATask({ endpoint: ENDPOINT, taskId: "t1" });
+		expect(calls[0].method).toBe("tasks/cancel");
+		expect(result.status.state).toBe("canceled");
+	});
+});
+
+describe("isSettledTaskState", () => {
+	it.each(["completed", "failed", "canceled", "rejected"] as TaskState[])(
+		"treats terminal state %s as settled",
+		(state) => expect(isSettledTaskState(state)).toBe(true),
+	);
+
+	it.each(["input-required", "auth-required"] as TaskState[])(
+		"treats %s as settled — the agent is waiting on us, so polling would spin forever",
+		(state) => expect(isSettledTaskState(state)).toBe(true),
+	);
+
+	it.each(["submitted", "working"] as TaskState[])(
+		"treats in-flight state %s as unsettled",
+		(state) => expect(isSettledTaskState(state)).toBe(false),
+	);
+});
+
+describe("pollA2ATask", () => {
+	it("returns as soon as the task completes", async () => {
+		stubRpc([task("working"), task("working"), task("completed")]);
+		const result = await pollA2ATask({
+			endpoint: ENDPOINT,
+			taskId: "t1",
+			sleep: noSleep,
+		});
+		expect(result.status.state).toBe("completed");
+		expect(calls).toHaveLength(3);
+	});
+
+	it("stops at an interrupted state rather than polling forever", async () => {
+		stubRpc([task("working"), task("auth-required")]);
+		const result = await pollA2ATask({
+			endpoint: ENDPOINT,
+			taskId: "t1",
+			sleep: noSleep,
+		});
+		expect(result.status.state).toBe("auth-required");
+	});
+
+	it("reports each observed state so a caller can show progress", async () => {
+		stubRpc([task("submitted"), task("working"), task("completed")]);
+		const seen: TaskState[] = [];
+		await pollA2ATask({
+			endpoint: ENDPOINT,
+			taskId: "t1",
+			sleep: noSleep,
+			onState: (t) => seen.push(t.status.state),
+		});
+		expect(seen).toEqual(["submitted", "working", "completed"]);
+	});
+
+	it("backs off between polls instead of hammering a booting habitat", async () => {
+		stubRpc([task("working"), task("working"), task("working"), task("completed")]);
+		const waits: number[] = [];
+		await pollA2ATask({
+			endpoint: ENDPOINT,
+			taskId: "t1",
+			intervalMs: 100,
+			sleep: async (ms) => {
+				waits.push(ms);
+			},
+		});
+		expect(waits).toEqual([100, 200, 400]);
+	});
+
+	it("caps the backoff so a long wake never stalls out", async () => {
+		stubRpc([...Array(12).fill(task("working")), task("completed")]);
+		const waits: number[] = [];
+		await pollA2ATask({
+			endpoint: ENDPOINT,
+			taskId: "t1",
+			intervalMs: 1_000,
+			sleep: async (ms) => {
+				waits.push(ms);
+			},
+		});
+		expect(Math.max(...waits)).toBe(15_000);
+	});
+
+	it("throws a timeout error naming the last state it saw", async () => {
+		stubRpc([task("working")]);
+		let clock = 0;
+		await expect(
+			pollA2ATask({
+				endpoint: ENDPOINT,
+				taskId: "t1",
+				timeoutMs: 500,
+				sleep: noSleep,
+				now: () => (clock += 1_000),
+			}),
+		).rejects.toThrow(A2APollTimeoutError);
+	});
+
+	it("stops when the caller aborts", async () => {
+		stubRpc([task("working")]);
+		const controller = new AbortController();
+		controller.abort();
+		await expect(
+			pollA2ATask({
+				endpoint: ENDPOINT,
+				taskId: "t1",
+				sleep: noSleep,
+				signal: controller.signal,
+			}),
+		).rejects.toThrow();
+	});
+});
+
+describe("sendAndAwaitA2ATask", () => {
+	it("tracks a task opened by the send through to completion", async () => {
+		stubRpc([task("submitted"), task("working"), task("completed")]);
+		const result = await sendAndAwaitA2ATask({
+			endpoint: ENDPOINT,
+			text: "hi",
+			sleep: noSleep,
+		});
+		expect((result as Task).status.state).toBe("completed");
+		expect(calls[0].method).toBe("message/send");
+		expect(calls[1].method).toBe("tasks/get");
+	});
+
+	it("does not poll when the send already came back settled", async () => {
+		stubRpc([task("completed")]);
+		await sendAndAwaitA2ATask({ endpoint: ENDPOINT, text: "hi", sleep: noSleep });
+		expect(calls).toHaveLength(1);
+	});
+
+	it("returns an immediate Message without polling", async () => {
+		stubRpc([
+			{ kind: "message", role: "agent", messageId: "m1", parts: [{ kind: "text", text: "yo" }] },
+		]);
+		const result = await sendAndAwaitA2ATask({
+			endpoint: ENDPOINT,
+			text: "hi",
+			sleep: noSleep,
+		});
+		expect(isA2ATask(result)).toBe(false);
+		expect(calls).toHaveLength(1);
+	});
+
+	it("carries the bearer token through to the polling calls", async () => {
+		stubRpc([task("working"), task("completed")]);
+		await sendAndAwaitA2ATask({
+			endpoint: ENDPOINT,
+			text: "hi",
+			apiKey: "secret",
+			sleep: noSleep,
+		});
+		expect(calls.every((c) => c.headers.authorization === "Bearer secret")).toBe(true);
+	});
+});

--- a/packages/protocols/src/a2a/task-client.ts
+++ b/packages/protocols/src/a2a/task-client.ts
@@ -1,0 +1,266 @@
+/**
+ * A2A task surface for callers — the half of the protocol this repo never
+ * used.
+ *
+ * `message/send` blocks until the agent finishes. That is fine for a quick
+ * question and wrong for two situations this fleet now has: a habitat that is
+ * asleep and has to boot before it can answer, and work that genuinely takes
+ * minutes (a rollup across every client habitat). Both exceed any sane HTTP
+ * timeout.
+ *
+ * A2A already models this. A send with `configuration.blocking: false` returns
+ * a **Task** in a non-terminal state straight away; the caller then tracks it
+ * with `tasks/get` until it reaches a terminal or interrupted state. Per
+ * ADR 0007 a dormant habitat is not a special case — it is a task that takes
+ * longer to reach `working`.
+ *
+ * Everything here is built on the SDK's `JsonRpcTransport` rather than
+ * hand-rolled JSON-RPC, so wire-format handling is the SDK's problem.
+ *
+ * Note for readers comparing against the A2A docs: the pinned SDK (0.3.14)
+ * spells non-blocking as `configuration.blocking: false`, not
+ * `returnImmediately`, and serves no `tasks/list`.
+ */
+
+import { JsonRpcTransport } from "@a2a-js/sdk/client";
+import type { Message, Task, TaskState } from "@a2a-js/sdk";
+import {
+	isInterruptedTaskState,
+	isTerminalTaskState,
+} from "./file-task-store.js";
+
+/** Default ceiling on how long `pollA2ATask` will wait. */
+const DEFAULT_POLL_TIMEOUT_MS = 15 * 60_000;
+/** Starting gap between polls; backs off up to {@link MAX_POLL_INTERVAL_MS}. */
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const MAX_POLL_INTERVAL_MS = 15_000;
+
+/**
+ * Normalise an agent's base URL to its JSON-RPC endpoint. A bare origin gets
+ * `/a2a` appended; an endpoint that already ends in `/a2a` is left alone.
+ *
+ * Addressing a container by host and port is not a reason to hand-roll a
+ * client — `http://127.0.0.1:7440` is a perfectly good URL.
+ */
+export function resolveA2AEndpointUrl(endpoint: string): string {
+	const url = new URL(endpoint);
+	const path = url.pathname.replace(/\/+$/, "");
+	if (!path.endsWith("/a2a")) url.pathname = `${path}/a2a`;
+	return url.toString();
+}
+
+/** Wraps fetch so every request the transport makes carries the bearer. */
+function authenticatedFetch(apiKey?: string): typeof fetch {
+	if (!apiKey) return fetch;
+	return (input, init) =>
+		fetch(input, {
+			...init,
+			headers: {
+				...(init?.headers as Record<string, string> | undefined),
+				authorization: `Bearer ${apiKey}`,
+			},
+		});
+}
+
+/** Build a transport pointed at an agent's JSON-RPC endpoint. */
+export function createA2ATransport(
+	endpoint: string,
+	apiKey?: string,
+): JsonRpcTransport {
+	return new JsonRpcTransport({
+		endpoint: resolveA2AEndpointUrl(endpoint),
+		fetchImpl: authenticatedFetch(apiKey),
+	});
+}
+
+export interface A2ATaskTarget {
+	/** Agent base URL or full `/a2a` endpoint. */
+	endpoint: string;
+	/** Optional bearer token. */
+	apiKey?: string;
+}
+
+export interface SendA2ATaskOptions extends A2ATaskTarget {
+	/** User text to send. */
+	text: string;
+	/** Thread this message into an existing conversation. */
+	contextId?: string;
+	/**
+	 * Wait for completion. Defaults to false — the point of this function is
+	 * to get a Task back before the work is done.
+	 */
+	blocking?: boolean;
+	/** Where the agent should POST status updates, if it supports them. */
+	pushNotificationUrl?: string;
+}
+
+function newMessageId(): string {
+	return `a2a-msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Send a message without waiting for the answer. Resolves as soon as the agent
+ * acknowledges, normally with a Task in `submitted` or `working`.
+ *
+ * An agent may still answer immediately with a Message rather than a Task —
+ * that is legal, and callers must handle both.
+ */
+export async function sendA2ATask(
+	options: SendA2ATaskOptions,
+): Promise<Task | Message> {
+	const transport = createA2ATransport(options.endpoint, options.apiKey);
+	return transport.sendMessage({
+		message: {
+			kind: "message",
+			messageId: newMessageId(),
+			role: "user",
+			parts: [{ kind: "text", text: options.text }],
+			...(options.contextId ? { contextId: options.contextId } : {}),
+		},
+		configuration: {
+			blocking: options.blocking ?? false,
+			...(options.pushNotificationUrl
+				? { pushNotificationConfig: { url: options.pushNotificationUrl } }
+				: {}),
+		},
+	}) as Promise<Task | Message>;
+}
+
+/** True when the result of a send is a Task rather than an immediate Message. */
+export function isA2ATask(result: Task | Message): result is Task {
+	return (result as Task)?.kind === "task";
+}
+
+export interface GetA2ATaskOptions extends A2ATaskTarget {
+	taskId: string;
+	/** Trailing messages of the task's history to include. */
+	historyLength?: number;
+}
+
+/** Fetch a task's current state. */
+export async function getA2ATask(options: GetA2ATaskOptions): Promise<Task> {
+	const transport = createA2ATransport(options.endpoint, options.apiKey);
+	return transport.getTask({
+		id: options.taskId,
+		...(options.historyLength !== undefined
+			? { historyLength: options.historyLength }
+			: {}),
+	});
+}
+
+/** Ask the agent to stop a task that is still running. */
+export async function cancelA2ATask(
+	options: A2ATaskTarget & { taskId: string },
+): Promise<Task> {
+	const transport = createA2ATransport(options.endpoint, options.apiKey);
+	return transport.cancelTask({ id: options.taskId });
+}
+
+/**
+ * A task has settled when it will not move again on its own — either it
+ * finished, or it is waiting on someone. `auth-required` and `input-required`
+ * count: continuing to poll them would spin forever, because the agent is
+ * waiting for the caller, not the other way round.
+ */
+export function isSettledTaskState(state: TaskState | undefined): boolean {
+	return isTerminalTaskState(state) || isInterruptedTaskState(state);
+}
+
+export interface PollA2ATaskOptions extends GetA2ATaskOptions {
+	/** Gap between polls; backs off toward 15s. Default 1s. */
+	intervalMs?: number;
+	/** Give up after this long. Default 15 minutes. */
+	timeoutMs?: number;
+	/** Caller-side cancellation. */
+	signal?: AbortSignal;
+	/** Called with each observed state, for progress reporting. */
+	onState?: (task: Task) => void;
+	/** Injectable sleep, so tests do not wait in real time. */
+	sleep?: (ms: number) => Promise<void>;
+	/** Injectable clock, so tests do not depend on wall time. */
+	now?: () => number;
+}
+
+export class A2APollTimeoutError extends Error {
+	constructor(
+		readonly taskId: string,
+		readonly lastState: TaskState | undefined,
+		timeoutMs: number,
+	) {
+		super(
+			`Task ${taskId} did not settle within ${timeoutMs}ms (last state: ${lastState ?? "unknown"})`,
+		);
+		this.name = "A2APollTimeoutError";
+	}
+}
+
+const defaultSleep = (ms: number) =>
+	new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Poll a task until it settles, and return it.
+ *
+ * Backs off from `intervalMs` toward 15s: a habitat cold-starting behind a
+ * clone and a dependency install can take minutes, and hammering it every
+ * second for the whole boot helps nobody.
+ */
+export async function pollA2ATask(options: PollA2ATaskOptions): Promise<Task> {
+	const sleep = options.sleep ?? defaultSleep;
+	const now = options.now ?? (() => Date.now());
+	const timeoutMs = options.timeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
+	const startedAt = now();
+
+	let interval = options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+	let lastState: TaskState | undefined;
+
+	for (;;) {
+		options.signal?.throwIfAborted();
+
+		const task = await getA2ATask(options);
+		lastState = task.status?.state;
+		options.onState?.(task);
+
+		if (isSettledTaskState(lastState)) return task;
+
+		if (now() - startedAt >= timeoutMs) {
+			throw new A2APollTimeoutError(options.taskId, lastState, timeoutMs);
+		}
+
+		await sleep(interval);
+		interval = Math.min(interval * 2, MAX_POLL_INTERVAL_MS);
+	}
+}
+
+export interface SendAndAwaitOptions extends SendA2ATaskOptions {
+	intervalMs?: number;
+	timeoutMs?: number;
+	signal?: AbortSignal;
+	onState?: (task: Task) => void;
+	sleep?: (ms: number) => Promise<void>;
+	now?: () => number;
+}
+
+/**
+ * Send without blocking, then track the task to settlement — the shape a
+ * caller wants when the agent might be asleep. Returns the Message directly
+ * if the agent answered immediately instead of opening a task.
+ */
+export async function sendAndAwaitA2ATask(
+	options: SendAndAwaitOptions,
+): Promise<Task | Message> {
+	const sent = await sendA2ATask(options);
+	if (!isA2ATask(sent)) return sent;
+	if (isSettledTaskState(sent.status?.state)) return sent;
+
+	return pollA2ATask({
+		endpoint: options.endpoint,
+		apiKey: options.apiKey,
+		taskId: sent.id,
+		intervalMs: options.intervalMs,
+		timeoutMs: options.timeoutMs,
+		signal: options.signal,
+		onState: options.onState,
+		sleep: options.sleep,
+		now: options.now,
+	});
+}

--- a/packages/protocols/src/a2a/task-recovery.test.ts
+++ b/packages/protocols/src/a2a/task-recovery.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Task, TaskState } from "@a2a-js/sdk";
+import { FileTaskStore } from "./file-task-store.js";
+import {
+	ABANDONED_TASK_MARKER,
+	DEFAULT_ABANDONED_REASON,
+	sweepAbandonedTasks,
+} from "./task-recovery.js";
+
+let dir: string;
+
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "umwelten-task-recovery-"));
+});
+
+afterEach(async () => {
+	await rm(dir, { recursive: true, force: true });
+});
+
+function makeTask(id: string, state: TaskState): Task {
+	return {
+		kind: "task",
+		id,
+		contextId: `ctx-${id}`,
+		status: { state, timestamp: "2026-07-25T00:00:00.000Z" },
+	} as Task;
+}
+
+/** Seeds a store as a previous container generation would have left it. */
+async function seed(...tasks: Task[]): Promise<FileTaskStore> {
+	const store = new FileTaskStore({ dir });
+	for (const task of tasks) await store.save(task);
+	return new FileTaskStore({ dir });
+}
+
+const fixedClock = () => "2026-07-25T12:00:00.000Z";
+const fixedIds = () => "msg-fixed";
+
+describe("sweepAbandonedTasks", () => {
+	it("fails a task left mid-flight by a stopped container", async () => {
+		const store = await seed(makeTask("a", "working"));
+
+		const result = await sweepAbandonedTasks(store, { now: fixedClock, messageId: fixedIds });
+
+		expect(result.swept).toEqual(["a"]);
+		expect((await store.load("a"))?.status.state).toBe("failed");
+	});
+
+	it("fails a task that never got past submitted", async () => {
+		const store = await seed(makeTask("a", "submitted"));
+		await sweepAbandonedTasks(store, { now: fixedClock, messageId: fixedIds });
+		expect((await store.load("a"))?.status.state).toBe("failed");
+	});
+
+	it("records a reason that says the habitat stopped, not a generic error", async () => {
+		const store = await seed(makeTask("a", "working"));
+		await sweepAbandonedTasks(store, { now: fixedClock, messageId: fixedIds });
+
+		const status = (await store.load("a"))?.status;
+		const text = status?.message?.parts?.[0];
+		expect(text).toMatchObject({ kind: "text", text: DEFAULT_ABANDONED_REASON });
+		expect(status?.message?.metadata).toMatchObject({ [ABANDONED_TASK_MARKER]: true });
+	});
+
+	it("marks the failure with the sweep's timestamp", async () => {
+		const store = await seed(makeTask("a", "working"));
+		await sweepAbandonedTasks(store, { now: fixedClock, messageId: fixedIds });
+		expect((await store.load("a"))?.status.timestamp).toBe("2026-07-25T12:00:00.000Z");
+	});
+
+	it("accepts a caller-supplied reason", async () => {
+		const store = await seed(makeTask("a", "working"));
+		await sweepAbandonedTasks(store, {
+			now: fixedClock,
+			messageId: fixedIds,
+			reason: "reaped for idleness",
+		});
+		expect((await store.load("a"))?.status.message?.parts?.[0]).toMatchObject({
+			text: "reaped for idleness",
+		});
+	});
+
+	it.each(["completed", "failed", "canceled", "rejected"] as TaskState[])(
+		"leaves an already-terminal %s task untouched",
+		async (state) => {
+			const store = await seed(makeTask("a", state));
+			const result = await sweepAbandonedTasks(store, { now: fixedClock, messageId: fixedIds });
+
+			expect(result.swept).toEqual([]);
+			expect(result.terminal).toEqual(["a"]);
+			expect((await store.load("a"))?.status.state).toBe(state);
+			// An already-failed task must keep its original reason, not be
+			// relabelled as abandoned.
+			expect((await store.load("a"))?.status.message).toBeUndefined();
+		},
+	);
+
+	it.each(["input-required", "auth-required"] as TaskState[])(
+		"never sweeps a %s task, which is legitimately waiting",
+		async (state) => {
+			const store = await seed(makeTask("a", state));
+			const result = await sweepAbandonedTasks(store, { now: fixedClock, messageId: fixedIds });
+
+			expect(result.swept).toEqual([]);
+			expect(result.interrupted).toEqual(["a"]);
+			expect((await store.load("a"))?.status.state).toBe(state);
+		},
+	);
+
+	it("sorts a mixed fleet of tasks into swept, terminal and interrupted", async () => {
+		const store = await seed(
+			makeTask("mid", "working"),
+			makeTask("done", "completed"),
+			makeTask("waiting", "auth-required"),
+			makeTask("new", "submitted"),
+		);
+
+		const result = await sweepAbandonedTasks(store, { now: fixedClock, messageId: fixedIds });
+
+		expect(result.swept.sort()).toEqual(["mid", "new"]);
+		expect(result.terminal).toEqual(["done"]);
+		expect(result.interrupted).toEqual(["waiting"]);
+	});
+
+	it("persists the transition so a later container generation sees it", async () => {
+		const store = await seed(makeTask("a", "working"));
+		await sweepAbandonedTasks(store, { now: fixedClock, messageId: fixedIds });
+
+		expect((await new FileTaskStore({ dir }).load("a"))?.status.state).toBe("failed");
+	});
+
+	it("is idempotent — a second sweep finds nothing left to do", async () => {
+		const store = await seed(makeTask("a", "working"));
+		await sweepAbandonedTasks(store, { now: fixedClock, messageId: fixedIds });
+
+		const second = await sweepAbandonedTasks(store, { now: fixedClock, messageId: fixedIds });
+		expect(second.swept).toEqual([]);
+		expect(second.terminal).toEqual(["a"]);
+	});
+
+	it("preserves the task's identity and artifacts while failing it", async () => {
+		const task = {
+			...makeTask("a", "working"),
+			artifacts: [{ artifactId: "a1", parts: [{ kind: "text", text: "partial" }] }],
+		} as Task;
+		const store = await seed(task);
+
+		await sweepAbandonedTasks(store, { now: fixedClock, messageId: fixedIds });
+
+		const swept = await store.load("a");
+		expect(swept?.contextId).toBe("ctx-a");
+		// Work produced before the container died is still the record of what
+		// happened, so it survives the transition.
+		expect(swept?.artifacts).toEqual(task.artifacts);
+	});
+
+	it("does nothing on an empty store", async () => {
+		const result = await sweepAbandonedTasks(new FileTaskStore({ dir }));
+		expect(result).toEqual({ swept: [], terminal: [], interrupted: [] });
+	});
+});

--- a/packages/protocols/src/a2a/task-recovery.ts
+++ b/packages/protocols/src/a2a/task-recovery.ts
@@ -1,0 +1,104 @@
+/**
+ * Boot-time recovery for Tasks abandoned by a stopped container.
+ *
+ * Once habitats stop while idle, a Task can be interrupted mid-flight with no
+ * terminal event ever emitted. Nothing is working on it any more, but its
+ * record still says `working` — so a caller polling it waits forever, and a
+ * caller checking later finds a Task that looks alive and is not.
+ *
+ * On start, transition those to `failed` with a reason that says what actually
+ * happened. This is only possible because the Task state lives where the
+ * habitat can read it (ADR 0007).
+ *
+ * Tasks in an interrupted state — waiting for a follow-up message, or for a
+ * credential someone has to authorize — are deliberately NOT swept. They are
+ * legitimately waiting, and killing them would destroy resumable work.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Task } from "@a2a-js/sdk";
+import { type FileTaskStore, isAbandonableTaskState } from "./file-task-store.js";
+
+/** Marker on the failing status message, so an abandoned Task is identifiable. */
+export const ABANDONED_TASK_MARKER = "umwelten.task.abandoned";
+
+export const DEFAULT_ABANDONED_REASON =
+	"Abandoned: the habitat stopped while this task was still running.";
+
+export interface SweepOptions {
+	/** Injectable clock, so tests do not depend on wall time. */
+	now?: () => string;
+	/** Injectable id source, so tests do not depend on randomness. */
+	messageId?: () => string;
+	/** Override the human-facing reason recorded on the failed Task. */
+	reason?: string;
+}
+
+export interface SweepResult {
+	/** Ids of Tasks transitioned to `failed`. */
+	swept: string[];
+	/** Ids left alone because they were already terminal. */
+	terminal: string[];
+	/** Ids left alone because they are legitimately waiting. */
+	interrupted: string[];
+}
+
+/** Builds the `failed` status recorded on an abandoned Task. */
+function abandonedStatus(
+	task: Task,
+	reason: string,
+	timestamp: string,
+	messageId: string,
+): Task["status"] {
+	return {
+		state: "failed",
+		timestamp,
+		message: {
+			kind: "message",
+			role: "agent",
+			messageId,
+			taskId: task.id,
+			contextId: task.contextId,
+			parts: [{ kind: "text", text: reason }],
+			metadata: { [ABANDONED_TASK_MARKER]: true },
+		},
+	};
+}
+
+/**
+ * Transition every mid-flight Task to `failed`. Call before the habitat
+ * accepts new requests, so no caller can observe a Task this is about to move.
+ */
+export async function sweepAbandonedTasks(
+	store: FileTaskStore,
+	options: SweepOptions = {},
+): Promise<SweepResult> {
+	const now = options.now ?? (() => new Date().toISOString());
+	const nextMessageId = options.messageId ?? (() => randomUUID());
+	const reason = options.reason ?? DEFAULT_ABANDONED_REASON;
+
+	const result: SweepResult = { swept: [], terminal: [], interrupted: [] };
+
+	for (const task of await store.listAll()) {
+		const state = task.status?.state;
+
+		if (!isAbandonableTaskState(state)) {
+			// Sorting the untouched ones lets a caller log *why* each was skipped;
+			// "interrupted" and "already finished" are very different situations.
+			if (state === "input-required" || state === "auth-required") {
+				result.interrupted.push(task.id);
+			} else {
+				result.terminal.push(task.id);
+			}
+			continue;
+		}
+
+		await store.save({
+			...task,
+			status: abandonedStatus(task, reason, now(), nextMessageId()),
+		});
+		result.swept.push(task.id);
+	}
+
+	return result;
+}

--- a/packages/protocols/src/index.ts
+++ b/packages/protocols/src/index.ts
@@ -25,6 +25,16 @@ export {
   sweepAbandonedTasks,
   ABANDONED_TASK_MARKER,
   DEFAULT_ABANDONED_REASON,
+  resolveA2AEndpointUrl,
+  createA2ATransport,
+  sendA2ATask,
+  getA2ATask,
+  cancelA2ATask,
+  pollA2ATask,
+  sendAndAwaitA2ATask,
+  isA2ATask,
+  isSettledTaskState,
+  A2APollTimeoutError,
 } from "./a2a/index.js";
 export type {
   A2AEndpoint,
@@ -42,6 +52,11 @@ export type {
   FileTaskStoreOptions,
   SweepOptions,
   SweepResult,
+  A2ATaskTarget,
+  SendA2ATaskOptions,
+  GetA2ATaskOptions,
+  PollA2ATaskOptions,
+  SendAndAwaitOptions,
 } from "./a2a/index.js";
 
 // ── MCP Serve (OAuth MCP server framework) ──────────────────────────────

--- a/packages/protocols/src/index.ts
+++ b/packages/protocols/src/index.ts
@@ -16,6 +16,15 @@ export {
   fetchJson,
   truncateJson,
   discoverToken,
+  FileTaskStore,
+  TERMINAL_TASK_STATES,
+  INTERRUPTED_TASK_STATES,
+  isTerminalTaskState,
+  isInterruptedTaskState,
+  isAbandonableTaskState,
+  sweepAbandonedTasks,
+  ABANDONED_TASK_MARKER,
+  DEFAULT_ABANDONED_REASON,
 } from "./a2a/index.js";
 export type {
   A2AEndpoint,
@@ -30,6 +39,9 @@ export type {
   AgentCard,
   AgentSkill,
   A2AChatOptions,
+  FileTaskStoreOptions,
+  SweepOptions,
+  SweepResult,
 } from "./a2a/index.js";
 
 // ── MCP Serve (OAuth MCP server framework) ──────────────────────────────


### PR DESCRIPTION
Design and first implementation slice for running Focus.AI's operations as a fleet of habitats — one per client, each owning its own repo and mounting that client's code repos read-only, with an operations habitat above them.

Specs: #266 (this repo), The-Focus-AI/habitats#117, The-Focus-AI/operations#3.

## Implementation — closes #267, #268, #271, #272, #273

**Durable task state (#267, #273).** The SDK's `InMemoryTaskStore` loses every Task when its process exits — fine while a server only stops when someone stops it, fatal once an idle reaper does the stopping, because a caller polling `tasks/get` after a restart is told the Task never existed. `FileTaskStore` persists each Task on the habitat's own volume: files named by a hash of the task id so none can escape the directory, temp-then-rename writes so a crash leaves the previous record intact, and per-id serialisation so concurrent writers cannot interleave. A boot sweep transitions Tasks left mid-flight by a previous container generation to `failed` with a reason, and runs before the transport accepts requests. Interrupted Tasks (`input-required`, `auth-required`) are never swept — they are legitimately waiting, and killing them would destroy resumable work.

**A2A client on the SDK (#268).** Two of three senders hand-rolled their JSON-RPC — one over `node:http`, one over `fetch` — while only the streaming path used the SDK. None could poll a Task, which is what blocked every caller from surviving a habitat cold start or work longer than a request. All senders and the agent-card fetch now go through `JsonRpcTransport`; `node:http` is gone. New task surface: `sendA2ATask` (non-blocking by default), `getA2ATask`, `cancelA2ATask`, `pollA2ATask`, `sendAndAwaitA2ATask`. Polling backs off from 1s toward 15s — a habitat cold-starting behind a clone and a dependency install takes minutes — and stops at interrupted states as well as terminal ones, since the agent is waiting on the caller there.

**Derived read scopes (#272).** Repo access was encoded in four places nothing reconciled. Mount a repo without widening the read scope and the boot clone fails with a GitHub 404 that reads exactly like "that repo does not exist". Read is now computed from the Owned repo plus declared Mounted repos and merged in at mint time. Write is never derived — it covers the Owned repo only and stays explicit. That asymmetry is what keeps ADR 0004's blind spot #1 closed: laundering private content into a public repo needs write, and no mount list can grant it.

**Cross-hop call chain (#271).** The recursion guard tracked depth and cycles in `AsyncLocalStorage`, which stops at the container boundary — so an A2A cycle started fresh at every hop and ran forever. With LLM agents on both ends and output caps forbidden by this repo's hard rules, forever means unbounded spend. The chain now travels in A2A message metadata and is rehydrated on receipt. It is untrusted input: only ever used to refuse work, malformed chains decode to empty, ids and length capped.

## Design — ADRs 0006–0009

- **0006** — repo access is a role, not a count: one Owned repo (read-write, explicit) plus any number of read-only Mounted repos, with read derived. Answers the question habitats ADR 0005 §5 deferred.
- **0007** — A2A Tasks are the wake contract; the durable store lives on the habitat volume; Task, Run and Source Session stay separate projections.
- **0008** — the fleet call graph is a directed tree and Gaia is the directory, not the router.
- **0009** — one 1Password vault per habitat, resolved by Gaia on the host so no container holds a vault credential.

Plus `CONTEXT.md` fleet vocabulary, the dependency-ordered build list, and `docs/agents/fleet-restructure-runbook.md` — the claim protocol for agents picking up the remaining tickets.

## Corrections to the spec prose

Established by reading the pinned SDK (0.3.14) rather than the published docs, which describe a later API. The tickets are right; #266's Problem Statement is not:

- **There is no `tasks/list`.** Served methods are `message/send`, `message/stream`, `tasks/get`, `tasks/cancel`, `tasks/resubscribe` and the four `tasks/pushNotificationConfig/*`.
- Non-blocking send is `configuration.blocking: false`, not `returnImmediately`.
- `TaskStore` is `save`/`load` only — no `list`, no scoping.
- `InMemoryTaskStore` stores by reference; a persisted store cannot reproduce that and should not try. Every SDK mutation is followed by an explicit `save()`, so nothing depends on it.

## Behaviour changes reviewers should look at

- **Transport errors are now worded by the SDK.** Status and body are both still present. The SDK's parse errors truncate the body to a few characters, which loses the clue that matters most when an agent sits behind a proxy — that an HTML error page came back — so the URL sender tees the response and appends an excerpt.
- **The SDK validates JSON-RPC response ids.** An existing fixture returned a hardcoded string id the hand-rolled sender never checked; the stub now echoes the request id. Its `Response` mock was also a bare `{ status, text() }` object, which `fetch` never produces.
- **`FileTaskStore` is stricter than `InMemoryTaskStore` about caller mutation.** Documented in the test as deliberate, not bug-compatible.
- Two `remote-agent-tools` tests asserted the exact send payload and now also assert the chain is carried.

## Known gap

The call chain uses the caller's `entry.id` outbound and the receiver's `config.name` inbound. A habitat addressed under a different id than it calls itself puts two labels for one habitat in the chain, and cycle detection misses it. Harmless while ADR 0008's tree holds; worth keying on registry id. Not yet ticketed.

## Verification

`pnpm test:run` green: 159 files, 1918 tests (up from 156 / 1829). Typecheck clean across `protocols` and `habitat`. No output-token cap introduced anywhere; the `request-options` regression tests are untouched.

Not verified: any of this against a live habitat. The conformance suite that would do that is #274, which is unblocked but not built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22


---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_