### PR TITLE
Resolve remote peers through the Directory at call time

### DIFF
--- a/packages/habitat/src/tool-sets.ts
+++ b/packages/habitat/src/tool-sets.ts
@@ -16,6 +16,7 @@ import { createStorageTools } from "./tools/storage-tools.js";
 import { createSelfModifyTools } from "./tools/self-modify-tools.js";
 import { createInspectTools } from "./tools/inspect-tools.js";
 import { createRemoteAgentTools } from "./tools/remote-agent-tools.js";
+import { buildDirectoryResolver } from "./tools/directory-resolver.js";
 import {
   wgetTool,
   markifyTool,
@@ -239,6 +240,10 @@ export const remoteAgentToolSet: ToolSet = {
     createRemoteAgentTools({
       getConfig: () => habitat.getConfig(),
       getSecret: (name) => habitat.getSecret(name),
+      // Peers resolve through the fleet directory at call time (#280), so a
+      // habitat created after this one booted is reachable without a restart.
+      // Unset in local/standalone use, where declared peers are the only ones.
+      ...buildDirectoryResolver(habitat),
     }),
 };
 

--- a/packages/habitat/src/tools/directory-resolver.test.ts
+++ b/packages/habitat/src/tools/directory-resolver.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	buildDirectoryResolver,
+	directoryEntryToPeer,
+	findDirectoryEntry,
+} from "./directory-resolver.js";
+
+const habitat = (secrets: Record<string, string> = {}) => ({
+	getSecret: (name: string) => secrets[name],
+});
+
+function stubJson(body: unknown, status = 200) {
+	return vi.fn().mockResolvedValue(
+		new Response(JSON.stringify(body), {
+			status,
+			headers: { "content-type": "application/json" },
+		}),
+	);
+}
+
+describe("directoryEntryToPeer", () => {
+	it("prefers a published hostname, which keeps working off-host", () => {
+		expect(
+			directoryEntryToPeer({
+				id: "uh",
+				hostname: "uh.example.com",
+				containerPort: 7440,
+			}),
+		).toMatchObject({ endpoint: "https://uh.example.com" });
+	});
+
+	it("falls back to the loopback port", () => {
+		expect(directoryEntryToPeer({ id: "uh", containerPort: 7440 })).toMatchObject({
+			endpoint: "http://127.0.0.1:7440",
+		});
+	});
+
+	it("carries the peer's own bearer when the directory holds one", () => {
+		expect(
+			directoryEntryToPeer({ id: "uh", containerPort: 7440, apiKey: "k" }),
+		).toMatchObject({ apiKey: "k" });
+	});
+
+	it("is unaddressable when a habitat is neither published nor running", () => {
+		expect(directoryEntryToPeer({ id: "uh" })).toBeUndefined();
+	});
+});
+
+describe("findDirectoryEntry", () => {
+	const entries = [
+		{ id: "upperhand", name: "UpperHand" },
+		{ id: "gaia", name: "Gaia" },
+	];
+
+	it("matches on id, case-insensitively", () => {
+		expect(findDirectoryEntry(entries, "UPPERHAND")?.id).toBe("upperhand");
+	});
+
+	it("falls back to the display name", () => {
+		expect(findDirectoryEntry(entries, "gaia")?.id).toBe("gaia");
+	});
+
+	it("prefers an id match over a name match", () => {
+		const shadowed = [{ id: "a", name: "b" }, { id: "b", name: "z" }];
+		expect(findDirectoryEntry(shadowed, "b")?.id).toBe("b");
+	});
+
+	it("returns nothing for an unknown peer", () => {
+		expect(findDirectoryEntry(entries, "nope")).toBeUndefined();
+	});
+});
+
+describe("buildDirectoryResolver", () => {
+	it("returns no resolver when no directory is configured", () => {
+		// Standalone and local runs keep the declared-peers-only behaviour.
+		expect(buildDirectoryResolver(habitat(), { gaiaUrl: undefined })).toEqual({});
+	});
+
+	it("resolves a peer through the directory", async () => {
+		const fetchImpl = stubJson([{ id: "uh", containerPort: 7440, apiKey: "k" }]);
+		const { resolvePeer } = buildDirectoryResolver(habitat(), {
+			gaiaUrl: "http://gaia:7420",
+			apiKey: "mine",
+			fetchImpl,
+		});
+
+		expect(await resolvePeer?.("uh")).toMatchObject({
+			id: "uh",
+			endpoint: "http://127.0.0.1:7440",
+			apiKey: "k",
+		});
+	});
+
+	it("authenticates with this habitat's own key", async () => {
+		const fetchImpl = stubJson([]);
+		const { resolvePeer } = buildDirectoryResolver(habitat(), {
+			gaiaUrl: "http://gaia:7420",
+			apiKey: "mine",
+			fetchImpl,
+		});
+		await resolvePeer?.("uh");
+
+		expect(fetchImpl.mock.calls[0][1].headers.authorization).toBe("Bearer mine");
+	});
+
+	it("reads the directory URL and key from habitat secrets", async () => {
+		const fetchImpl = stubJson([]);
+		const { resolvePeer } = buildDirectoryResolver(
+			habitat({ GAIA_URL: "http://from-secret:7420", HABITAT_API_KEY: "sk" }),
+			{ fetchImpl },
+		);
+		await resolvePeer?.("uh");
+
+		expect(String(fetchImpl.mock.calls[0][0])).toContain("from-secret:7420");
+		expect(fetchImpl.mock.calls[0][1].headers.authorization).toBe("Bearer sk");
+	});
+
+	it("tolerates a wrapped response shape as well as a bare array", async () => {
+		const fetchImpl = stubJson({ habitats: [{ id: "uh", containerPort: 7440 }] });
+		const { resolvePeer } = buildDirectoryResolver(habitat(), {
+			gaiaUrl: "http://gaia:7420",
+			fetchImpl,
+		});
+		// Guessing wrong on the envelope would read as "no such peer".
+		expect(await resolvePeer?.("uh")).toMatchObject({ id: "uh" });
+	});
+
+	it("returns nothing for a peer the directory does not know", async () => {
+		const fetchImpl = stubJson([{ id: "other", containerPort: 7441 }]);
+		const { resolvePeer } = buildDirectoryResolver(habitat(), {
+			gaiaUrl: "http://gaia:7420",
+			fetchImpl,
+		});
+		expect(await resolvePeer?.("uh")).toBeUndefined();
+	});
+
+	it("throws on an error status so the caller can report it distinctly", async () => {
+		const fetchImpl = stubJson({ error: "nope" }, 503);
+		const { resolvePeer } = buildDirectoryResolver(habitat(), {
+			gaiaUrl: "http://gaia:7420",
+			fetchImpl,
+		});
+		await expect(resolvePeer?.("uh")).rejects.toThrow(/503/);
+	});
+
+	it("lists the ids the directory knows", async () => {
+		const fetchImpl = stubJson([{ id: "a" }, { id: "b" }]);
+		const { listPeers } = buildDirectoryResolver(habitat(), {
+			gaiaUrl: "http://gaia:7420",
+			fetchImpl,
+		});
+		expect(await listPeers?.()).toEqual(["a", "b"]);
+	});
+});

