### PR TITLE
The habitat's own repo is the source of truth for its environment

### DIFF
--- a/packages/habitat/src/tools/gaia/apply-declaration.test.ts
+++ b/packages/habitat/src/tools/gaia/apply-declaration.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { GaiaRegistryManager } from "./registry.js";
+import { applyHabitatDeclaration } from "./apply-declaration.js";
+import { HabitatDeclarationError } from "./declaration.js";
+
+let dir: string;
+let registry: GaiaRegistryManager;
+
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "umwelten-apply-decl-"));
+	registry = new GaiaRegistryManager(dir);
+	await registry.load();
+});
+
+afterEach(async () => {
+	await rm(dir, { recursive: true, force: true });
+});
+
+const OWNED = "https://github.com/The-Focus-AI/client-upperhand.git";
+const API = "https://github.com/The-Focus-AI/uh-api.git";
+const WEB = "https://github.com/The-Focus-AI/uh-web.git";
+
+/** Stands in for cloning the Owned repo and reading habitat.json from it. */
+const reads = (declaration: unknown) =>
+	vi.fn().mockResolvedValue(
+		declaration === undefined ? undefined : JSON.stringify(declaration),
+	);
+
+const apply = (readDeclaration: any, id = "upperhand") =>
+	applyHabitatDeclaration(registry, { id, gitUrl: OWNED, readDeclaration });
+
+describe("applying a declaration", () => {
+	it("creates a habitat that did not exist", async () => {
+		const result = await apply(reads({ name: "UpperHand", mounts: [{ gitRemote: API }] }));
+
+		expect(result.action).toBe("created");
+		expect(result.entry.config.gitUrl).toBe(OWNED);
+		expect(result.entry.config.agents.map((a) => a.id)).toEqual(["uh-api"]);
+	});
+
+	it("derives the read scope from the declaration", async () => {
+		const result = await apply(reads({ mounts: [{ gitRemote: API }] }));
+		expect(result.entry.github?.read).toEqual(["client-upperhand", "uh-api"]);
+	});
+
+	it("takes write scope only from the declaration", async () => {
+		const result = await apply(
+			reads({ mounts: [{ gitRemote: API }], github: { write: ["client-upperhand"] } }),
+		);
+		expect(result.entry.github?.write).toEqual(["client-upperhand"]);
+	});
+
+	it("clones the Owned repo to find the declaration", async () => {
+		const readDeclaration = reads({ name: "UpperHand" });
+		await apply(readDeclaration);
+		// Under ambient read — the narrowed scope cannot be known until the
+		// declaration is in hand.
+		expect(readDeclaration).toHaveBeenCalledWith(OWNED, undefined);
+	});
+});
+
+describe("re-applying a changed declaration", () => {
+	beforeEach(async () => {
+		await apply(reads({ name: "UpperHand", mounts: [{ gitRemote: API }] }));
+	});
+
+	it("updates rather than duplicating", async () => {
+		const result = await apply(reads({ name: "UpperHand", mounts: [{ gitRemote: API }] }));
+		expect(result.action).toBe("updated");
+		expect(registry.list()).toHaveLength(1);
+	});
+
+	it("is idempotent — the same declaration twice leaves the same entry", async () => {
+		const first = registry.get("upperhand")!;
+		await apply(reads({ name: "UpperHand", mounts: [{ gitRemote: API }] }));
+		const second = registry.get("upperhand")!;
+
+		expect(second.config.agents).toEqual(first.config.agents);
+		expect(second.github).toEqual(first.github);
+	});
+
+	it("widens the scope when a mount is added in the repo", async () => {
+		const result = await apply(
+			reads({ mounts: [{ gitRemote: API }, { gitRemote: WEB }] }),
+		);
+		expect(result.entry.github?.read).toEqual(
+			expect.arrayContaining(["client-upperhand", "uh-api", "uh-web"]),
+		);
+	});
+
+	it("narrows the scope when a mount is removed from the repo", async () => {
+		const result = await apply(reads({ mounts: [] }));
+		expect(result.entry.github?.read).not.toContain("uh-api");
+		expect(result.entry.github?.read).toContain("client-upperhand");
+	});
+
+	it("picks up a model change", async () => {
+		const result = await apply(
+			reads({ provider: "google", model: "gemini-3-flash-preview" }),
+		);
+		expect(result.entry.config.defaultModel).toBe("gemini-3-flash-preview");
+	});
+
+	/**
+	 * An apply is a config change, not a restart. Clobbering the port or key
+	 * would take a running container down for no reason.
+	 */
+	it("leaves runtime facts alone", async () => {
+		await registry.update("upperhand", { containerPort: 7440 });
+		const before = registry.get("upperhand")!;
+
+		const result = await apply(reads({ mounts: [{ gitRemote: WEB }] }));
+
+		expect(result.entry.containerPort).toBe(7440);
+		expect(result.entry.apiKey).toBe(before.apiKey);
+		expect(result.entry.createdAt).toBe(before.createdAt);
+	});
+
+	it("keeps agents the declaration does not describe", async () => {
+		const existing = registry.get("upperhand")!;
+		await registry.update("upperhand", {
+			config: {
+				...existing.config,
+				agents: [
+					...existing.config.agents,
+					{ id: "gaia", name: "Gaia", projectPath: "agents/gaia", kind: "remote-habitat" },
+				],
+			},
+		});
+
+		const result = await apply(reads({ mounts: [{ gitRemote: WEB }] }));
+		// Remote peers are wired by another path and are not this file's to delete.
+		expect(result.entry.config.agents.map((a) => a.id).sort()).toEqual([
+			"gaia",
+			"uh-web",
+		]);
+	});
+});
+
+describe("a declaration that cannot be applied", () => {
+	it("refuses a repo with no declaration rather than defaulting one", async () => {
+		await expect(apply(reads(undefined))).rejects.toThrow(HabitatDeclarationError);
+		expect(registry.list()).toHaveLength(0);
+	});
+
+	it("names the file and the repo so the fix is obvious", async () => {
+		await expect(apply(reads(undefined))).rejects.toThrow(
+			/habitat\.json.*client-upperhand/s,
+		);
+	});
+
+	it("registers nothing when the declaration is malformed", async () => {
+		const readDeclaration = vi.fn().mockResolvedValue("{ not json");
+		await expect(apply(readDeclaration)).rejects.toThrow(HabitatDeclarationError);
+		expect(registry.list()).toHaveLength(0);
+	});
+
+	it("leaves an existing habitat untouched when a re-apply is malformed", async () => {
+		await apply(reads({ name: "UpperHand", mounts: [{ gitRemote: API }] }));
+		const before = registry.get("upperhand")!;
+
+		await expect(apply(vi.fn().mockResolvedValue("{ bad"))).rejects.toThrow();
+
+		const after = registry.get("upperhand")!;
+		expect(after.config.agents).toEqual(before.config.agents);
+		expect(after.github).toEqual(before.github);
+	});
+
+	it("surfaces a clone failure rather than swallowing it", async () => {
+		const readDeclaration = vi.fn().mockRejectedValue(new Error("auth required"));
+		await expect(apply(readDeclaration)).rejects.toThrow(/auth required/);
+	});
+});

