### PR TITLE
Context explorer: Ollama defaults, model lock UX, markdown, guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -72,6 +72,8 @@ export default defineConfig({
             { text: 'Cost Analysis', link: '/guide/cost-analysis' },
             { text: 'Session Management', link: '/guide/session-management' },
             { text: 'Context Management', link: '/guide/context-management' },
+            { text: 'Turn Fan-out', link: '/guide/turn-fanout' },
+            { text: 'Context Explorer', link: '/guide/context-explorer' },
             { text: 'Memory & Tools', link: '/guide/memory-tools' },
             { text: 'Batch Processing', link: '/guide/batch-processing' },
             { text: 'Concurrent Processing', link: '/guide/concurrent-processing' },

--- a/docs/guide/context-explorer.md
+++ b/docs/guide/context-explorer.md
@@ -1,0 +1,225 @@
+# Context Explorer
+
+An interactive page for **turn fan-out**: ask a question, watch the answer
+stream in, then watch several probes run **in parallel over that same context** —
+and pick a compacted baseline to continue from.
+
+This is the hands-on surface for [`runFanout()`](./turn-fanout.md). The API and
+probe design live there; this guide is how to run the app, choose models, read
+the cards, and experiment.
+
+## Quick start
+
+From the repo root (API keys via `.env` / `dotenvx`; Ollama needs no cloud key):
+
+```bash
+dotenvx run -- pnpm tsx examples/context-explorer/server.ts
+# → http://127.0.0.1:7432
+
+PORT=7433 dotenvx run -- pnpm tsx examples/context-explorer/server.ts
+```
+
+Open the URL, type a question, press **Ask** (or ⌘/Ctrl+Enter). The answer
+streams as markdown; when it finishes, six probe cards fill in as each probe
+lands.
+
+Default models are local:
+
+| field | default |
+|---|---|
+| answer | `ollama/gemma4:26b` |
+| fan-out | `ollama/gemma4:26b` |
+
+Pull the model first if needed: `ollama pull gemma4:26b`.
+
+## What you are looking at
+
+After every turn the page does two things with the **same message snapshot**:
+
+1. **Answer** — the normal chat turn (`Interaction.streamText()`), optionally
+   with tools.
+2. **Fan-out** — `runFanout()` runs a list of probes concurrently over that
+   snapshot.
+
+Probes come in two kinds:
+
+| kind | color | purpose |
+|---|---|---|
+| **annotation** | orange | Information *about* the state (title, intent, done?, open loops). Does not change the conversation. |
+| **baseline** | blue | A candidate *replacement* context from a compaction strategy. **Continue from this** swaps it in as the live history. |
+
+Each card reports latency, prompt tokens (when available), cost, and whether the
+probe **shared the prefix** or **rebuilt the prompt**. Annotations send the
+history verbatim plus a short question, so a provider-side prefix cache can
+apply. Compaction strategies build their own summarizer prompt, so they do not
+share that prefix. That distinction is the measurement the page exists to make —
+nothing is constrained to make the numbers flattering.
+
+## Choosing models
+
+Header fields use `provider/model` (split on the **first** `/`):
+
+```text
+ollama/gemma4:26b
+ollama/gemma4:12b
+google/gemini-3-flash-preview
+openrouter/openai/gpt-5.4-nano
+lmstudio/some-local-model
+llamaswap/your-swap-name
+```
+
+- **answer** — model for the chat turn.
+- **fan-out** — model for every probe (unless a probe overrides in code). Leave
+  blank to match answer.
+- **tools** — when checked, attaches `webTools` + `mathTools` to the answer
+  path only (not to probes).
+
+### Model lock (important)
+
+Models are **locked when a run is created**. The page:
+
+1. Creates a run on load with whatever is in the header.
+2. Shows the **locked** models in the stats bar (not just the input fields).
+3. On **Ask**, if the header no longer matches the live run, starts a **new**
+   run automatically so typing `ollama/…` actually takes effect.
+
+**New run** does the same explicitly and clears the transcript view.
+
+Status text during a turn names the models in use, e.g. `Answering with
+ollama/gemma4:26b…` then `Fanning out with ollama/gemma4:26b (6 probes)…`.
+
+### Useful splits
+
+Run a large or cloud model for answers and a cheap/local one for fan-out:
+
+```text
+answer:   google/gemini-3-flash-preview
+fan-out:  ollama/gemma4:12b
+```
+
+Local-only (privacy / cost):
+
+```text
+answer:   ollama/gemma4:26b
+fan-out:  ollama/gemma4:26b
+```
+
+Fan-out fires several probes in parallel. On a single GPU they will queue —
+expect higher wall time than one isolated chat turn, even when each probe is
+short.
+
+Bare model names without a `provider/` prefix fall back to the default model;
+always include the provider.
+
+## Reading a turn
+
+1. **You** bubble — plain text of the question.
+2. **Assistant** bubble — streamed markdown (headings, lists, fenced code with a
+   **Copy** button on each block).
+3. Meta line — context tokens before → after, answer latency, answer cost.
+4. **after this turn** — probe cards as they complete.
+
+On a baseline card, **continue from this** replaces the live interaction
+messages with that probe's `replacement`. The next Ask continues from the
+compacted context, not the full history. Stats update; the chosen baseline is
+marked on that turn.
+
+## Session state on disk
+
+Each run writes under:
+
+```text
+~/.umwelten/context-explorer/<runId>/
+  transcript.jsonl   # conversation in the standard session format
+  fanout.jsonl       # one JSON line per turn: models, answer, every probe result
+```
+
+Override the root with `CONTEXT_EXPLORER_DIR`. `transcript.jsonl` is readable by
+the rest of the session tooling. `fanout.jsonl` is for later reporting
+(cost, latency, `sharedPrefix` per probe).
+
+In-memory runs are lost on server restart; the files remain.
+
+## Experimenting with probes
+
+Default probes live in core:
+
+`packages/core/src/interaction/reflection/fanout.ts` → `DEFAULT_PROBES`
+
+| id | kind | asks / strategy |
+|---|---|---|
+| `title` | annotation | short title |
+| `intent` | annotation | what the person is trying to do |
+| `done` | annotation | finished? what remains? |
+| `open-loops` | annotation | unresolved bullets, or `none` |
+| `through-line-and-facts` | baseline | compaction strategy of that id |
+| `truncate` | baseline | free truncate strategy |
+
+An annotation is a label and a question:
+
+```typescript
+{
+  id: "next",
+  label: "What would you ask next?",
+  kind: "annotation",
+  question: "What is the single most useful next question? Reply with it only.",
+  // optional: model: { provider: "ollama", name: "gemma4:12b" },
+}
+```
+
+A baseline is a registered compaction `strategyId` (see
+[Context Management](./context-management.md)). The page loads probes from
+`GET /api/defaults` and sends them on `POST /api/runs`. There is no probe editor
+in the UI yet — change `DEFAULT_PROBES`, or POST a custom `probes` array when
+creating a run.
+
+Unit tests for prefix identity, failure isolation, and model override:
+`packages/core/src/interaction/reflection/fanout.test.ts`.
+
+## How the app is wired
+
+Thin on purpose. Machinery is umwelten; the example is a socket and a page.
+
+| piece | location |
+|---|---|
+| turn | `Interaction.streamText()` — `@umwelten/core` |
+| fan-out | `runFanout()` — `core/interaction/reflection/fanout.ts` |
+| baselines | compaction registry — `core/context/registry.ts` |
+| tools | `webTools` + `mathTools` — `core/stimulus/tools` |
+| persistence | `writeSessionTranscript()` — `core/session-record` |
+| HTTP + SSE | `examples/context-explorer/server.ts` |
+| UI | `examples/context-explorer/index.html` |
+
+Main routes:
+
+| method | path | role |
+|---|---|---|
+| `GET` | `/` | page |
+| `GET` | `/api/defaults` | default probes + model |
+| `GET` | `/api/strategies` | registered compaction strategies |
+| `POST` | `/api/runs` | create run (`answerModel`, `fanoutModel`, `useTools`, `probes`) |
+| `POST` | `/api/runs/:id/ask` | SSE: answer deltas, then probes |
+| `POST` | `/api/runs/:id/continue-from` | adopt a baseline (`turnIndex`, `probeId`) |
+| `GET` | `/api/runs/:id/context` | current messages |
+
+## Design notes
+
+- **Why fan-out after every turn?** Annotations should ride a warm prefix; if that
+  holds, marginal cost is mostly the short question. Whether it holds is a
+  property of the backend — `sharedPrefix` records the claim; cache stats
+  (e.g. llama.cpp `timings.cache_n`) turn it into a measurement.
+- **Why not a separate package?** See [ADR 0006](../adr/0006-turn-fanout-in-core-not-a-package.md).
+  Fan-out is reflection over an `Interaction`; baselines reuse the existing
+  compaction registry rather than inventing a parallel tree.
+- **API deep dive:** [Turn Fan-out](./turn-fanout.md).
+
+## Troubleshooting
+
+| symptom | check |
+|---|---|
+| Still on Google after typing `ollama/…` | Stats bar shows locked models; Ask should auto-switch. Hard-refresh if the page is stale. |
+| `ollama` errors | `ollama list`, model pulled, daemon running. |
+| Very slow fan-out on one GPU | Expected: several probes in parallel queue. Try a smaller fan-out model. |
+| Weird tool calls in the answer | Uncheck **tools** for pure fan-out experiments. |
+| Run lost after restart | Server holds runs in memory; reopen and New run. Files under `~/.umwelten/context-explorer/` remain. |
+| Markdown not rendering | Page loads `marked` from a CDN; need network for first load, or check the browser console. |

--- a/docs/guide/turn-fanout.md
+++ b/docs/guide/turn-fanout.md
@@ -111,10 +111,11 @@ One failing probe never takes the others, or the turn, down with it.
 ## Seeing it
 
 `examples/context-explorer/` is an interactive page built on this: ask a
-question, watch the answer stream, watch the probes fill in as cards, and click
-**continue from this** on any baseline to adopt it as the live context. Answer
-model and fan-out model are selected separately, so running the fan-out on a
-cheap or local model against a large answer model is a one-field change.
+question, watch the answer stream as markdown, watch the probes fill in as cards,
+and click **continue from this** on any baseline to adopt it as the live context.
+Answer model and fan-out model are selected separately (defaults:
+`ollama/gemma4:26b`), so running the fan-out on a cheap or local model against a
+large answer model is a one-field change.
 
 ```bash
 dotenvx run -- pnpm tsx examples/context-explorer/server.ts   # http://127.0.0.1:7432
@@ -122,6 +123,10 @@ dotenvx run -- pnpm tsx examples/context-explorer/server.ts   # http://127.0.0.1
 
 State lands in `~/.umwelten/context-explorer/<runId>/` as `transcript.jsonl` in
 the standard session format, plus `fanout.jsonl` with one line per turn.
+
+For the full walkthrough — model lock UX, local vs cloud, reading cards,
+editing probes, and the HTTP surface — see
+[Context Explorer](./context-explorer.md).
 
 ## Design notes
 

--- a/examples/context-explorer/README.md
+++ b/examples/context-explorer/README.md
@@ -1,12 +1,18 @@
 # Context explorer
 
-Ask a question, watch the answer stream in, then watch several probes run **in
-parallel over that same context** — and pick one to continue from.
+Ask a question, watch the answer stream in as markdown, then watch several probes
+run **in parallel over that same context** — and pick one to continue from.
+
+Full guide: [docs/guide/context-explorer.md](../../docs/guide/context-explorer.md)
+(API / design: [docs/guide/turn-fanout.md](../../docs/guide/turn-fanout.md)).
 
 ```bash
 dotenvx run -- pnpm tsx examples/context-explorer/server.ts   # http://127.0.0.1:7432
 PORT=7433 dotenvx run -- pnpm tsx examples/context-explorer/server.ts
 ```
+
+Defaults: answer and fan-out both `ollama/gemma4:26b` (requires Ollama with that
+model pulled). Override in the header with `provider/model`.
 
 ## What it's for
 
@@ -33,8 +39,9 @@ summarizer prompt and pay full price. Nothing is constrained to make that come
 out well — the point is to find out.
 
 Both models are selectable in the header (`provider/model`), separately for the
-answer and the fan-out. Running the fan-out on a cheap or local model while the
-answer runs on a big one is the obvious thing to try.
+answer and the fan-out. The stats bar shows the models **locked for the current
+run**; changing the header and clicking Ask (or New run) starts a run with the
+new selection.
 
 ## Where the code is
 
@@ -48,9 +55,9 @@ The app is thin on purpose. All of the machinery is umwelten:
 | tools | `webTools` + `mathTools` — `core/stimulus/tools` |
 | persistence | `writeSessionTranscript()` — `core/session-record` |
 
-`server.ts` adds a socket and routes; `index.html` is the page. Add a probe by
-editing `DEFAULT_PROBES` in `fanout.ts` — annotations are just a label and a
-question.
+`server.ts` adds a socket and routes; `index.html` is the page (markdown via
+`marked`, copy buttons on fenced code). Add a probe by editing `DEFAULT_PROBES`
+in `fanout.ts` — annotations are just a label and a question.
 
 ## State
 
@@ -65,10 +72,3 @@ Each run writes a session directory:
 `transcript.jsonl` is the same format the rest of the session tooling reads.
 `fanout.jsonl` is what a report gets built from. Override the root with
 `CONTEXT_EXPLORER_DIR`.
-
-## Status
-
-Not yet run against a live provider — built in an environment without API keys,
-so the server, the routes, the page and the fan-out logic are exercised by unit
-tests and a boot check, but no real turn has gone through it end to end. First
-real run is the test.

--- a/examples/context-explorer/index.html
+++ b/examples/context-explorer/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Context explorer</title>
+<script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js"></script>
 <style>
   :root {
     color-scheme: light;
@@ -19,6 +20,7 @@
     --series-2: #eb6834;
     --good: #0ca30c;
     --critical: #d03b3b;
+    --code-bg: #f0efeb;
   }
   @media (prefers-color-scheme: dark) {
     :root:where(:not([data-theme="light"])) {
@@ -26,6 +28,7 @@
       --surface-1: #1a1a19; --surface-2: #232322; --plane: #0d0d0d;
       --text-primary: #ffffff; --text-secondary: #c3c2b7; --grid: #2c2c2a;
       --border: rgba(255,255,255,0.10); --series-1: #3987e5; --series-2: #d95926;
+      --code-bg: #121211;
     }
   }
   * { box-sizing: border-box; }
@@ -45,19 +48,21 @@
     font: inherit; color: inherit; background: var(--surface-1);
     border: 1px solid var(--border); border-radius: 7px; padding: .28rem .5rem;
   }
-  input.model { width: 190px; }
+  input.model { width: 220px; }
   button { cursor: pointer; }
   button:hover { background: var(--surface-2); }
   button.primary { background: var(--series-1); border-color: var(--series-1); color: #fff; }
   button:disabled { opacity: .5; cursor: not-allowed; }
-  .stats { margin-left: auto; display: flex; gap: .85rem; font-size: .78rem; color: var(--text-secondary); font-variant-numeric: tabular-nums; }
+  .stats { margin-left: auto; display: flex; gap: .85rem; font-size: .78rem; color: var(--text-secondary); font-variant-numeric: tabular-nums; flex-wrap: wrap; justify-content: flex-end; }
   .stats b { color: var(--text-primary); }
+  .stats .models { color: var(--text-primary); max-width: 42ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   main { flex: 1; overflow-y: auto; padding: 1rem; }
   .wrap { max-width: 1180px; margin: 0 auto; }
   .turn { margin-bottom: 1.6rem; }
   .bubble { border: 1px solid var(--border); border-radius: 10px; background: var(--surface-1); padding: .7rem .85rem; margin-bottom: .5rem; }
   .bubble .role { font-size: .68rem; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin-bottom: .2rem; }
-  .bubble .text { white-space: pre-wrap; word-break: break-word; }
+  .bubble .text { word-break: break-word; }
+  .bubble .text.plain { white-space: pre-wrap; }
   .meta { font-size: .75rem; color: var(--text-secondary); font-variant-numeric: tabular-nums; margin-top: .4rem; }
   .tools { font-size: .75rem; color: var(--series-2); margin-top: .3rem; }
   .fan-head { font-size: .72rem; text-transform: uppercase; letter-spacing: .05em; color: var(--text-secondary); margin: .9rem 0 .45rem; }
@@ -80,13 +85,78 @@
   .composer textarea { flex: 1; resize: vertical; min-height: 46px; max-height: 220px; background: var(--plane); }
   #status { max-width: 1180px; margin: 0 auto .4rem; font-size: .78rem; color: var(--text-secondary); min-height: 1.2em; }
   .hint { color: var(--text-secondary); font-size: .85rem; }
+
+  /* Markdown in assistant answers */
+  .md { line-height: 1.55; }
+  .md > :first-child { margin-top: 0; }
+  .md > :last-child { margin-bottom: 0; }
+  .md p, .md ul, .md ol, .md pre, .md blockquote, .md table { margin: .55em 0; }
+  .md h1, .md h2, .md h3, .md h4 { margin: .9em 0 .35em; line-height: 1.25; font-weight: 600; }
+  .md h1 { font-size: 1.25rem; }
+  .md h2 { font-size: 1.1rem; }
+  .md h3 { font-size: 1rem; }
+  .md ul, .md ol { padding-left: 1.35em; }
+  .md li { margin: .2em 0; }
+  .md a { color: var(--series-1); }
+  .md blockquote {
+    margin-left: 0; padding: .2rem .75rem; border-left: 3px solid var(--border);
+    color: var(--text-secondary);
+  }
+  .md code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: .86em;
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: .05em .3em;
+  }
+  .md pre {
+    position: relative;
+    margin: .7em 0;
+    padding: .7rem .8rem;
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow-x: auto;
+  }
+  .md pre code {
+    background: none; border: none; padding: 0; font-size: .82rem;
+    white-space: pre; display: block; line-height: 1.45;
+  }
+  .md table { border-collapse: collapse; width: 100%; font-size: .9em; }
+  .md th, .md td { border: 1px solid var(--border); padding: .3rem .5rem; text-align: left; }
+  .md th { background: var(--surface-2); }
+  .md hr { border: none; border-top: 1px solid var(--border); margin: 1em 0; }
+  .code-block {
+    position: relative;
+  }
+  .copy-btn {
+    position: absolute;
+    top: .4rem;
+    right: .4rem;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: .25rem;
+    font-size: .68rem;
+    line-height: 1;
+    padding: .28rem .45rem;
+    border-radius: 6px;
+    background: var(--surface-1);
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+    opacity: .85;
+  }
+  .copy-btn:hover { opacity: 1; background: var(--surface-2); color: var(--text-primary); }
+  .copy-btn.copied { color: var(--good); border-color: var(--good); }
+  .copy-btn svg { width: 12px; height: 12px; display: block; }
 </style>
 </head>
 <body>
 <header>
   <h1>Context explorer</h1>
-  <label class="inline">answer <input id="answer-model" class="model" value="google/gemini-3-flash-preview"></label>
-  <label class="inline">fan-out <input id="fanout-model" class="model" placeholder="same as answer"></label>
+  <label class="inline">answer <input id="answer-model" class="model" value="ollama/gemma4:26b"></label>
+  <label class="inline">fan-out <input id="fanout-model" class="model" placeholder="same as answer" value="ollama/gemma4:26b"></label>
   <label class="inline"><input type="checkbox" id="use-tools" checked> tools</label>
   <button id="new-run">New run</button>
   <div class="stats" id="stats"></div>
@@ -105,11 +175,19 @@
 </footer>
 
 <script>
+const DEFAULT_MODEL = { provider: 'ollama', name: 'gemma4:26b' };
 const state = { runId: null, run: null, probes: [], busy: false };
 const $ = (id) => document.getElementById(id);
 const esc = (s) => String(s ?? '').replace(/[&<>"]/g, (c) => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;' }[c]));
 const num = (n) => Number(n || 0).toLocaleString();
 const usd = (n) => n == null ? '—' : (n < 0.01 ? '$' + n.toFixed(4) : '$' + n.toFixed(2));
+
+const COPY_ICON = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
+const CHECK_ICON = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>`;
+
+if (window.marked) {
+  marked.setOptions({ gfm: true, breaks: false });
+}
 
 async function api(path, options) {
   const res = await fetch(path, { ...options, headers: { 'content-type': 'application/json', ...(options && options.headers) } });
@@ -125,25 +203,115 @@ function parseModel(value, fallback) {
   return { provider: raw.slice(0, slash), name: raw.slice(slash + 1) };
 }
 
+function formatModel(model) {
+  if (!model || !model.provider || !model.name) return '—';
+  return `${model.provider}/${model.name}`;
+}
+
+function sameModel(a, b) {
+  return !!a && !!b && a.provider === b.provider && a.name === b.name;
+}
+
+/** Models/tools from the header — what the next New run will lock in. */
+function headerConfig() {
+  const answerModel = parseModel($('answer-model').value, DEFAULT_MODEL);
+  const fanoutModel = parseModel($('fanout-model').value, answerModel);
+  return { answerModel, fanoutModel, useTools: $('use-tools').checked };
+}
+
 function setStatus(text, isError) {
   $('status').textContent = text || '';
   $('status').className = isError ? 'err' : '';
 }
 
-async function newRun() {
-  const answerModel = parseModel($('answer-model').value, { provider: 'google', name: 'gemini-3-flash-preview' });
-  const fanoutModel = parseModel($('fanout-model').value, answerModel);
+function renderMarkdown(md) {
+  if (!window.marked) return `<div class="plain">${esc(md)}</div>`;
+  return marked.parse(md || '');
+}
+
+/** Render markdown into el and attach copy buttons on fenced code blocks. */
+function setMarkdown(el, md, { final = false } = {}) {
+  el.classList.add('md');
+  el.classList.remove('plain');
+  el.dataset.raw = md;
+  el.innerHTML = renderMarkdown(md);
+  enhanceCodeBlocks(el);
+  if (final) el.dataset.final = '1';
+}
+
+function enhanceCodeBlocks(root) {
+  for (const pre of root.querySelectorAll('pre')) {
+    if (pre.closest('.code-block')) continue;
+    const wrap = document.createElement('div');
+    wrap.className = 'code-block';
+    pre.parentNode.insertBefore(wrap, pre);
+    wrap.appendChild(pre);
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'copy-btn';
+    btn.title = 'Copy code';
+    btn.innerHTML = `${COPY_ICON}<span>Copy</span>`;
+    btn.addEventListener('click', async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const code = pre.querySelector('code');
+      const text = code ? code.textContent : pre.textContent;
+      try {
+        await navigator.clipboard.writeText(text || '');
+        btn.classList.add('copied');
+        btn.innerHTML = `${CHECK_ICON}<span>Copied</span>`;
+        setTimeout(() => {
+          btn.classList.remove('copied');
+          btn.innerHTML = `${COPY_ICON}<span>Copy</span>`;
+        }, 1400);
+      } catch {
+        btn.innerHTML = `${COPY_ICON}<span>Failed</span>`;
+      }
+    });
+    wrap.appendChild(btn);
+  }
+}
+
+async function newRun(options = {}) {
+  const { answerModel, fanoutModel, useTools } = headerConfig();
   const defaults = await api('/api/defaults');
   state.probes = defaults.probes;
   const run = await api('/api/runs', {
     method: 'POST',
-    body: JSON.stringify({ answerModel, fanoutModel, useTools: $('use-tools').checked, probes: state.probes }),
+    body: JSON.stringify({ answerModel, fanoutModel, useTools, probes: state.probes }),
   });
   state.runId = run.id;
   state.run = run;
-  $('turns').innerHTML = '<p class="hint">New run. Ask something.</p>';
+  state.useTools = useTools;
+  if (!options.keepMessages) {
+    $('turns').innerHTML =
+      `<p class="hint">New run using <b>${esc(formatModel(run.answerModel))}</b>` +
+      (sameModel(run.answerModel, run.fanoutModel)
+        ? ''
+        : ` (fan-out <b>${esc(formatModel(run.fanoutModel))}</b>)`) +
+      `. Ask something.</p>`;
+  }
   renderStats();
-  setStatus('');
+  setStatus(options.status || '');
+  return run;
+}
+
+/** If the header no longer matches the live run, start a new one so typing a model actually takes effect. */
+async function ensureRunMatchesHeader() {
+  const wanted = headerConfig();
+  if (!state.runId || !state.run) {
+    return newRun({ status: `Using ${formatModel(wanted.answerModel)}` });
+  }
+  const answerOk = sameModel(state.run.answerModel, wanted.answerModel);
+  const fanoutOk = sameModel(state.run.fanoutModel, wanted.fanoutModel);
+  const toolsOk = state.useTools === wanted.useTools;
+  if (answerOk && fanoutOk && toolsOk) return state.run;
+  return newRun({
+    status: `Switched to ${formatModel(wanted.answerModel)}` +
+      (sameModel(wanted.answerModel, wanted.fanoutModel) ? '' : ` / fan-out ${formatModel(wanted.fanoutModel)}`) +
+      ' — previous run abandoned.',
+  });
 }
 
 function renderStats() {
@@ -152,7 +320,11 @@ function renderStats() {
   const turns = run.turns || [];
   const fanoutCost = turns.reduce((sum, t) => sum + t.fanout.reduce((s, p) => s + (p.costUsd || 0), 0), 0);
   const answerCost = turns.reduce((sum, t) => sum + (t.answerCostUsd || 0), 0);
+  const modelsLabel = sameModel(run.answerModel, run.fanoutModel)
+    ? formatModel(run.answerModel)
+    : `ans ${formatModel(run.answerModel)} · fan ${formatModel(run.fanoutModel)}`;
   $('stats').innerHTML =
+    `<span class="models" title="Models locked for this run (change header + New run, or just Ask to auto-switch)"><b>${esc(modelsLabel)}</b></span>` +
     `<span><b>${turns.length}</b> turns</span>` +
     `<span><b>${num(run.contextTokens)}</b> ctx tokens</span>` +
     `<span>answers <b>${usd(answerCost)}</b></span>` +
@@ -226,9 +398,10 @@ function redrawFanoutFoot(turnIndex, chosen) {
 
 async function ask() {
   if (state.busy) return;
-  if (!state.runId) await newRun();
   const text = $('input').value.trim();
   if (!text) return;
+  // Header models only used to apply on New run before; now Ask also rebinds if they changed.
+  await ensureRunMatchesHeader();
   state.busy = true;
   $('send').disabled = true;
   $('input').value = '';
@@ -236,14 +409,29 @@ async function ask() {
   const turnIndex = (state.run.turns || []).length;
   const el = renderTurn(turnIndex);
   el.innerHTML =
-    `<div class="bubble"><div class="role">you</div><div class="text">${esc(text)}</div></div>` +
-    `<div class="bubble"><div class="role">assistant</div><div class="text" id="answer-${turnIndex}"></div>` +
+    `<div class="bubble"><div class="role">you</div><div class="text plain">${esc(text)}</div></div>` +
+    `<div class="bubble"><div class="role">assistant</div><div class="text md" id="answer-${turnIndex}"></div>` +
     `<div class="tools" id="tools-${turnIndex}"></div><div class="meta" id="meta-${turnIndex}"></div></div>`;
   el.scrollIntoView({ behavior: 'smooth', block: 'end' });
 
   const answerEl = $(`answer-${turnIndex}`);
   const toolsEl = $(`tools-${turnIndex}`);
   const tools = [];
+  let raw = '';
+  let renderQueued = false;
+
+  const queueMarkdown = (final = false) => {
+    if (final) {
+      setMarkdown(answerEl, raw, { final: true });
+      return;
+    }
+    if (renderQueued) return;
+    renderQueued = true;
+    requestAnimationFrame(() => {
+      renderQueued = false;
+      setMarkdown(answerEl, raw);
+    });
+  };
 
   try {
     const res = await fetch(`/api/runs/${state.runId}/ask`, {
@@ -251,6 +439,10 @@ async function ask() {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ text }),
     });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || res.statusText);
+    }
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
@@ -268,14 +460,18 @@ async function ask() {
         try { event = JSON.parse(line); } catch { continue; }
 
         if (event.type === 'delta') {
-          answerEl.textContent += event.delta;
+          raw += event.delta;
+          queueMarkdown();
         } else if (event.type === 'tool-call') {
           tools.push(event.name);
           toolsEl.textContent = '⚒ ' + tools.join(', ');
         } else if (event.type === 'answer') {
-          if (!answerEl.textContent) answerEl.textContent = event.text;
+          if (!raw) raw = event.text || '';
+          queueMarkdown(true);
+        } else if (event.type === 'answer-start') {
+          setStatus(`Answering with ${formatModel(state.run.answerModel)}…`);
         } else if (event.type === 'fanout-start') {
-          setStatus(`Fanning out ${event.probes.length} probes over the same context…`);
+          setStatus(`Fanning out with ${formatModel(state.run.fanoutModel)} (${event.probes.length} probes)…`);
           const cards = document.createElement('div');
           cards.innerHTML = `<div class="fan-head">after this turn</div><div class="cards">` +
             state.probes.map((p) => probeCard(p, null, turnIndex)).join('') + `</div>`;
@@ -291,6 +487,7 @@ async function ask() {
         } else if (event.type === 'turn-complete') {
           state.run = event.run;
           const turn = state.run.turns[turnIndex];
+          if (raw) setMarkdown(answerEl, raw, { final: true });
           $(`meta-${turnIndex}`).textContent =
             `${num(turn.contextTokensBefore)} → ${num(turn.contextTokensAfter)} ctx tokens · ` +
             `${num(turn.answerLatencyMs)} ms · ${usd(turn.answerCostUsd)}`;
@@ -301,6 +498,7 @@ async function ask() {
         }
       }
     }
+    if (raw) setMarkdown(answerEl, raw, { final: true });
   } catch (error) {
     setStatus(error.message, true);
   } finally {

--- a/examples/context-explorer/server.ts
+++ b/examples/context-explorer/server.ts
@@ -168,7 +168,7 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
     json(res, 200, {
       probes: DEFAULT_PROBES,
       systemPrompt: DEFAULT_SYSTEM_PROMPT,
-      answerModel: { provider: "google", name: "gemini-3-flash-preview" },
+      answerModel: { provider: "ollama", name: "gemma4:26b" },
     });
     return;
   }
@@ -183,8 +183,8 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
     }>(req);
 
     const answerModel = modelFrom(body.answerModel, {
-      provider: "google",
-      name: "gemini-3-flash-preview",
+      provider: "ollama",
+      name: "gemma4:26b",
     });
     const id = randomUUID();
     const run: Run = {


### PR DESCRIPTION
## Summary

Follow-up to #265 after real runs against the context explorer.

- Default answer and fan-out models to `ollama/gemma4:26b` (local-first).
- Fix model selection UX: show models locked on the current run; rebind on Ask when the header no longer matches so typing `provider/model` actually takes effect.
- Stream assistant answers as markdown (`marked`) with copy buttons on fenced code blocks.
- Add `docs/guide/context-explorer.md` and wire it into the VitePress sidebar, turn-fanout guide, and example README.

## Test plan

- [ ] `dotenvx run -- pnpm tsx examples/context-explorer/server.ts` → http://127.0.0.1:7432
- [ ] New run defaults to `ollama/gemma4:26b` in header and stats bar
- [ ] Change answer field to `google/gemini-3-flash-preview`, Ask once → stats show Google; status mentions model
- [ ] Change back to `ollama/gemma4:12b`, Ask → auto new run, Ollama used (no `$` cost)
- [ ] Ask for a code sample → markdown renders; code block has working Copy
- [ ] Uncheck tools for a pure fan-out turn; probe cards still land
- [ ] Continue from a baseline; next turn uses compacted context
- [ ] Guide renders: `/guide/context-explorer` (docs dev or built site)