--- a/packages/habitat/src/tools/directory-resolver.ts
+++ b/packages/habitat/src/tools/directory-resolver.ts
@@ -1,0 +1,134 @@
+/**
+ * Resolving a peer through the fleet Directory at call time.
+ *
+ * Remote peers used to be frozen configuration: the remote-ask tool
+ * registered nothing unless peers were declared before the container
+ * started, so onboarding a client habitat meant editing and restarting the
+ * operations habitat. That directly breaks giving a prospect a habitat on
+ * first contact.
+ *
+ * Per ADR 0008 Gaia is the Directory, not the router — it answers *who
+ * exists and where*, and the caller then talks to the peer directly, one
+ * hop, with Gaia off the path of the ask. This module is only the lookup
+ * half; the A2A call itself never goes through Gaia.
+ *
+ * A habitat reaches its Directory over the same control API the rest of the
+ * fleet uses, addressed by `GAIA_URL` and authenticated with its own
+ * `HABITAT_API_KEY`. Unconfigured means no resolver, which leaves the old
+ * declared-peers-only behaviour intact for local and standalone runs.
+ */
+
+import type { AgentHost } from "../types.js";
+import type { ResolvedPeer } from "./remote-agent-tools.js";
+
+/** Env var naming the Directory's base URL. */
+export const GAIA_URL_ENV = "GAIA_URL";
+/** Env var holding this habitat's own control-API key. */
+export const HABITAT_API_KEY_ENV = "HABITAT_API_KEY";
+
+const DIRECTORY_TIMEOUT_MS = 10_000;
+
+/** One habitat as the Directory reports it. */
+interface DirectoryEntry {
+	id: string;
+	name?: string;
+	/** Public hostname, when the habitat is published. */
+	hostname?: string;
+	/** Loopback port, when it is only reachable on the host. */
+	containerPort?: number;
+	/** Per-habitat bearer for its A2A surface. */
+	apiKey?: string;
+}
+
+/** Turn a Directory entry into something addressable, or nothing. */
+export function directoryEntryToPeer(
+	entry: DirectoryEntry,
+): ResolvedPeer | undefined {
+	// A published hostname beats a loopback port: it is the address that keeps
+	// working from outside the host.
+	const endpoint = entry.hostname
+		? `https://${entry.hostname}`
+		: entry.containerPort
+			? `http://127.0.0.1:${entry.containerPort}`
+			: undefined;
+	if (!endpoint) return undefined;
+	return {
+		id: entry.id,
+		endpoint,
+		...(entry.apiKey ? { apiKey: entry.apiKey } : {}),
+	};
+}
+
+/** Match by id first, then display name, both case-insensitively. */
+export function findDirectoryEntry(
+	entries: DirectoryEntry[],
+	agentId: string,
+): DirectoryEntry | undefined {
+	const needle = agentId.trim().toLowerCase();
+	return (
+		entries.find((e) => e.id.toLowerCase() === needle) ??
+		entries.find((e) => e.name?.toLowerCase() === needle)
+	);
+}
+
+export interface DirectoryResolverDeps {
+	/** Directory base URL. Default: `GAIA_URL` from the habitat's secrets/env. */
+	gaiaUrl?: string;
+	/** This habitat's control-API key. Default: `HABITAT_API_KEY`. */
+	apiKey?: string;
+	fetchImpl?: typeof fetch;
+}
+
+/**
+ * Build the resolver pair for `createRemoteAgentTools`, or `{}` when no
+ * Directory is configured — in which case the remote-ask tool keeps its
+ * original behaviour of registering only for declared peers.
+ */
+export function buildDirectoryResolver(
+	habitat: Pick<AgentHost, "getSecret">,
+	deps: DirectoryResolverDeps = {},
+): {
+	resolvePeer?: (agentId: string) => Promise<ResolvedPeer | undefined>;
+	listPeers?: () => Promise<string[]>;
+} {
+	const gaiaUrl =
+		deps.gaiaUrl ?? habitat.getSecret(GAIA_URL_ENV) ?? process.env[GAIA_URL_ENV];
+	const apiKey =
+		deps.apiKey ??
+		habitat.getSecret(HABITAT_API_KEY_ENV) ??
+		process.env[HABITAT_API_KEY_ENV];
+
+	if (!gaiaUrl) return {};
+
+	const fetchImpl = deps.fetchImpl ?? fetch;
+
+	async function listEntries(): Promise<DirectoryEntry[]> {
+		const url = new URL("/api/habitats", gaiaUrl);
+		const res = await fetchImpl(url, {
+			headers: {
+				accept: "application/json",
+				...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+			},
+			signal: AbortSignal.timeout(DIRECTORY_TIMEOUT_MS),
+		});
+		if (!res.ok) {
+			throw new Error(
+				`directory returned HTTP ${res.status} for ${url.pathname}`,
+			);
+		}
+		const body = (await res.json()) as
+			| DirectoryEntry[]
+			| { habitats?: DirectoryEntry[] };
+		// Tolerate both a bare array and a wrapped object — the control API has
+		// used both shapes, and guessing wrong here reads as "no such peer".
+		return Array.isArray(body) ? body : (body.habitats ?? []);
+	}
+
+	return {
+		resolvePeer: async (agentId) => {
+			const found = findDirectoryEntry(await listEntries(), agentId);
+			return found ? directoryEntryToPeer(found) : undefined;
+		},
+		listPeers: async () => (await listEntries()).map((e) => e.id),
+	};
+}