--- a/packages/habitat/src/tools/gaia/apply-declaration.ts
+++ b/packages/habitat/src/tools/gaia/apply-declaration.ts
@@ -1,0 +1,149 @@
+/**
+ * Applying a habitat's declaration to the registry.
+ *
+ * The registry entry becomes a materialisation of the declaration plus
+ * runtime facts, so it is derived and rebuildable rather than precious
+ * (ADR 0006). Applying is idempotent: the same declaration applied twice
+ * leaves the same entry, and re-applying a changed one updates the config and
+ * re-derives the scopes without touching anything a running container depends
+ * on.
+ *
+ * There is a bootstrap circularity — Gaia must clone the repo to learn the
+ * scopes it needs a token to clone with. It is resolved by cloning the Owned
+ * repo under ambient read first, then narrowing to the derived list. That
+ * ordering is the whole reason `readDeclaration` is injected here rather than
+ * done inline: the clone happens under a different credential than everything
+ * afterwards.
+ */
+
+import type { GaiaHabitatEntry } from "./types.js";
+import {
+	HABITAT_DECLARATION_FILE,
+	HabitatDeclarationError,
+	declarationToCreateOptions,
+	parseHabitatDeclaration,
+	type HabitatDeclaration,
+} from "./declaration.js";
+import { mountsToAgentEntries } from "./mounts.js";
+import { deriveRepoScopes, mergeDerivedReadScope } from "./repo-scopes.js";
+import type { HabitatConfig } from "../../types.js";
+
+/** The registry surface applying needs — narrow, so tests need no real Gaia. */
+export interface ApplyRegistry {
+	get(id: string): GaiaHabitatEntry | undefined;
+	create(
+		options: ReturnType<typeof declarationToCreateOptions>,
+	): Promise<GaiaHabitatEntry>;
+	update(
+		id: string,
+		updates: Partial<GaiaHabitatEntry>,
+	): Promise<GaiaHabitatEntry>;
+}
+
+export interface ApplyDeclarationOptions {
+	id: string;
+	/** The Owned repo — where the declaration was found. */
+	gitUrl: string;
+	gitBranch?: string;
+	/**
+	 * Read `habitat.json` from the Owned repo. Clones under ambient read, since
+	 * the narrowed scope cannot be known until the declaration is in hand.
+	 * Returns undefined when the repo has no declaration.
+	 */
+	readDeclaration: (
+		gitUrl: string,
+		gitBranch?: string,
+	) => Promise<string | undefined>;
+}
+
+export interface ApplyResult {
+	entry: GaiaHabitatEntry;
+	/** Whether this created the habitat or updated an existing one. */
+	action: "created" | "updated";
+	declaration: HabitatDeclaration;
+}
+
+/**
+ * Read a habitat's declaration and make the registry match it.
+ *
+ * A repo with no declaration is refused rather than defaulted: a habitat
+ * conjured from nothing is exactly the un-reviewed configuration this ticket
+ * exists to remove.
+ */
+export async function applyHabitatDeclaration(
+	registry: ApplyRegistry,
+	options: ApplyDeclarationOptions,
+): Promise<ApplyResult> {
+	const source = await options.readDeclaration(
+		options.gitUrl,
+		options.gitBranch,
+	);
+	if (source === undefined) {
+		throw new HabitatDeclarationError(
+			`No ${HABITAT_DECLARATION_FILE} at the root of ${options.gitUrl}. A habitat's environment is declared in its own repo — add one, or create the habitat directly if it is not repo-backed.`,
+		);
+	}
+
+	const declaration = parseHabitatDeclaration(source);
+	const createOptions = declarationToCreateOptions(declaration, {
+		id: options.id,
+		gitUrl: options.gitUrl,
+		...(options.gitBranch ? { gitBranch: options.gitBranch } : {}),
+	});
+
+	const existing = registry.get(options.id);
+	if (!existing) {
+		return {
+			entry: await registry.create(createOptions),
+			action: "created",
+			declaration,
+		};
+	}
+
+	// Rebuild the config from the declaration, but keep agents the declaration
+	// does not describe — remote-habitat peers and credential-only entries are
+	// wired by other paths and are not this file's to delete.
+	const mountedAgents = mountsToAgentEntries(declaration.mounts);
+	const keptAgents = (existing.config.agents ?? []).filter(
+		(a) => (a.kind ?? "repo") !== "repo" || a.mode !== "read",
+	);
+	const config: HabitatConfig = {
+		...existing.config,
+		name: createOptions.name,
+		defaultProvider: createOptions.provider ?? existing.config.defaultProvider,
+		defaultModel: createOptions.model ?? existing.config.defaultModel,
+		gitUrl: options.gitUrl,
+		...(options.gitBranch ? { gitBranch: options.gitBranch } : {}),
+		agents: [...keptAgents, ...mountedAgents],
+		...(declaration.skillsFromGit
+			? { skillsFromGit: declaration.skillsFromGit }
+			: {}),
+	};
+
+	const entry = await registry.update(options.id, {
+		name: createOptions.name,
+		config,
+		...(declaration.secretBindings
+			? { secretBindings: declaration.secretBindings }
+			: {}),
+		// Read is re-derived from what the declaration says to mount, so removing
+		// a mount in the repo actually narrows the scope. Write comes only from
+		// the declaration and is never derived.
+		github: mergeDerivedReadScope(
+			{
+				...(declaration.github?.read !== undefined
+					? { read: declaration.github.read }
+					: {}),
+				...(declaration.github?.write !== undefined
+					? { write: declaration.github.write }
+					: {}),
+			},
+			deriveRepoScopes(config),
+		),
+		...(declaration.storage ? { storage: declaration.storage } : {}),
+		...(declaration.image ? { image: declaration.image } : {}),
+		...(declaration.hostname ? { hostname: declaration.hostname } : {}),
+	} as Partial<GaiaHabitatEntry>);
+
+	return { entry, action: "updated", declaration };
+}

