### PR TITLE
Create a habitat with its Mounted repos in one operation

### DIFF
--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -60,7 +60,28 @@ export function createHabitatLifecycleTools(
 			inputSchema: z.object({
 				id: z.string().describe("Slug identifier (e.g. 'jeeves-bot')"),
 				name: z.string().describe("Display name"),
-				gitUrl: z.string().optional().describe("Git URL for provisioning"),
+				gitUrl: z
+					.string()
+					.optional()
+					.describe(
+						"Git URL of the habitat's Owned repo — the one repo it may write to",
+					),
+				mounts: z
+					.array(
+						z.object({
+							gitRemote: z.string().describe("Git URL to clone read-only"),
+							gitBranch: z.string().optional(),
+							id: z
+								.string()
+								.optional()
+								.describe("Mount id; defaults to the repo name"),
+							name: z.string().optional(),
+						}),
+					)
+					.optional()
+					.describe(
+						"Repos this habitat reads but never writes. The GitHub read scope is derived from these plus the Owned repo, so mounts never need a separate grant. Write scope is never derived.",
+					),
 				gitBranch: z.string().optional().describe("Git branch (default: main)"),
 				provider: z
 					.string()

--- a/packages/habitat/src/tools/gaia/mounts.test.ts
+++ b/packages/habitat/src/tools/gaia/mounts.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { MountDeclarationError, mountsToAgentEntries } from "./mounts.js";
+
+describe("mountsToAgentEntries", () => {
+	it("returns nothing when no mounts are declared", () => {
+		expect(mountsToAgentEntries(undefined)).toEqual([]);
+		expect(mountsToAgentEntries([])).toEqual([]);
+	});
+
+	it("derives the mount id from the repo name, so the common case is just a remote", () => {
+		const [entry] = mountsToAgentEntries([
+			{ gitRemote: "https://github.com/The-Focus-AI/uh-api.git" },
+		]);
+		expect(entry).toMatchObject({ id: "uh-api", name: "uh-api" });
+	});
+
+	/**
+	 * The half that makes this a Mounted repo rather than a second Owned one:
+	 * read mode blocks writes and forces read-only tool subsets.
+	 */
+	it("marks every mount read-only", () => {
+		const entries = mountsToAgentEntries([
+			{ gitRemote: "https://github.com/x/a.git" },
+			{ gitRemote: "https://github.com/x/b.git" },
+		]);
+		expect(entries.every((e) => e.mode === "read")).toBe(true);
+		expect(entries.every((e) => e.kind === "repo")).toBe(true);
+	});
+
+	it("gives each mount its own directory", () => {
+		const entries = mountsToAgentEntries([
+			{ gitRemote: "https://github.com/x/a.git" },
+			{ gitRemote: "https://github.com/x/b.git" },
+		]);
+		expect(entries.map((e) => e.projectPath)).toEqual([
+			"agents/a/repo",
+			"agents/b/repo",
+		]);
+	});
+
+	it("honours an explicit id and name", () => {
+		const [entry] = mountsToAgentEntries([
+			{ gitRemote: "https://github.com/x/a.git", id: "api", name: "The API" },
+		]);
+		expect(entry).toMatchObject({ id: "api", name: "The API", projectPath: "agents/api/repo" });
+	});
+
+	it("carries a branch when one is pinned", () => {
+		const [entry] = mountsToAgentEntries([
+			{ gitRemote: "https://github.com/x/a.git", gitBranch: "release" },
+		]);
+		expect(entry.gitBranch).toBe("release");
+	});
+
+	it("omits the branch when none is pinned", () => {
+		const [entry] = mountsToAgentEntries([{ gitRemote: "https://github.com/x/a.git" }]);
+		expect(entry).not.toHaveProperty("gitBranch");
+	});
+
+	it("handles ssh remotes", () => {
+		const [entry] = mountsToAgentEntries([
+			{ gitRemote: "git@github.com:The-Focus-AI/uh-web.git" },
+		]);
+		expect(entry.id).toBe("uh-web");
+	});
+
+	/**
+	 * Throwing beats skipping: a mount that silently vanishes surfaces much
+	 * later as "the agent can't see that repo".
+	 */
+	it("rejects a mount with no remote", () => {
+		expect(() => mountsToAgentEntries([{ gitRemote: "  " }])).toThrow(
+			MountDeclarationError,
+		);
+	});
+
+	it("rejects a remote it cannot name, rather than guessing", () => {
+		expect(() => mountsToAgentEntries([{ gitRemote: "wat" }])).toThrow(
+			/explicit id/,
+		);
+	});
+
+	it("rejects duplicate ids, which would collide in one directory namespace", () => {
+		expect(() =>
+			mountsToAgentEntries([
+				{ gitRemote: "https://github.com/a/same.git" },
+				{ gitRemote: "https://github.com/b/same.git" },
+			]),
+		).toThrow(/Duplicate mount id/);
+	});
+
+	it("allows two repos with the same name when one is given an explicit id", () => {
+		const entries = mountsToAgentEntries([
+			{ gitRemote: "https://github.com/a/same.git" },
+			{ gitRemote: "https://github.com/b/same.git", id: "same-b" },
+		]);
+		expect(entries.map((e) => e.id)).toEqual(["same", "same-b"]);
+	});
+});

--- a/packages/habitat/src/tools/gaia/mounts.ts
+++ b/packages/habitat/src/tools/gaia/mounts.ts
@@ -1,0 +1,88 @@
+/**
+ * Turning declared mounts into the agent entries the entrypoint clones.
+ *
+ * Per ADR 0006 a habitat has at most one **Owned repo** — the material it is
+ * responsible for, read-write — and any number of **Mounted repos**, which it
+ * reads and never writes. Mounts are carried as agent entries with
+ * `kind: "repo"` and `mode: "read"`, which is what makes the container
+ * entrypoint clone them and what makes the file tools refuse to write into
+ * them.
+ *
+ * Creating a habitat used to accept an Owned repo but not mounts, so standing
+ * up a client habitat was a create call, then a config update, then a scope
+ * grant, then a rebuild — with nothing tying the mounts to the scopes. This
+ * builds both from one declaration.
+ */
+
+import type { AgentEntry } from "../../types.js";
+import type { MountedRepoSpec } from "./types.js";
+import { repoNameFromGitUrl, bareRepoName } from "./repo-scopes.js";
+
+/** Slug an id into something safe for a directory name. */
+function toMountId(spec: MountedRepoSpec): string | undefined {
+	const explicit = spec.id?.trim();
+	if (explicit) return explicit;
+	// Default to the repo's own name — that is what makes the common case
+	// `{ gitRemote }` with nothing else.
+	return bareRepoName(repoNameFromGitUrl(spec.gitRemote));
+}
+
+export class MountDeclarationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "MountDeclarationError";
+	}
+}
+
+/**
+ * Build read-only agent entries from declared mounts.
+ *
+ * Throws rather than skipping on a bad declaration: a mount that silently
+ * vanishes would surface much later as "the agent can't see that repo",
+ * which is a far worse afternoon than a rejected create call.
+ */
+export function mountsToAgentEntries(
+	mounts: MountedRepoSpec[] | undefined,
+): AgentEntry[] {
+	if (!mounts?.length) return [];
+
+	const entries: AgentEntry[] = [];
+	const seen = new Set<string>();
+
+	for (const spec of mounts) {
+		const remote = spec.gitRemote?.trim();
+		if (!remote) {
+			throw new MountDeclarationError(
+				"A mount needs a gitRemote; got an entry without one.",
+			);
+		}
+
+		const id = toMountId(spec);
+		if (!id) {
+			throw new MountDeclarationError(
+				`Could not derive a mount id from "${remote}". Pass an explicit id.`,
+			);
+		}
+		if (seen.has(id)) {
+			throw new MountDeclarationError(
+				`Duplicate mount id "${id}". Mounts share a directory namespace, so ids must be unique — pass an explicit id for one of them.`,
+			);
+		}
+		seen.add(id);
+
+		entries.push({
+			id,
+			name: spec.name ?? id,
+			// Where the entrypoint clones it inside the container.
+			projectPath: `agents/${id}/repo`,
+			kind: "repo",
+			// The half that makes this a Mounted repo rather than a second Owned
+			// one: read mode blocks writes and forces read-only tool subsets.
+			mode: "read",
+			gitRemote: remote,
+			...(spec.gitBranch ? { gitBranch: spec.gitBranch } : {}),
+		});
+	}
+
+	return entries;
+}

--- a/packages/habitat/src/tools/gaia/registry.mounts.test.ts
+++ b/packages/habitat/src/tools/gaia/registry.mounts.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { GaiaRegistryManager } from "./registry.js";
+
+let dir: string;
+let registry: GaiaRegistryManager;
+
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "umwelten-registry-mounts-"));
+	registry = new GaiaRegistryManager(dir);
+	await registry.load();
+});
+
+afterEach(async () => {
+	await rm(dir, { recursive: true, force: true });
+});
+
+const OWNED = "https://github.com/The-Focus-AI/client-upperhand.git";
+const API = "https://github.com/The-Focus-AI/uh-api.git";
+const WEB = "https://github.com/The-Focus-AI/uh-web.git";
+
+describe("creating a habitat with mounts", () => {
+	it("stands one up in a single call", async () => {
+		const entry = await registry.create({
+			id: "upperhand",
+			name: "UpperHand",
+			gitUrl: OWNED,
+			mounts: [{ gitRemote: API }, { gitRemote: WEB }],
+		});
+
+		expect(entry.config.gitUrl).toBe(OWNED);
+		expect(entry.config.agents.map((a) => a.id)).toEqual(["uh-api", "uh-web"]);
+	});
+
+	it("derives the read scope from the Owned repo plus the mounts", async () => {
+		const entry = await registry.create({
+			id: "upperhand",
+			name: "UpperHand",
+			gitUrl: OWNED,
+			mounts: [{ gitRemote: API }],
+		});
+		// No separate grant call — this is the drift ADR 0006 removes.
+		expect(entry.github?.read).toEqual(["client-upperhand", "uh-api"]);
+	});
+
+	it("never derives a write scope, however many repos are mounted", async () => {
+		const entry = await registry.create({
+			id: "upperhand",
+			name: "UpperHand",
+			gitUrl: OWNED,
+			mounts: [{ gitRemote: API }, { gitRemote: WEB }],
+		});
+		expect(entry.github?.write).toBeUndefined();
+	});
+
+	it("keeps an explicitly declared write scope untouched", async () => {
+		const entry = await registry.create({
+			id: "upperhand",
+			name: "UpperHand",
+			gitUrl: OWNED,
+			mounts: [{ gitRemote: API }],
+			github: { write: ["client-upperhand"] },
+		});
+		expect(entry.github?.write).toEqual(["client-upperhand"]);
+	});
+
+	it("keeps a declared read repo the habitat does not mount", async () => {
+		const entry = await registry.create({
+			id: "upperhand",
+			name: "UpperHand",
+			gitUrl: OWNED,
+			mounts: [{ gitRemote: API }],
+			github: { read: ["standards"] },
+		});
+		expect(entry.github?.read).toContain("standards");
+		expect(entry.github?.read).toContain("uh-api");
+	});
+
+	it("marks every mount read-only", async () => {
+		const entry = await registry.create({
+			id: "upperhand",
+			name: "UpperHand",
+			mounts: [{ gitRemote: API }],
+		});
+		expect(entry.config.agents[0]).toMatchObject({ mode: "read", kind: "repo" });
+	});
+
+	it("creates a habitat with no mounts exactly as before", async () => {
+		const entry = await registry.create({ id: "plain", name: "Plain" });
+		expect(entry.config.agents).toEqual([]);
+	});
+
+	/** A half-registered habitat is worse than a rejected create call. */
+	it("registers nothing when the mount declaration is bad", async () => {
+		await expect(
+			registry.create({
+				id: "broken",
+				name: "Broken",
+				mounts: [{ gitRemote: "wat" }],
+			}),
+		).rejects.toThrow();
+
+		expect(registry.get("broken")).toBeUndefined();
+		expect(registry.list()).toHaveLength(0);
+	});
+
+	it("persists mounts across a reload", async () => {
+		await registry.create({
+			id: "upperhand",
+			name: "UpperHand",
+			gitUrl: OWNED,
+			mounts: [{ gitRemote: API }],
+		});
+
+		const reloaded = new GaiaRegistryManager(dir);
+		await reloaded.load();
+		expect(reloaded.get("upperhand")?.config.agents.map((a) => a.id)).toEqual([
+			"uh-api",
+		]);
+	});
+});
+
+describe("changing mounts on an existing habitat", () => {
+	beforeEach(async () => {
+		await registry.create({
+			id: "upperhand",
+			name: "UpperHand",
+			gitUrl: OWNED,
+			mounts: [{ gitRemote: API }],
+		});
+	});
+
+	it("widens the read scope when a mount is added", async () => {
+		const entry = await registry.setMounts("upperhand", [
+			{ gitRemote: API },
+			{ gitRemote: WEB },
+		]);
+		expect(entry.github?.read).toEqual(
+			expect.arrayContaining(["client-upperhand", "uh-api", "uh-web"]),
+		);
+	});
+
+	it("narrows the read scope when a mount is removed", async () => {
+		const entry = await registry.setMounts("upperhand", []);
+		expect(entry.github?.read).not.toContain("uh-api");
+		// The Owned repo is still readable — it did not go anywhere.
+		expect(entry.github?.read).toContain("client-upperhand");
+	});
+
+	it("keeps a separately declared read repo through a mount change", async () => {
+		await registry.update("upperhand", {
+			github: { read: ["client-upperhand", "uh-api", "standards"] },
+		});
+		const entry = await registry.setMounts("upperhand", []);
+		expect(entry.github?.read).toContain("standards");
+	});
+
+	it("leaves non-repo agents alone", async () => {
+		const existing = registry.get("upperhand")!;
+		await registry.update("upperhand", {
+			config: {
+				...existing.config,
+				agents: [
+					...existing.config.agents,
+					{ id: "gaia", name: "Gaia", projectPath: "agents/gaia", kind: "remote-habitat" },
+				],
+			},
+		});
+
+		const entry = await registry.setMounts("upperhand", [{ gitRemote: WEB }]);
+		expect(entry.config.agents.map((a) => a.id).sort()).toEqual(["gaia", "uh-web"]);
+	});
+
+	it("refuses for a habitat that does not exist", async () => {
+		await expect(registry.setMounts("nope", [])).rejects.toThrow(/not found/);
+	});
+});