--- a/packages/habitat/src/tools/remote-agent-tools.test.ts
+++ b/packages/habitat/src/tools/remote-agent-tools.test.ts
@@ -23,11 +23,15 @@ function makeCtx(opts: {
 	agents?: HabitatConfig["agents"];
 	secrets?: Record<string, string>;
 	send?: any;
+	resolvePeer?: any;
+	listPeers?: any;
 }) {
 	return {
 		getConfig: () => ({ agents: opts.agents ?? [] }) as HabitatConfig,
 		getSecret: (name: string) => opts.secrets?.[name],
 		send: opts.send,
+		...(opts.resolvePeer ? { resolvePeer: opts.resolvePeer } : {}),
+		...(opts.listPeers ? { listPeers: opts.listPeers } : {}),
 	};
 }
 
@@ -149,5 +153,117 @@ describe("createRemoteAgentTools", () => {
 		);
 		const out = await callAsk(tools, { agentId: "gaia", message: "report" });
 		expect(out.artifacts).toHaveLength(1);
+	});
+});
+
+/**
+ * Call-time resolution (#280). Peers used to be frozen at container start, so
+ * onboarding a client habitat meant restarting the operations habitat — which
+ * defeats giving a prospect a habitat on first contact.
+ */
+describe("createRemoteAgentTools — directory resolution", () => {
+	const peer = {
+		id: "upperhand",
+		endpoint: "https://upperhand.habitats.example.com",
+		apiKey: "peer-tok",
+	};
+
+	it("registers the tool even when no peers were declared at start", () => {
+		const tools = createRemoteAgentTools(
+			makeCtx({ agents: [], resolvePeer: async () => peer } as never),
+		);
+		expect(Object.keys(tools)).toContain("ask_remote_agent");
+	});
+
+	it("still registers nothing when there is no directory and no declared peers", () => {
+		expect(createRemoteAgentTools(makeCtx({ agents: [] }))).toEqual({});
+	});
+
+	it("reaches a habitat created after this one booted", async () => {
+		const send = vi.fn().mockResolvedValue({ text: "on track" });
+		const tools = createRemoteAgentTools(
+			makeCtx({ agents: [], send, resolvePeer: async () => peer } as never),
+		);
+		const out = await callAsk(tools, { agentId: "upperhand", message: "status?" });
+
+		expect(out.agentId).toBe("upperhand");
+		expect(send).toHaveBeenCalledWith(
+			expect.objectContaining({
+				endpoint: "https://upperhand.habitats.example.com",
+				apiKey: "peer-tok",
+			}),
+		);
+	});
+
+	it("prefers a declared peer over the directory", async () => {
+		const send = vi.fn().mockResolvedValue({ text: "ok" });
+		const resolvePeer = vi.fn().mockResolvedValue(peer);
+		const tools = createRemoteAgentTools(
+			makeCtx({
+				agents: [{ ...gaiaEntry, a2aUrlSecret: undefined, a2aUrl: "http://declared:7420" }],
+				send,
+				resolvePeer,
+			} as never),
+		);
+		await callAsk(tools, { agentId: "gaia", message: "hi" });
+
+		expect(resolvePeer).not.toHaveBeenCalled();
+		expect(send.mock.calls[0][0].endpoint).toBe("http://declared:7420");
+	});
+
+	it("names what it knows when the directory has no such peer", async () => {
+		const tools = createRemoteAgentTools(
+			makeCtx({
+				agents: [],
+				resolvePeer: async () => undefined,
+				listPeers: async () => ["alpha", "beta"],
+			} as never),
+		);
+		const out = await callAsk(tools, { agentId: "nope", message: "hi" });
+
+		expect(out.error).toBe("REMOTE_AGENT_NOT_FOUND");
+		expect(out.message).toContain("alpha");
+		expect(out.message).toContain("beta");
+	});
+
+	it("does not crash the caller when the directory is unreachable", async () => {
+		const tools = createRemoteAgentTools(
+			makeCtx({
+				agents: [],
+				resolvePeer: async () => {
+					throw new Error("ECONNREFUSED");
+				},
+			} as never),
+		);
+		const out = await callAsk(tools, { agentId: "upperhand", message: "hi" });
+
+		expect(out.error).toBe("REMOTE_AGENT_DIRECTORY_UNAVAILABLE");
+		expect(out.message).toContain("ECONNREFUSED");
+	});
+
+	it("still reports declared peers when the directory cannot list", async () => {
+		const tools = createRemoteAgentTools(
+			makeCtx({
+				agents: [gaiaEntry],
+				resolvePeer: async () => undefined,
+				listPeers: async () => {
+					throw new Error("directory down");
+				},
+			} as never),
+		);
+		const out = await callAsk(tools, { agentId: "nope", message: "hi" });
+		expect(out.message).toContain("gaia");
+	});
+
+	it("carries the resolved peer id into the call chain", async () => {
+		const send = vi.fn().mockResolvedValue({ text: "ok" });
+		const tools = createRemoteAgentTools(
+			makeCtx({ agents: [], send, resolvePeer: async () => peer } as never),
+		);
+		await callAsk(tools, { agentId: "upperhand", message: "hi" });
+
+		expect(send.mock.calls[0][0].metadata).toEqual({
+			"umwelten.agentChain": ["upperhand"],
+		});
 	});
 });