--- a/packages/habitat/src/tools/gaia/declaration.test.ts
+++ b/packages/habitat/src/tools/gaia/declaration.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+	HABITAT_DECLARATION_FILE,
+	HabitatDeclarationError,
+	declarationToCreateOptions,
+	parseHabitatDeclaration,
+} from "./declaration.js";
+
+const MINIMAL = JSON.stringify({ name: "UpperHand" });
+
+describe("parseHabitatDeclaration", () => {
+	it("accepts a minimal declaration", () => {
+		expect(parseHabitatDeclaration(MINIMAL)).toEqual({ name: "UpperHand" });
+	});
+
+	it("accepts an empty object — every field is optional", () => {
+		expect(parseHabitatDeclaration("{}")).toEqual({});
+	});
+
+	it("reads mounts", () => {
+		const d = parseHabitatDeclaration(
+			JSON.stringify({
+				mounts: [
+					{ gitRemote: "https://github.com/x/a.git" },
+					{ gitRemote: "https://github.com/x/b.git", gitBranch: "release", id: "bee" },
+				],
+			}),
+		);
+		expect(d.mounts).toEqual([
+			{ gitRemote: "https://github.com/x/a.git" },
+			{ gitRemote: "https://github.com/x/b.git", gitBranch: "release", id: "bee" },
+		]);
+	});
+
+	it("reads model, secret bindings and github write", () => {
+		const d = parseHabitatDeclaration(
+			JSON.stringify({
+				provider: "google",
+				model: "gemini-3-flash-preview",
+				secretBindings: ["GOOGLE_GENERATIVE_AI_API_KEY"],
+				github: { write: ["client-upperhand"] },
+			}),
+		);
+		expect(d).toMatchObject({
+			provider: "google",
+			model: "gemini-3-flash-preview",
+			secretBindings: ["GOOGLE_GENERATIVE_AI_API_KEY"],
+			github: { write: ["client-upperhand"] },
+		});
+	});
+
+	it("preserves an org-wide read, which is a deliberate act", () => {
+		const d = parseHabitatDeclaration(JSON.stringify({ github: { read: "org" } }));
+		expect(d.github?.read).toBe("org");
+	});
+
+	/**
+	 * The Owned repo is the repo the declaration lives in. Writing it down
+	 * would create a second place for it to be wrong.
+	 */
+	it("refuses a declared gitUrl", () => {
+		expect(() =>
+			parseHabitatDeclaration(JSON.stringify({ gitUrl: "https://github.com/x/a.git" })),
+		).toThrow(/the repo this file lives in/);
+	});
+
+	describe("rejects rather than repairs", () => {
+		it.each([
+			["not JSON at all", "{ nope"],
+			["a top-level array", "[]"],
+			["a top-level string", '"hello"'],
+			["a non-string name", JSON.stringify({ name: 42 })],
+			["mounts that are not an array", JSON.stringify({ mounts: {} })],
+			["a mount that is not an object", JSON.stringify({ mounts: ["x"] })],
+			["a mount with no remote", JSON.stringify({ mounts: [{}] })],
+			["a mount with a blank remote", JSON.stringify({ mounts: [{ gitRemote: "  " }] })],
+			["a non-string mount branch", JSON.stringify({ mounts: [{ gitRemote: "g", gitBranch: 1 }] })],
+			["secretBindings that are not strings", JSON.stringify({ secretBindings: [1] })],
+			["github that is not an object", JSON.stringify({ github: "org" })],
+			["a non-array github.write", JSON.stringify({ github: { write: "x" } })],
+		])("rejects %s", (_label, source) => {
+			expect(() => parseHabitatDeclaration(source)).toThrow(HabitatDeclarationError);
+		});
+
+		it("names the file in the error, so the fix is obvious", () => {
+			expect(() => parseHabitatDeclaration("{ nope")).toThrow(
+				new RegExp(HABITAT_DECLARATION_FILE),
+			);
+		});
+	});
+});
+
+describe("declarationToCreateOptions", () => {
+	const ctx = { id: "upperhand", gitUrl: "https://github.com/x/client-upperhand.git" };
+
+	it("takes the id and Owned repo from context, not the declaration", () => {
+		const opts = declarationToCreateOptions({ name: "UpperHand" }, ctx);
+		expect(opts).toMatchObject({ id: "upperhand", gitUrl: ctx.gitUrl });
+	});
+
+	it("falls back to the id when the declaration names nothing", () => {
+		expect(declarationToCreateOptions({}, ctx).name).toBe("upperhand");
+	});
+
+	it("carries mounts through to creation", () => {
+		const opts = declarationToCreateOptions(
+			{ mounts: [{ gitRemote: "https://github.com/x/a.git" }] },
+			ctx,
+		);
+		expect(opts.mounts).toHaveLength(1);
+	});
+
+	it("omits what the declaration did not state", () => {
+		const opts = declarationToCreateOptions({}, ctx);
+		expect(opts).not.toHaveProperty("provider");
+		expect(opts).not.toHaveProperty("storage");
+	});
+
+	it("carries a branch when the context pins one", () => {
+		expect(
+			declarationToCreateOptions({}, { ...ctx, gitBranch: "main" }).gitBranch,
+		).toBe("main");
+	});
+});