--- a/packages/habitat/src/tools/gaia/registry.ts
+++ b/packages/habitat/src/tools/gaia/registry.ts
@@ -6,6 +6,9 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { randomBytes } from "node:crypto";
+import type { AgentEntry, HabitatConfig } from "../../types.js";
+import { mountsToAgentEntries } from "./mounts.js";
+import { deriveRepoScopes, mergeDerivedReadScope } from "./repo-scopes.js";
 import type {
 	GaiaRegistry,
 	GaiaHabitatEntry,
@@ -23,6 +26,20 @@ function slugify(name: string): string {
 		.toLowerCase()
 		.replace(/[^a-z0-9]+/g, "-")
 		.replace(/^-|-$/g, "");
+}
+
+/**
+ * The read entries a human declared, i.e. everything that is not explained
+ * by the habitat's own repos. Recomputed rather than remembered, so removing
+ * a mount narrows the scope.
+ */
+function explicitReads(
+	entry: GaiaHabitatEntry,
+	_mounted: AgentEntry[],
+): string[] | "org" | undefined {
+	if (entry.github?.read === "org") return "org";
+	const derivedNow = new Set(deriveRepoScopes(entry.config).read);
+	return (entry.github?.read ?? []).filter((r) => !derivedNow.has(r));
 }
 
 export class GaiaRegistryManager {
@@ -81,6 +98,11 @@ export class GaiaRegistryManager {
 			throw new Error(`Habitat "${id}" already exists`);
 		}
 
+		// Mounts become read-only agent entries the entrypoint clones (ADR 0006).
+		// Thrown errors here abort the create before anything is registered —
+		// see the half-registered-habitat note below.
+		const mountedAgents = mountsToAgentEntries(options.mounts);
+
 		const entry: GaiaHabitatEntry = {
 			id,
 			name: options.name,
@@ -88,7 +110,7 @@ export class GaiaRegistryManager {
 				name: options.name,
 				defaultProvider: options.provider,
 				defaultModel: options.model,
-				agents: [],
+				agents: mountedAgents,
 				gitUrl: options.gitUrl,
 				gitBranch: options.gitBranch,
 				...(options.skillsFromGit?.length
@@ -102,19 +124,72 @@ export class GaiaRegistryManager {
 			apiKey: generateApiKey(),
 			...(options.image ? { image: options.image } : {}),
 			...(options.hostname ? { hostname: options.hostname } : {}),
-			...(options.github ? { github: options.github } : {}),
+			// Read scope is derived from the Owned repo plus these mounts, so a
+			// mount can never fail at boot with a GitHub 404 that reads like
+			// "no such repo". Write is never derived (ADR 0006).
+			github: mergeDerivedReadScope(
+				options.github,
+				deriveRepoScopes({
+					name: options.name,
+					agents: mountedAgents,
+					gitUrl: options.gitUrl,
+				} as HabitatConfig),
+			),
 			...(options.storage ? { storage: options.storage } : {}),
 			createdAt: new Date().toISOString(),
 		};
 
-		this.registry.habitats.push(entry);
-
-		// Create data directory for this habitat
+		// Everything that can fail happens before the entry is registered, so a
+		// failed create leaves no half-registered habitat behind.
 		const habitatDataDir = join(this.dataDir, "habitats", id);
 		await mkdir(habitatDataDir, { recursive: true });
 
-		await this.save();
+		this.registry.habitats.push(entry);
+		try {
+			await this.save();
+		} catch (err) {
+			// Roll the in-memory registry back, or the next unrelated save would
+			// quietly persist a habitat this call already reported as failed.
+			this.registry.habitats = this.registry.habitats.filter(
+				(h) => h !== entry,
+			);
+			throw err;
+		}
 		return entry;
+	}
+
+	/**
+	 * Replace a habitat's Mounted repos and re-derive its read scope.
+	 *
+	 * Adding a mount without widening the scope is the failure ADR 0006
+	 * exists to prevent, so the two move together here rather than being two
+	 * calls a caller can get half-right.
+	 */
+	async setMounts(
+		id: string,
+		mounts: CreateHabitatOptions["mounts"],
+	): Promise<GaiaHabitatEntry> {
+		const entry = this.get(id);
+		if (!entry) throw new Error(`Habitat "${id}" not found`);
+
+		const mountedAgents = mountsToAgentEntries(mounts);
+		// Preserve anything that is not a code mount — remote-habitat peers and
+		// credential-only entries live in the same array.
+		const kept = (entry.config.agents ?? []).filter(
+			(a) => (a.kind ?? "repo") !== "repo" || a.mode !== "read",
+		);
+		const agents = [...kept, ...mountedAgents];
+
+		const config = { ...entry.config, agents };
+		return this.update(id, {
+			config,
+			github: mergeDerivedReadScope(
+				// Drop the previous derivation before re-deriving, so removing a
+				// mount actually narrows the scope instead of leaving it behind.
+				{ ...entry.github, read: explicitReads(entry, mountedAgents) },
+				deriveRepoScopes(config),
+			),
+		});
 	}
 
 	/** Update a habitat entry. */

--- a/packages/habitat/src/tools/gaia/types.ts
+++ b/packages/habitat/src/tools/gaia/types.ts
@@ -131,6 +131,31 @@ export interface CreateHabitatOptions {
 	github?: GaiaHabitatEntry["github"];
 	/** Backing-storage declaration (see GaiaHabitatEntry.storage). */
 	storage?: GaiaHabitatEntry["storage"];
+	/**
+	 * Repos this habitat reads but never writes (ADR 0006).
+	 *
+	 * Declaring them at creation is the point: standing a client habitat up
+	 * used to be a create call plus a config update plus a scope grant plus a
+	 * rebuild, with nothing tying the mounts to the scopes. Passing them here
+	 * derives the read scope from them in the same step, so the two cannot
+	 * drift.
+	 */
+	mounts?: MountedRepoSpec[];
+}
+
+/** A read-only repo mounted into a habitat. */
+export interface MountedRepoSpec {
+	/** Git remote to clone. */
+	gitRemote: string;
+	/** Branch to clone; defaults to the remote's default. */
+	gitBranch?: string;
+	/**
+	 * Stable id for the mount. Defaults to the repo name, which is what makes
+	 * `mounts: [{ gitRemote }]` the common case.
+	 */
+	id?: string;
+	/** Display name; defaults to the id. */
+	name?: string;
 }
 
 /** Status of a credential (whether it's known to be working). */


### PR DESCRIPTION
Closes #281. **This is the ticket that unblocks the operations migration** — The-Focus-AI/operations#5 waits on it.

Standing up a client habitat was a create call, then a config update to add mounts, then a scope grant, then a rebuild. Four steps, nothing tying the mounts to the scopes, about to be repeated fifteen times.

Mounts are now declared at creation and become read-only agent entries the entrypoint clones (ADR 0006). The GitHub read scope is derived from them plus the Owned repo **in the same step**, so a mount can never fail at boot with a 404 that reads like "that repo does not exist". Write is still never derived.

```ts
await registry.create({
  id: "upperhand",
  name: "UpperHand",
  gitUrl: "https://github.com/The-Focus-AI/client-upperhand.git",  // Owned, read-write
  mounts: [{ gitRemote: ".../uh-api.git" }, { gitRemote: ".../uh-web.git" }],  // read-only
});
// github.read === ["client-upperhand", "uh-api", "uh-web"]; github.write === undefined
```

`setMounts()` changes them afterwards and re-derives the scope with them, so adding a mount widens and removing one narrows. The two move together rather than being two calls a caller can get half-right. Non-repo agents — remote-habitat peers, credential-only entries — are left alone.

## Atomicity

A bad mount declaration aborts the create before anything is registered, and a failed save rolls the in-memory registry back. Without that second part a failed create would leave an entry in memory that the next unrelated save quietly persisted — a habitat that exists despite the call having reported failure.

## Smaller decisions

- **Mount ids default to the repo name**, so the common case is just `{ gitRemote }`.
- **Duplicate ids are refused** rather than silently colliding in one directory namespace; pass an explicit id for one of them.
- **An unparseable remote asks for an explicit id** rather than guessing at a name.
- **Bad declarations throw rather than skip** — a mount that silently vanishes surfaces much later as "the agent can't see that repo".

## Verification

26 new tests. Full suite green: 166 files, 2010 tests. All packages typecheck.

Not verified against a live Gaia — no container is actually cloned here. The next thing that would prove this end to end is standing up one real client habitat, which is what operations#5 and #6 cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22


---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_