### PR TITLE
Cache agent cards so the Directory can see Dormant habitats

### DIFF
--- a/packages/habitat/src/tools/gaia/gaia-tools/context.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/context.ts
@@ -85,23 +85,85 @@ export function entryOpenUrl(
 	return null;
 }
 
-/** Fetch agent cards from all running habitats; failures are reported per-entry. */
+/** One habitat's entry in the Directory. */
+export type DiscoveredHabitat =
+	| { id: string; card: AgentCardSummary; cached: boolean; fetchedAt?: string }
+	| { id: string; error: string; card?: AgentCardSummary; fetchedAt?: string };
+
+export interface DiscoverHabitatsOptions {
+	/**
+	 * Persist a freshly fetched card back onto the registry entry. Omitted in
+	 * tests and in read-only callers; without it discovery still answers, it
+	 * just does not warm the cache.
+	 */
+	saveCard?: (
+		id: string,
+		card: AgentCardSummary,
+		fetchedAt: string,
+	) => Promise<void>;
+	/** Injectable clock so tests do not depend on wall time. */
+	now?: () => string;
+	/** Injectable card fetch (tests). */
+	fetchCard?: typeof fetchAgentCard;
+}
+
+/**
+ * Report every habitat in the fleet, running or not.
+ *
+ * Running habitats are fetched live and their card is cached on the way
+ * through. Dormant habitats answer from that cache — the whole point, since
+ * a fleet that sleeps by design would otherwise report almost nothing
+ * (ADR 0008). A habitat that has never been started has no card at all,
+ * which is reported as such rather than as an error, because "we have never
+ * seen this one" and "this one failed" are different situations.
+ *
+ * A failed fetch against a running habitat keeps the previously cached card:
+ * a transient blip should degrade the Directory to stale, not to empty.
+ */
 export async function discoverHabitats(
 	entries: GaiaHabitatEntry[],
-): Promise<
-	Array<{ id: string; card: AgentCardSummary } | { id: string; error: string }>
-> {
-	const running = entries.filter((e) => e.containerPort);
-	const results = await Promise.allSettled(
-		running.map(async (entry) => {
-			const card = await fetchAgentCard(entryToEndpoint(entry));
-			return { id: entry.id, card };
-		}),
-	);
+	options: DiscoverHabitatsOptions = {},
+): Promise<DiscoveredHabitat[]> {
+	const now = options.now ?? (() => new Date().toISOString());
+	const fetchCard = options.fetchCard ?? fetchAgentCard;
 
-	return results.map((r, i) =>
-		r.status === "fulfilled"
-			? r.value
-			: { id: running[i].id, error: r.reason?.message ?? "Unknown error" },
+	return Promise.all(
+		entries.map(async (entry): Promise<DiscoveredHabitat> => {
+			const cached = entry.cachedCard;
+
+			if (!entry.containerPort) {
+				// Dormant. Answer from cache rather than waking it.
+				if (cached) {
+					return {
+						id: entry.id,
+						card: cached.card,
+						cached: true,
+						fetchedAt: cached.fetchedAt,
+					};
+				}
+				return {
+					id: entry.id,
+					error: "No cached agent card — this habitat has not been started yet.",
+				};
+			}
+
+			try {
+				const card = await fetchCard(entryToEndpoint(entry));
+				const fetchedAt = now();
+				// Best effort: a registry write failure must not fail discovery.
+				await options.saveCard?.(entry.id, card, fetchedAt).catch(() => {});
+				return { id: entry.id, card, cached: false, fetchedAt };
+			} catch (err) {
+				const message = err instanceof Error ? err.message : "Unknown error";
+				return cached
+					? {
+							id: entry.id,
+							error: message,
+							card: cached.card,
+							fetchedAt: cached.fetchedAt,
+						}
+					: { id: entry.id, error: message };
+			}
+		}),
 	);
 }

--- a/packages/habitat/src/tools/gaia/gaia-tools/discover.test.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/discover.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentCardSummary } from "@umwelten/protocols";
+import type { GaiaHabitatEntry } from "../types.js";
+import { discoverHabitats } from "./context.js";
+
+const CARD: AgentCardSummary = { name: "Upperhand", description: "client agent" };
+const OLD_CARD: AgentCardSummary = { name: "Upperhand", description: "older" };
+
+function entry(overrides: Partial<GaiaHabitatEntry> = {}): GaiaHabitatEntry {
+	return {
+		id: "uh",
+		name: "Upperhand",
+		config: { name: "Upperhand", agents: [] },
+		secretBindings: [],
+		apiKey: "k",
+		createdAt: "2026-07-01T00:00:00.000Z",
+		...overrides,
+	} as GaiaHabitatEntry;
+}
+
+const now = () => "2026-07-26T00:00:00.000Z";
+
+describe("discoverHabitats", () => {
+	it("queries a running habitat live", async () => {
+		const fetchCard = vi.fn().mockResolvedValue(CARD);
+		const [result] = await discoverHabitats([entry({ containerPort: 7440 })], {
+			fetchCard,
+			now,
+		});
+
+		expect(result).toMatchObject({ id: "uh", card: CARD, cached: false });
+		expect(fetchCard).toHaveBeenCalledOnce();
+	});
+
+	/**
+	 * The whole point of the cache: a fleet that sleeps by design would
+	 * otherwise report almost nothing (ADR 0008).
+	 */
+	it("reports a dormant habitat from its cached card", async () => {
+		const fetchCard = vi.fn();
+		const [result] = await discoverHabitats(
+			[entry({ cachedCard: { card: CARD, fetchedAt: "2026-07-20T00:00:00.000Z" } })],
+			{ fetchCard, now },
+		);
+
+		expect(result).toMatchObject({
+			id: "uh",
+			card: CARD,
+			cached: true,
+			fetchedAt: "2026-07-20T00:00:00.000Z",
+		});
+		// Finding out what a habitat can do must never wake it.
+		expect(fetchCard).not.toHaveBeenCalled();
+	});
+
+	it("distinguishes a never-started habitat from a stale one", async () => {
+		const [result] = await discoverHabitats([entry()], { fetchCard: vi.fn(), now });
+		expect(result).toMatchObject({ id: "uh" });
+		expect((result as { error: string }).error).toMatch(/not been started/);
+		expect((result as { card?: unknown }).card).toBeUndefined();
+	});
+
+	it("stamps a freshly fetched card with the time it was captured", async () => {
+		const [result] = await discoverHabitats([entry({ containerPort: 7440 })], {
+			fetchCard: vi.fn().mockResolvedValue(CARD),
+			now,
+		});
+		expect(result).toMatchObject({ fetchedAt: "2026-07-26T00:00:00.000Z" });
+	});
+
+	it("warms the cache from a running habitat", async () => {
+		const saveCard = vi.fn().mockResolvedValue(undefined);
+		await discoverHabitats([entry({ containerPort: 7440 })], {
+			fetchCard: vi.fn().mockResolvedValue(CARD),
+			saveCard,
+			now,
+		});
+		expect(saveCard).toHaveBeenCalledWith("uh", CARD, "2026-07-26T00:00:00.000Z");
+	});
+
+	it("does not warm the cache for a dormant habitat", async () => {
+		const saveCard = vi.fn();
+		await discoverHabitats(
+			[entry({ cachedCard: { card: CARD, fetchedAt: "2026-07-20T00:00:00.000Z" } })],
+			{ fetchCard: vi.fn(), saveCard, now },
+		);
+		expect(saveCard).not.toHaveBeenCalled();
+	});
+
+	it("still answers when the cache write fails", async () => {
+		const [result] = await discoverHabitats([entry({ containerPort: 7440 })], {
+			fetchCard: vi.fn().mockResolvedValue(CARD),
+			saveCard: vi.fn().mockRejectedValue(new Error("registry is read-only")),
+			now,
+		});
+		// A registry hiccup must not take discovery down with it.
+		expect(result).toMatchObject({ card: CARD, cached: false });
+	});
+
+	/**
+	 * A transient blip should degrade the Directory to stale, not to empty.
+	 */
+	it("keeps the previous card when a live fetch fails", async () => {
+		const [result] = await discoverHabitats(
+			[
+				entry({
+					containerPort: 7440,
+					cachedCard: { card: OLD_CARD, fetchedAt: "2026-07-20T00:00:00.000Z" },
+				}),
+			],
+			{ fetchCard: vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED")), now },
+		);
+
+		expect(result).toMatchObject({
+			id: "uh",
+			card: OLD_CARD,
+			fetchedAt: "2026-07-20T00:00:00.000Z",
+		});
+		expect((result as { error: string }).error).toMatch(/ECONNREFUSED/);
+	});
+
+	it("reports a fetch failure with no cache as a plain error", async () => {
+		const [result] = await discoverHabitats([entry({ containerPort: 7440 })], {
+			fetchCard: vi.fn().mockRejectedValue(new Error("boom")),
+			now,
+		});
+		expect(result).toMatchObject({ id: "uh", error: "boom" });
+		expect((result as { card?: unknown }).card).toBeUndefined();
+	});
+
+	it("reports every habitat in the fleet, mixed states and all", async () => {
+		const results = await discoverHabitats(
+			[
+				entry({ id: "awake", containerPort: 7440 }),
+				entry({
+					id: "asleep",
+					cachedCard: { card: CARD, fetchedAt: "2026-07-20T00:00:00.000Z" },
+				}),
+				entry({ id: "never-run" }),
+			],
+			{ fetchCard: vi.fn().mockResolvedValue(CARD), now },
+		);
+
+		expect(results.map((r) => r.id)).toEqual(["awake", "asleep", "never-run"]);
+		expect(results.filter((r) => "card" in r && r.card)).toHaveLength(2);
+	});
+
+	it("returns nothing for an empty fleet", async () => {
+		expect(await discoverHabitats([], { now })).toEqual([]);
+	});
+});

--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -312,11 +312,17 @@ export function createHabitatLifecycleTools(
 
 		discover_habitats: tool({
 			description:
-				"Fetch agent cards from all running habitats to learn their capabilities.",
+				"List every habitat in the fleet with its capabilities. Running habitats are queried live; dormant ones answer from their last known agent card, so this never needs to wake anything.",
 			inputSchema: z.object({}),
 			execute: async () => {
 				const entries = registry.list();
-				const results = await discoverHabitats(entries);
+				const results = await discoverHabitats(entries, {
+					// Warm the cache as we go, so the next call can answer for a
+					// habitat that has gone to sleep in the meantime.
+					saveCard: async (id, card, fetchedAt) => {
+						await registry.update(id, { cachedCard: { card, fetchedAt } });
+					},
+				});
 				return JSON.stringify(results, null, 2);
 			},
 		}),

--- a/packages/habitat/src/tools/gaia/registry.ts
+++ b/packages/habitat/src/tools/gaia/registry.ts
@@ -129,6 +129,7 @@ export class GaiaRegistryManager {
 				| "containerPort"
 				| "image"
 				| "github"
+				| "cachedCard"
 			>
 		>,
 	): Promise<GaiaHabitatEntry> {

--- a/packages/habitat/src/tools/gaia/types.ts
+++ b/packages/habitat/src/tools/gaia/types.ts
@@ -2,6 +2,7 @@
  * Types for the Gaia Orchestrator — manages multiple habitat containers.
  */
 
+import type { AgentCardSummary } from "@umwelten/protocols";
 import type { HabitatConfig, CapabilityBinding } from "../../types.js";
 
 /** A registered habitat managed by Gaia. */
@@ -69,6 +70,22 @@ export interface GaiaHabitatEntry {
 		kind: "google-drive";
 		read?: boolean;
 		write?: boolean;
+	};
+	/**
+	 * Last agent card seen for this habitat, with when it was captured.
+	 *
+	 * Discovery used to fetch every card live, which meant it only ever saw
+	 * running habitats. Once habitats sleep while idle (ADR 0007) that would
+	 * report almost nothing, so the Directory serves this instead — a Dormant
+	 * habitat is reported with the capabilities it last advertised rather than
+	 * omitted, and finding out what a habitat can do never requires waking it.
+	 *
+	 * Absent means never successfully fetched, which is distinct from stale.
+	 */
+	cachedCard?: {
+		card: AgentCardSummary;
+		/** ISO timestamp of the fetch that produced this card. */
+		fetchedAt: string;
 	};
 	/** ISO timestamp */
 	createdAt: string;


### PR DESCRIPTION
Closes #270.

Discovery fetched every agent card live and filtered to entries with a container port, so it only ever reported **running** habitats. Once habitats sleep while idle (ADR 0007) that reports almost nothing — which breaks the premise of ADR 0008, since Gaia is the Directory and a directory that can only list what is already awake is not one.

The card and its capture time are now cached on the registry entry. Running habitats are queried live and warm the cache on the way through; dormant ones answer from it, so finding out what a habitat can do never requires waking it.

Three cases kept deliberately distinct, because they call for different responses:

- **Never started** — no card, reported as such rather than as an error. "We have never seen this one" is not a failure.
- **Live fetch failed, cache exists** — the previous card is returned alongside the error. A transient blip should degrade the Directory to stale, not to empty.
- **Cache write failed** — discovery still answers. A registry hiccup must not take the Directory down with it.

## Verification

11 new tests covering each state and the mixed-fleet case. Full suite green: 163 files, 1960 tests. All packages typecheck.

Not verified against a live fleet — the cache is exercised through an injected fetch, not a real habitat.

## Note on the branch

This branch's previous PR (#286) was squash-merged, so its old history was already on `main`. Restarted from `main` and force-pushed with lease rather than stacking new work on merged commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22


---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_