--- a/packages/habitat/src/tools/gaia/declaration.ts
+++ b/packages/habitat/src/tools/gaia/declaration.ts
@@ -1,0 +1,208 @@
+/**
+ * A habitat's environment, declared in its own repo.
+ *
+ * Per ADR 0006 the habitat's repo is the source of truth for what the habitat
+ * *is* — its Owned repo, its Mounted repos, its model, the credentials it
+ * needs. Gaia *applies* that declaration; the registry entry becomes a
+ * materialisation of it plus runtime facts (assigned port, container status,
+ * cached card), which are derived and rebuildable rather than precious.
+ *
+ * This is the "build an environment" primitive: creating a client habitat
+ * instantiates from a template repo, and every later change is a pull request
+ * against that repo rather than a Gaia tool call. The accepted trade is
+ * better provenance for worse ergonomics.
+ *
+ * A `habitat.json` at the repo root looks like:
+ *
+ *   {
+ *     "name": "UpperHand",
+ *     "provider": "google",
+ *     "model": "gemini-3-flash-preview",
+ *     "mounts": [{ "gitRemote": "https://github.com/The-Focus-AI/uh-api.git" }],
+ *     "secretBindings": ["GOOGLE_GENERATIVE_AI_API_KEY"],
+ *     "github": { "write": ["client-upperhand"] }
+ *   }
+ *
+ * The Owned repo is deliberately absent: it is the repo the declaration lives
+ * in, so writing it down would create a second place for it to be wrong.
+ */
+
+import type { CreateHabitatOptions, GaiaHabitatEntry, MountedRepoSpec } from "./types.js";
+
+/** Filename Gaia looks for at the root of a habitat's Owned repo. */
+export const HABITAT_DECLARATION_FILE = "habitat.json";
+
+export interface HabitatDeclaration {
+	name?: string;
+	provider?: string;
+	model?: string;
+	/** Repos this habitat reads and never writes. */
+	mounts?: MountedRepoSpec[];
+	secretBindings?: string[];
+	skillsFromGit?: string[];
+	/**
+	 * GitHub capabilities. Only `write` is meaningful here — `read` is derived
+	 * from the Owned repo plus the mounts (ADR 0006), so declaring it is at
+	 * best redundant and at worst a second place to drift.
+	 */
+	github?: { write?: string[]; read?: "org" | string[] };
+	storage?: GaiaHabitatEntry["storage"];
+	image?: string;
+	hostname?: string;
+}
+
+export class HabitatDeclarationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "HabitatDeclarationError";
+	}
+}
+
+function fail(what: string): never {
+	throw new HabitatDeclarationError(
+		`Invalid ${HABITAT_DECLARATION_FILE}: ${what}`,
+	);
+}
+
+function asStringArray(value: unknown, field: string): string[] | undefined {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value) || value.some((v) => typeof v !== "string")) {
+		fail(`"${field}" must be an array of strings.`);
+	}
+	return value as string[];
+}
+
+function parseMounts(value: unknown): MountedRepoSpec[] | undefined {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value)) fail(`"mounts" must be an array.`);
+
+	return value.map((raw, i) => {
+		if (typeof raw !== "object" || raw === null) {
+			fail(`mounts[${i}] must be an object.`);
+		}
+		const m = raw as Record<string, unknown>;
+		if (typeof m.gitRemote !== "string" || !m.gitRemote.trim()) {
+			fail(`mounts[${i}] needs a non-empty "gitRemote".`);
+		}
+		for (const key of ["gitBranch", "id", "name"] as const) {
+			if (m[key] !== undefined && typeof m[key] !== "string") {
+				fail(`mounts[${i}].${key} must be a string.`);
+			}
+		}
+		return {
+			gitRemote: m.gitRemote,
+			...(m.gitBranch ? { gitBranch: m.gitBranch as string } : {}),
+			...(m.id ? { id: m.id as string } : {}),
+			...(m.name ? { name: m.name as string } : {}),
+		};
+	});
+}
+
+/**
+ * Parse and validate a declaration.
+ *
+ * Rejects rather than repairs. A partially understood declaration would
+ * produce a partially configured habitat, which fails later and further from
+ * the cause than a rejected apply does.
+ */
+export function parseHabitatDeclaration(source: string): HabitatDeclaration {
+	let raw: unknown;
+	try {
+		raw = JSON.parse(source);
+	} catch (err) {
+		fail(`not valid JSON — ${err instanceof Error ? err.message : String(err)}`);
+	}
+	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+		fail("expected a JSON object at the top level.");
+	}
+
+	const d = raw as Record<string, unknown>;
+	for (const key of ["name", "provider", "model", "image", "hostname"] as const) {
+		if (d[key] !== undefined && typeof d[key] !== "string") {
+			fail(`"${key}" must be a string.`);
+		}
+	}
+
+	if (d.gitUrl !== undefined) {
+		// The Owned repo is the repo this file lives in. Declaring it here would
+		// be a second place for it to be wrong.
+		fail(
+			`"gitUrl" is not declared here — the Owned repo is the repo this file lives in.`,
+		);
+	}
+
+	let github: HabitatDeclaration["github"];
+	if (d.github !== undefined) {
+		if (typeof d.github !== "object" || d.github === null) {
+			fail(`"github" must be an object.`);
+		}
+		const g = d.github as Record<string, unknown>;
+		const write = asStringArray(g.write, "github.write");
+		const read =
+			g.read === "org" ? ("org" as const) : asStringArray(g.read, "github.read");
+		github = { ...(write ? { write } : {}), ...(read ? { read } : {}) };
+	}
+
+	return {
+		...(d.name ? { name: d.name as string } : {}),
+		...(d.provider ? { provider: d.provider as string } : {}),
+		...(d.model ? { model: d.model as string } : {}),
+		...(d.image ? { image: d.image as string } : {}),
+		...(d.hostname ? { hostname: d.hostname as string } : {}),
+		...(parseMounts(d.mounts) ? { mounts: parseMounts(d.mounts) } : {}),
+		...(asStringArray(d.secretBindings, "secretBindings")
+			? { secretBindings: asStringArray(d.secretBindings, "secretBindings") }
+			: {}),
+		...(asStringArray(d.skillsFromGit, "skillsFromGit")
+			? { skillsFromGit: asStringArray(d.skillsFromGit, "skillsFromGit") }
+			: {}),
+		...(github ? { github } : {}),
+		...(d.storage ? { storage: d.storage as GaiaHabitatEntry["storage"] } : {}),
+	};
+}
+
+/**
+ * Turn a declaration into creation options.
+ *
+ * `id` and `gitUrl` come from outside the declaration — the id is how the
+ * fleet addresses this habitat and the Owned repo is where the declaration
+ * was found, so neither is the declaration's to state.
+ */
+export function declarationToCreateOptions(
+	declaration: HabitatDeclaration,
+	context: { id: string; gitUrl: string; gitBranch?: string },
+): CreateHabitatOptions {
+	return {
+		id: context.id,
+		name: declaration.name ?? context.id,
+		gitUrl: context.gitUrl,
+		...(context.gitBranch ? { gitBranch: context.gitBranch } : {}),
+		...(declaration.provider ? { provider: declaration.provider } : {}),
+		...(declaration.model ? { model: declaration.model } : {}),
+		...(declaration.mounts ? { mounts: declaration.mounts } : {}),
+		...(declaration.secretBindings
+			? { secretBindings: declaration.secretBindings }
+			: {}),
+		...(declaration.skillsFromGit
+			? { skillsFromGit: declaration.skillsFromGit }
+			: {}),
+		...(declaration.github ? { github: declaration.github } : {}),
+		...(declaration.storage ? { storage: declaration.storage } : {}),
+		...(declaration.image ? { image: declaration.image } : {}),
+		...(declaration.hostname ? { hostname: declaration.hostname } : {}),
+	};
+}
+
+/**
+ * Runtime facts a registry entry holds that no declaration can state.
+ *
+ * Re-applying a declaration must not disturb these — an apply is a config
+ * change, not a restart, and clobbering the port or the API key would take a
+ * running container down for no reason.
+ */
+export const RUNTIME_ONLY_FIELDS = [
+	"apiKey",
+	"containerPort",
+	"cachedCard",
+	"createdAt",
+] as const;