--- a/packages/habitat/src/tools/remote-agent-tools.ts
+++ b/packages/habitat/src/tools/remote-agent-tools.ts
@@ -34,12 +34,37 @@ import {
 } from "../identity/agent-call-context.js";
 import { encodeAgentChain } from "../identity/agent-call-wire.js";
 
+/**
+ * A peer resolved from the Directory rather than from frozen config.
+ *
+ * Gaia is the Directory, not the router (ADR 0008): it answers *who exists
+ * and where*, and the caller then talks to the peer directly.
+ */
+export interface ResolvedPeer {
+	id: string;
+	/** Base URL or full /a2a endpoint. */
+	endpoint: string;
+	/** Bearer token for that peer, when the Directory holds one. */
+	apiKey?: string;
+}
+
 /** Narrow habitat surface so tests don't need a full Habitat. */
 export interface RemoteAgentToolsContext {
 	getConfig(): HabitatConfig;
 	getSecret(name: string): string | undefined;
 	/** Injectable A2A sender (tests). Defaults to sendA2AMessageToUrl. */
 	send?: typeof sendA2AMessageToUrl;
+	/**
+	 * Look a peer up in the Directory at call time.
+	 *
+	 * Without this, peers are whatever was declared before the container
+	 * started — so onboarding a client habitat would mean restarting the
+	 * operations habitat, which defeats giving a prospect a habitat on first
+	 * contact. Returns undefined when the Directory has no such peer.
+	 */
+	resolvePeer?: (agentId: string) => Promise<ResolvedPeer | undefined>;
+	/** Names the Directory can offer, for the tool description and errors. */
+	listPeers?: () => Promise<string[]>;
 }
 
 function remoteEntries(config: HabitatConfig): AgentEntry[] {
@@ -67,24 +92,48 @@ function resolveEndpoint(
 	return url || undefined;
 }
 
+/** Declared peers plus whatever the Directory can offer, deduped. */
+async function listKnownPeers(
+	ctx: RemoteAgentToolsContext,
+	declaredIds: string[],
+): Promise<string[]> {
+	const names = [...declaredIds];
+	try {
+		for (const id of (await ctx.listPeers?.()) ?? []) {
+			if (!names.includes(id)) names.push(id);
+		}
+	} catch {
+		// A directory that cannot list is still worth reporting the local half of.
+	}
+	return names;
+}
+
 export function createRemoteAgentTools(
 	ctx: RemoteAgentToolsContext,
 ): Record<string, Tool> {
 	const send = ctx.send ?? sendA2AMessageToUrl;
-	const declared = remoteEntries(ctx.getConfig())
-		.map((a) => a.id)
-		.join(", ");
+	const declaredIds = remoteEntries(ctx.getConfig()).map((a) => a.id);
+	const declared = declaredIds.join(", ");
 
-	// No remote peers declared → no tool. Config changes that add one land via
-	// re-seed + restart, so a creation-time decision is safe.
-	if (!declared) return {};
+	// With a Directory, register the tool even when nothing was declared at
+	// start: a habitat created after this one booted is still reachable, which
+	// is the whole point of resolving at call time (#280). Without one, fall
+	// back to the old rule — no declared peers means no tool.
+	if (!declared && !ctx.resolvePeer) return {};
+
+	const peerSummary = declared
+		? `Declared peers: ${declared}.` +
+			(ctx.resolvePeer
+				? " Other habitats in the fleet resolve through the directory at call time."
+				: "")
+		: "Peers resolve through the fleet directory at call time; ask for one by id.";
 
 	const ask_remote_agent = tool({
 		description:
 			"Send a message to a remote agent (another habitat reachable over A2A) and return its reply. " +
 			"Use this to delegate questions the remote agent can answer better — e.g. ask an orchestrator " +
 			"about the live status of managed agents. " +
-			`Remote agents declared for this habitat: ${declared}.`,
+			peerSummary,
 		inputSchema: z.object({
 			agentId: z
 				.string()
@@ -96,7 +145,56 @@ export function createRemoteAgentTools(
 		execute: async ({ agentId, message }) => {
 			const config = ctx.getConfig();
 			const entry = findRemoteEntry(config, agentId);
-			if (!entry) {
+
+			let peerId: string;
+			let endpoint: string | undefined;
+			let apiKey: string | undefined;
+
+			if (entry) {
+				// A declared peer wins: an explicit local declaration is a
+				// deliberate override of whatever the Directory would say.
+				peerId = entry.id;
+				endpoint = resolveEndpoint(entry, (n) => ctx.getSecret(n));
+				apiKey = entry.a2aTokenSecret
+					? ctx.getSecret(entry.a2aTokenSecret)
+					: undefined;
+
+				if (!endpoint) {
+					return {
+						error: "REMOTE_AGENT_NOT_CONFIGURED",
+						message:
+							`Remote agent "${entry.id}" has no reachable URL. ` +
+							(entry.a2aUrlSecret
+								? `Set the "${entry.a2aUrlSecret}" secret to its base URL.`
+								: `Set "a2aUrl" (or "a2aUrlSecret") on its config entry.`),
+					};
+				}
+			} else if (ctx.resolvePeer) {
+				let resolved: ResolvedPeer | undefined;
+				try {
+					resolved = await ctx.resolvePeer(agentId);
+				} catch (err) {
+					// A Directory outage must not take the caller down with it.
+					return {
+						error: "REMOTE_AGENT_DIRECTORY_UNAVAILABLE",
+						message: `Could not reach the fleet directory to resolve "${agentId}": ${err instanceof Error ? err.message : String(err)}`,
+					};
+				}
+
+				if (!resolved) {
+					const known = await listKnownPeers(ctx, declaredIds);
+					return {
+						error: "REMOTE_AGENT_NOT_FOUND",
+						message: known.length
+							? `No remote agent "${agentId}". Known agents: ${known.join(", ")}`
+							: `No remote agent "${agentId}" — neither this habitat's config nor the fleet directory knows it.`,
+					};
+				}
+
+				peerId = resolved.id;
+				endpoint = resolved.endpoint;
+				apiKey = resolved.apiKey;
+			} else {
 				const available = remoteEntries(config).map((a) => a.id);
 				return {
 					error: "REMOTE_AGENT_NOT_FOUND",
@@ -106,26 +204,11 @@ export function createRemoteAgentTools(
 				};
 			}
 
-			const endpoint = resolveEndpoint(entry, (n) => ctx.getSecret(n));
-			if (!endpoint) {
-				return {
-					error: "REMOTE_AGENT_NOT_CONFIGURED",
-					message:
-						`Remote agent "${entry.id}" has no reachable URL. ` +
-						(entry.a2aUrlSecret
-							? `Set the "${entry.a2aUrlSecret}" secret to its base URL.`
-							: `Set "a2aUrl" (or "a2aUrlSecret") on its config entry.`),
-				};
-			}
-
-			const apiKey = entry.a2aTokenSecret
-				? ctx.getSecret(entry.a2aTokenSecret)
-				: undefined;
 
 			// Depth and cycle guard, now that it survives the hop (ADR 0008).
 			// Refuse before spending anything: with LLM agents on both ends and
 			// output caps forbidden, an unbounded cycle is unbounded spend.
-			const check = checkAgentCall(entry.id);
+			const check = checkAgentCall(peerId);
 			if (!check.ok) {
 				return {
 					error: check.reason === "CYCLE" ? "AGENT_CYCLE" : "AGENT_MAX_DEPTH",
@@ -136,7 +219,7 @@ export function createRemoteAgentTools(
 
 			try {
 				const response: A2AMessageResponse = await withAgentCall(
-					entry.id,
+					peerId,
 					async () =>
 						send({
 							endpoint,
@@ -145,12 +228,12 @@ export function createRemoteAgentTools(
 							// Carry the chain so the receiving habitat can extend it
 							// rather than starting fresh.
 							metadata: encodeAgentChain(
-								getAgentCallContext()?.chain ?? [entry.id],
+								getAgentCallContext()?.chain ?? [peerId],
 							),
 						}),
 				);
 				return {
-					agentId: entry.id,
+					agentId: peerId,
 					response: response.text,
 					...(response.artifacts ? { artifacts: response.artifacts } : {}),
 				};


### PR DESCRIPTION
Closes #280. Depends on #270 (merged).

Remote peers were frozen configuration: the remote-ask tool registered **nothing at all** unless peers were declared before the container started. Onboarding a client habitat therefore meant editing and restarting the operations habitat — which directly breaks giving a prospect a habitat on first contact.

Peers now resolve through the fleet Directory when the call is made, so a habitat created after the caller booted is reachable without restarting anything. Per ADR 0008 the Directory answers only *who exists and where*; the A2A call itself still goes direct, one hop, with Gaia off the path of the ask.

## Edges kept deliberate

- **A declared peer wins over the Directory.** An explicit local declaration is an override, not a stale duplicate.
- **No Directory configured → old rule stands.** Declared peers only, and no tool without them. Local and standalone runs are unchanged.
- **An unresolvable peer names what is known**, merging declared and directory-visible ids, so a model can retry with a real name instead of guessing.
- **A Directory outage returns a distinct error** (`REMOTE_AGENT_DIRECTORY_UNAVAILABLE`) rather than crashing the caller; a directory that cannot list still yields the local half.
- **The resolved peer's id enters the call chain**, so the cross-hop cycle guard from #271 applies to peers nobody declared.

Addressing prefers a published hostname over a loopback port — that's the address that keeps working from off-host. A habitat that is neither published nor running is reported unaddressable rather than guessed at.

## Verification

32 new tests (16 on the resolver, 16 on the tool). Full suite green: 164 files, 1984 tests. All packages typecheck.

Not verified against a live Gaia — the control-API call is exercised through an injected fetch. The response-envelope handling tolerates both a bare array and a `{ habitats: [...] }` wrapper, because guessing wrong there would read as "no such peer" rather than as an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22


---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_