### PR DESCRIPTION
Closes #282. **Unblocks The-Focus-AI/operations#6** — with #281 already merged, this is the last platform ticket standing between the fleet and the UpperHand pilot.

Per ADR 0006 a habitat's repo declares what the habitat *is* — its Mounted repos, model, credential bindings — and Gaia applies it. The registry entry becomes a materialisation of that declaration plus runtime facts: derived and rebuildable rather than precious. Creating a client habitat becomes instantiating from a template repo, and every later change is a pull request against that repo rather than a remembered sequence of tool calls.

```json
// habitat.json at the root of the Owned repo
{
  "name": "UpperHand",
  "provider": "google",
  "model": "gemini-3-flash-preview",
  "mounts": [{ "gitRemote": "https://github.com/The-Focus-AI/uh-api.git" }],
  "secretBindings": ["GOOGLE_GENERATIVE_AI_API_KEY"],
  "github": { "write": ["client-upperhand"] }
}
```

**One field is deliberately missing: the Owned repo.** It is the repo the declaration lives in, so writing it down would only create a second place for it to be wrong. A declared `gitUrl` is rejected with that reasoning in the error.

## What an apply must not disturb

- **Runtime facts** — assigned port, API key, cached card, created-at. An apply is a config change, not a restart; clobbering these would take a running container down for no reason.
- **Agents the declaration does not describe** — remote-habitat peers and credential-only entries are wired by other paths and are not this file's to delete.

## Refusing rather than repairing

A malformed declaration is rejected, not partially understood — a partially configured habitat fails later and further from the cause. A repo with **no** declaration is refused rather than defaulted, because a habitat conjured from nothing is exactly the un-reviewed configuration this ticket removes. A failed re-apply leaves the existing entry untouched.

## The bootstrap circularity

Gaia must clone the repo to learn the scopes it needs a token to clone with. `readDeclaration` is injected rather than done inline precisely because of that ordering: the first clone runs under ambient read, everything afterwards under the derived list.

## Verification

40 new tests. Full suite green: 168 files, 2050 tests. All packages typecheck.

Not verified against a live Gaia — the clone is injected, so nothing here has read a real `habitat.json` from a real repo. The thing that would prove it end to end is standing up the UpperHand habitat, which is operations#5 and #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22


---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_