### PR TITLE
Exchange foundation: domain model, ADRs, prototypes, and two provider fixes

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,35 @@
+# Context Map
+
+This repo holds two bounded contexts. They share a repo and a dependency graph,
+not a vocabulary — several words mean different things on either side of the
+boundary, and the false friends are listed below.
+
+## Contexts
+
+- [Umwelten](./CONTEXT.md) — helps agents preserve, revisit, and reason about
+  their work across conversations. Everything under `packages/` today except
+  the exchange.
+- [Exchange](./packages/exchange/CONTEXT.md) — buys model tokens wholesale from
+  Suppliers and resells them retail to Applications, metering usage and
+  settling with Suppliers.
+
+## Relationships
+
+- **Exchange → Umwelten**: none. The exchange depends on no Umwelten domain
+  concept. It is a service that Umwelten happens to be deployed alongside.
+- **Umwelten → Exchange**: one-way and over HTTP. `packages/core/src/providers/`
+  gains an entry that points at a running exchange. It must not import exchange
+  code — `core` sits at the root of the dependency DAG, and importing a package
+  that depends on `core` would introduce the repo's first cycle.
+- **Shared identity**: the signed `sub` that ADR 0003 establishes as the
+  speaking user on the habitat A2A surface is the same identity the exchange
+  meters as an **End User**. One identity, asserted once, read in two places.
+
+## False friends
+
+| Word | In Umwelten | In Exchange |
+| --- | --- | --- |
+| **Provider** | An upstream vendor integration under `packages/core/src/providers/` — Google, OpenRouter, Ollama. | Not used. The party that produces tokens is a **Supplier**, and a vendor is just one kind of Supplier. |
+| **Capability** | Not a domain term. | Something an **Offer** can do (tool calling, context length). Belongs to the Offer, not the Model. |
+| **User** | Ambiguous; usually the operator. | Never used bare. A person using an Application is an **End User**. |
+| **Cost** | What a model call was billed at (`src/costs/`). | What a **Supplier** is owed — deliberately distinct from **Charge**. |

--- a/docs/adr/0006-closed-membership-token-marketplace.md
+++ b/docs/adr/0006-closed-membership-token-marketplace.md
@@ -1,0 +1,49 @@
+# 0006 — The exchange is a marketplace in its model, closed in its membership
+
+Status: Accepted
+Date: 2026-07-26
+
+We are building an exchange that buys model tokens wholesale and resells them
+retail (`packages/exchange/CONTEXT.md`). It is modelled as a two-sided
+marketplace — **Supplier**, **Offer**, **Dispatch**, **Settlement** are all
+first-class — but becoming a Supplier requires our explicit consent. We are
+Supplier #1, renting to ourselves, and no code knows that.
+
+## Considered options
+
+An open supply side, where anyone can list a GPU, is what makes Vast.ai and
+RunPod cheap: a long tail of strangers bidding each other down. We rejected it
+for three reasons, in increasing order of importance.
+
+Payouts, reputation, and fraud are each a quarter of work — bank details, tax
+withholding, dispute handling, the 1–3 week ramp-up every marketplace uses to
+statistically discover whether a new supplier is honest. A closed network
+replaces all of it with a contract.
+
+More seriously, **guarantees are unenforceable against strangers**. We cannot
+verify that a supplier ran the model it claimed rather than a cheaper
+quantization, and we cannot stop it logging prompts. The DePIN networks have
+spent years on this and settled for reputation plus redundant sampling. Since
+the exchange is a reseller, every Guarantee it passes through is one *it* is
+liable for — so we can only sell guarantees we can personally stand behind.
+
+Concretely: an application that sends users' photographs to an image model
+cannot have them land on an unnamed stranger's gaming PC.
+
+## Consequences
+
+We forgo the price pressure of an open long tail. The exchange is a broker for
+a handful of known boxes, which is a smaller business than a public
+marketplace — and the one where we can name every machine that touches a user's
+data.
+
+Because the domain is marketplace-shaped from the start, opening membership
+later is a policy change rather than a rewrite.
+
+## Related
+
+Unifies with the decision that upstream vendors and owned hardware are the same
+concept: Google is a Supplier with a published wholesale price we cannot
+negotiate; the DGX is a Supplier whose price we set. One Offer table, one
+Dispatch decision, so overflow from a saturated on-prem box to a commercial
+vendor is ordinary routing rather than a special case.

--- a/docs/adr/0007-charge-is-independent-of-cost.md
+++ b/docs/adr/0007-charge-is-independent-of-cost.md
@@ -1,0 +1,38 @@
+# 0007 — Charge is recorded independently of Cost
+
+Status: Accepted
+Date: 2026-07-26
+
+Every request through the exchange records two numbers: **Cost**, what the
+Supplier is actually owed, and **Charge**, what we debit from a Balance. They
+are deliberately unrelated. Hardware we own has a Cost of zero and a Charge we
+choose.
+
+## Why
+
+A GPU in the office is free in dollars and scarce in capacity. If Charge tracked
+Cost, requests to owned hardware would burn nothing, "how much free use does a
+new signup get" would have no expressible answer, and the box would be
+overwhelmed by traffic the ledger considered costless. Pricing owned capacity
+synthetically means one Balance, in one denomination, rations everything.
+
+It also makes price the **routing lever**: making local capacity ten times
+cheaper than a commercial vendor is how traffic prefers hardware we already
+paid for.
+
+## Consequences
+
+The Balance is not the amount of real money owed to anyone. Every report must
+be explicit about which column it reads — Client invoices come from Cost,
+End User balances from Charge. Getting this wrong bills a customer for GPU time
+we never paid for.
+
+A Balance is a long-run control and will not protect a saturated box: someone
+with credit remaining can still fire enough concurrent requests to wedge it, and
+will only stop once the money runs out, long after the box is unusable. Burst
+protection is a separate mechanism — concurrency caps and queue depth enforced
+at admission. Money answers "how much may you consume this month"; concurrency
+answers "how much may you consume right now."
+
+There is one denomination and it is dollars. Product-facing units — "five free
+hairstyles" — are a display concern, not an accounting primitive.

--- a/docs/adr/0008-exchange-never-authenticates-end-users.md
+++ b/docs/adr/0008-exchange-never-authenticates-end-users.md
@@ -1,0 +1,29 @@
+# 0008 — The exchange never authenticates End Users
+
+Status: Accepted
+Date: 2026-07-26
+
+Applications hold a signing key and mint a short-lived JWT per request whose
+`sub` is their own end-user identifier. The exchange verifies the signature via
+JWKS and reads `sub`. It has no login, no password, no session, and no account
+recovery. Balances are keyed on `(Application, sub)`.
+
+This is deliberately the same mechanism ADR 0003 established for the habitat A2A
+surface, where the SaaS mints per-request user-signed grants and the container
+holds no shared secret. One identity, asserted once, read in two places — rather
+than a second identity system inside the same repo.
+
+## Consequences
+
+The key roll-up falls out for free: aggregate by Application for a Client
+invoice, or read one `(Application, sub)` row for a per-user balance. Identifiers
+from different Applications cannot collide.
+
+**An Application can mint End Users at will.** The exchange cannot distinguish a
+real person from a fabricated `sub` — only the Application can. So a signup grant
+funded by the exchange is a standing invitation to farm it. Grants must therefore
+be drawn from the owning Client's Balance, making abuse of an Application's
+signup flow that Client's cost and that Client's problem to solve.
+
+Had we authenticated End Users directly, we would own signup, login, password
+reset, email verification, and account recovery for every Application, forever.

--- a/docs/adr/0009-capabilities-are-probed-through-the-serving-path.md
+++ b/docs/adr/0009-capabilities-are-probed-through-the-serving-path.md
@@ -1,0 +1,40 @@
+# 0009 — An Offer's Capabilities are probed through the path that serves traffic
+
+Status: Accepted
+Date: 2026-07-26
+
+Capabilities belong to the **Offer**, not the Model, and are established by
+executing the model through the exact code path that will serve production
+traffic. Declared capability tables — model cards, runtime documentation, a
+different client library's results — are not admissible.
+
+## Why, empirically
+
+We probed models present in two runtimes on one machine
+(`reports/2026-07-26-supplier-probe-capability-divergence.md`). Ollama's
+`gemma4:e2b` and llama-swap's `unsloth/gemma-4-E2B-it-GGUF:Q4_K_M` are the same
+weights and came back **inverted on two of five capabilities**: Ollama had
+structured output and no reasoning channel, llama-swap had reasoning and no
+structured output. 5/5 llama-swap Offers failed structured output; 5/5 exposed
+reasoning.
+
+The instructive part is the cause. Neither divergence belonged to the runtime or
+the weights — both traced to our own provider integrations (a missing
+`supportsStructuredOutputs` flag on one side, unsupported reasoning parts on the
+other). Capability is a property of the whole path: client integration ×
+runtime × build × quantization × weights. A layer we would not have thought to
+model turned out to dominate the result.
+
+## Consequences
+
+Every Offer carries the cost of a probe run, and a probe is a snapshot that goes
+stale when any layer in that path changes — including a change to our own client
+code, which is the layer least likely to trigger a re-probe. Nothing yet decides
+when a probe expires.
+
+Dispatch filtering on probed capabilities is only as good as the last probe. A
+capability regression introduced by a client upgrade will route confidently into
+failure until someone re-probes.
+
+The upside is that this is the only design under which the exchange can honestly
+tell a buyer what it is selling.

--- a/docs/adr/0009-capabilities-are-probed-through-the-serving-path.md
+++ b/docs/adr/0009-capabilities-are-probed-through-the-serving-path.md
@@ -25,6 +25,13 @@ other). Capability is a property of the whole path: client integration ×
 runtime × build × quantization × weights. A layer we would not have thought to
 model turned out to dominate the result.
 
+We then fixed the flag (8b8975a) and re-probed. Structured output went 0/5 → 5/5
+on llama-swap — **and all five pairs still disagreed**, now on reasoning, plus
+`gpt-oss` still failing structured output through Ollama alone. Identifying a
+cause and eliminating it did not make the runtimes agree. That is the argument
+for this ADR in its strongest form: capability sets cannot be declared even
+after the known bug is gone, because there is always another layer.
+
 ## Consequences
 
 Every Offer carries the cost of a probe run, and a probe is a snapshot that goes

--- a/docs/adr/0009-capabilities-are-probed-through-the-serving-path.md
+++ b/docs/adr/0009-capabilities-are-probed-through-the-serving-path.md
@@ -27,10 +27,20 @@ model turned out to dominate the result.
 
 We then fixed the flag (8b8975a) and re-probed. Structured output went 0/5 → 5/5
 on llama-swap — **and all five pairs still disagreed**, now on reasoning, plus
-`gpt-oss` still failing structured output through Ollama alone. Identifying a
-cause and eliminating it did not make the runtimes agree. That is the argument
-for this ADR in its strongest form: capability sets cannot be declared even
-after the known bug is gone, because there is always another layer.
+`gpt-oss` still failing structured output through Ollama alone.
+
+So we fixed a second cause: nothing could ask an Ollama model to think, and the
+probe had never asked, so it was measuring each runtime's default rather than the
+Offer's capability (54d018c). Predicted the reasoning disagreements would
+collapse. **They did not** — Ollama accepts `think: true` for gemma-4 and returns
+no thinking content, because the flag is only honored by certain models. That
+divergence is real, is not ours, and cannot be fixed from the client.
+
+Two rounds of eliminating our own bugs, and the runtimes still do not agree. This
+is the argument for the ADR in its strongest form: a capability table cannot be
+declared even after every known bug is gone, because the layers underneath keep
+disagreeing — and it took removing the self-inflicted noise to see which
+divergence was genuine.
 
 ## Consequences
 

--- a/docs/adr/0010-supplier-agent-serves-by-default.md
+++ b/docs/adr/0010-supplier-agent-serves-by-default.md
@@ -27,6 +27,14 @@ So the choice of runtime determines what an Offer can do, which means an agent
 that does not choose the runtime cannot commit to what it is selling. That is the
 argument adapt-mode loses on.
 
+Throughput measurement afterwards found a blunter version of the same point
+(`reports/2026-07-26-headroom-ollama-does-not-batch.md`): **Ollama serves
+concurrent requests one at a time.** Aggregate throughput is flat from one to four
+concurrent requests, per-stream decode is identical to three significant figures,
+and TTFT rises 9×–63× — 48 seconds to first token on gemma4:31b. llama-server
+batches, scaling 2.9×–6.8×. The capability gap costs an adapted Offer a feature;
+this costs it the ability to have two customers at once.
+
 ## Consequences
 
 Adapt-mode stays supported, because it is the only onboarding path that costs a

--- a/docs/adr/0010-supplier-agent-serves-by-default.md
+++ b/docs/adr/0010-supplier-agent-serves-by-default.md
@@ -1,0 +1,45 @@
+# 0010 — The supplier agent serves models itself; adapting is a lesser Offer tier
+
+Status: Accepted
+Date: 2026-07-26
+
+The supplier agent owns the serving layer by default — it launches the runtime,
+pins context size and quantization, and controls concurrency. It may instead
+**adapt**, reselling a runtime already running on a box it does not control, but
+Offers produced that way are a distinct and lower tier: they carry no resource
+commitments and a narrower capability set.
+
+## Why, empirically
+
+Probing 16 Offers across Ollama and llama-swap on one machine
+(`reports/2026-07-26-supplier-probe-capability-divergence.md`) found that
+**llama-server is strictly more capable than Ollama on the same weights**: it
+serves reasoning on five models where Ollama serves none, and structured output
+on a model Ollama fails.
+
+The decisive part is that this survived two rounds of fixing our own client bugs.
+A missing `supportsStructuredOutputs` flag and an unreachable Ollama `think`
+parameter both looked like the cause and both were ours. Once removed, the
+reasoning gap remained — Ollama accepts `think: true` for gemma-4 and returns no
+thinking content at all. No client change can recover it.
+
+So the choice of runtime determines what an Offer can do, which means an agent
+that does not choose the runtime cannot commit to what it is selling. That is the
+argument adapt-mode loses on.
+
+## Consequences
+
+Adapt-mode stays supported, because it is the only onboarding path that costs a
+partner nothing — a laptop with an existing LM Studio install can join the pool
+the same day. But it is priced and labelled as a lesser tier rather than treated
+as equivalent. A box running our serving layer offers more and is worth more.
+
+`generateLlamaSwapConfig()` in `providers/llamaswap-config.ts` becomes production
+code rather than a convenience script, and the agent takes on process management
+on hardware we may not own — including the failure modes that come with it
+(a partner's box rebooting, a GPU claimed by whoever is sitting at the desk).
+
+This decision constrains capability but not Guarantees: a Guarantee is asserted
+by the operator and carried by the Supplier (ADR 0006), so an adapted Offer can
+still be on-premise and not-trained-on. It is capability and resource
+commitments — context size, quantization, concurrency — that require serving.

--- a/docs/adr/0011-the-exchange-meters-at-its-own-boundary.md
+++ b/docs/adr/0011-the-exchange-meters-at-its-own-boundary.md
@@ -1,0 +1,48 @@
+# 0011 — The exchange meters at its own boundary
+
+Status: Accepted
+Date: 2026-07-26
+
+The exchange counts prompt tokens at admission and completion tokens as it
+relays them. Usage reported by an upstream is a **reconciliation signal**,
+compared against our own count, never the basis for a Charge.
+
+## Why
+
+Measured, not assumed
+(`reports/2026-07-26-can-the-exchange-bill-what-it-sold.md`). Driving the real
+runner against a mock upstream, two of three realistic situations produced a
+request that looked free while real tokens were served:
+
+- **Upstream reports no usage** — 89 characters delivered, `promptTokens: 0`,
+  `completionTokens: 0`, cost undefined. The usage object arrives with every
+  expected key present and every value `undefined`; `normalizeTokenUsage`
+  correctly refuses to coerce that into zeros it would bill on.
+- **Client hangs up mid-stream** — `promptTokens` is hardcoded to `0` even though
+  the whole prompt was processed and paid for, `completionTokens` is a
+  `chars / 4` estimate, and cost is undefined. Submit a long prompt, abort near
+  the end of generation, and the exchange pays upstream for nearly all of it and
+  records nothing. Cheap to repeat.
+
+`ModelResponse.metadata` is not at fault — it was built for benchmark reporting,
+where "burned N tokens and produced nothing" is the right thing to capture. It is
+fit for that and unfit for money.
+
+Two properties make our own metering tractable: prompt tokens are knowable
+*before* the request is sent, and completion tokens pass through us on the way to
+the buyer. Counting on our side of the wire survives an abort by construction.
+
+## Consequences
+
+We need a tokenizer at admission, and it must be the same one for every Supplier
+so Charges are comparable. It will therefore disagree with each upstream's own
+count — that disagreement is the reconciliation signal, not an error, and a
+persistent skew is information about a Supplier.
+
+Because the count is incremental and ours, a Balance can be enforced *during*
+generation and the stream cut when credit runs out, rather than discovering the
+overdraft afterwards.
+
+The abort policy is explicit and deliberate: **prompt charge is always
+collected, completion is charged on our relayed count.** Do not "fix" this later
+into refunding aborted requests — that is the exploit, not a courtesy.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,10 @@ export default [
 			"**/.vitepress/dist/**",
 			"docs/.vitepress/dist/**",
 			"packages/*/dist/**",
+			// examples/ is ignored wholesale here because ESLint prunes ignored
+			// directories, so negations inside one have no effect. The two
+			// prototype dirs are linted by a second, explicitly-scoped
+			// invocation in the root `lint` script — see package.json.
 			"examples/**",
 			"scripts/**",
 			"output/**",
@@ -20,7 +24,11 @@ export default [
 	},
 	js.configs.recommended,
 	{
-		files: ["packages/*/src/**/*.{ts,tsx}"],
+		files: [
+			"packages/*/src/**/*.{ts,tsx}",
+			"examples/supplier-agent/**/*.ts",
+			"examples/exchange-metering/**/*.ts",
+		],
 		languageOptions: {
 			parser: tsParser,
 			ecmaVersion: 2024,

--- a/examples/exchange-metering/README.md
+++ b/examples/exchange-metering/README.md
@@ -1,0 +1,27 @@
+# Exchange metering spike (E3)
+
+> Can the exchange bill what it sold?
+
+```bash
+pnpm tsx examples/exchange-metering/run.ts
+```
+
+No API keys, no GPU. `mock-upstream.ts` serves an OpenAI-compatible SSE stream in
+three modes, and `LLAMASWAP_HOST` points the **real** runner, provider, and
+usage-extraction cascade at it — nothing is stubbed on our side.
+
+| Mode | What it serves | Why it matters |
+| --- | --- | --- |
+| `usage-in-final-chunk` | tokens, then usage | the happy path |
+| `no-usage` | tokens, never usage | real providers do this |
+| `never-finishes` | tokens forever | forces the client to hang up |
+
+**Answer: no, not from `ModelResponse.metadata`.** Two of the three produce a
+request that looks free while real tokens were served. Findings and the design
+consequence are in
+[`reports/2026-07-26-can-the-exchange-bill-what-it-sold.md`](../../reports/2026-07-26-can-the-exchange-bill-what-it-sold.md);
+the decision is [ADR 0011](../../docs/adr/0011-the-exchange-meters-at-its-own-boundary.md).
+
+Note the deliberate `process.exit(0)` at the end of `run.ts`: the local providers
+install a global undici dispatcher whose keep-alive sockets hold the event loop
+open, so the process will not exit on its own once one has been touched.

--- a/examples/exchange-metering/mock-upstream.ts
+++ b/examples/exchange-metering/mock-upstream.ts
@@ -1,0 +1,142 @@
+/**
+ * A mock OpenAI-compatible upstream, for asking whether the exchange can bill
+ * what it sold.
+ *
+ * Live providers are the wrong instrument for this question. The cases that
+ * decide whether a ledger is sound are the awkward ones — a client that hangs
+ * up mid-stream, an upstream that reports no usage at all — and those are hard
+ * to provoke on demand against a real API and impossible to provoke
+ * repeatably. So we serve them deliberately.
+ *
+ * Point `LLAMASWAP_HOST` at this server and the real runner, the real provider,
+ * and the real usage-extraction cascade all run unmodified.
+ */
+
+import http from "node:http";
+
+export type UpstreamMode =
+  /** Well-behaved: streams tokens, reports usage in the final chunk. */
+  | "usage-in-final-chunk"
+  /** Streams tokens and never reports usage. Real providers do this. */
+  | "no-usage"
+  /** Streams slowly and forever, so the client has to hang up. */
+  | "never-finishes";
+
+export interface MockUpstream {
+  baseUrl: string;
+  /** Requests received, so a test can assert what actually went upstream. */
+  requests: Record<string, unknown>[];
+  close: () => Promise<void>;
+}
+
+const COMPLETION_WORDS = [
+  "The", " quick", " brown", " fox", " jumps", " over", " the", " lazy", " dog",
+  " and", " then", " keeps", " going", " for", " quite", " a", " while", " longer",
+];
+
+/** Token counts a real upstream would report for the stream below. */
+export const MOCK_PROMPT_TOKENS = 137;
+export const MOCK_COMPLETION_TOKENS = COMPLETION_WORDS.length;
+
+function sseChunk(payload: unknown): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+function deltaChunk(model: string, content: string) {
+  return {
+    id: "chatcmpl-mock",
+    object: "chat.completion.chunk",
+    created: 1,
+    model,
+    choices: [{ index: 0, delta: { content }, finish_reason: null }],
+  };
+}
+
+export async function startMockUpstream(mode: UpstreamMode): Promise<MockUpstream> {
+  const requests: Record<string, unknown>[] = [];
+
+  const server = http.createServer(async (req, res) => {
+    if (req.url?.endsWith("/models")) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ data: [{ id: "mock-model" }] }));
+      return;
+    }
+
+    const body = await new Promise<string>((resolve) => {
+      let raw = "";
+      req.on("data", (c) => (raw += c));
+      req.on("end", () => resolve(raw));
+    });
+
+    let parsed: Record<string, unknown> = {};
+    try {
+      parsed = JSON.parse(body || "{}");
+    } catch {
+      /* leave empty */
+    }
+    requests.push(parsed);
+    const model = String(parsed.model ?? "mock-model");
+
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+
+    let aborted = false;
+    req.on("close", () => {
+      aborted = true;
+    });
+
+    for (const word of COMPLETION_WORDS) {
+      if (aborted) return;
+      res.write(sseChunk(deltaChunk(model, word)));
+      await new Promise((r) => setTimeout(r, 40));
+    }
+
+    if (mode === "never-finishes") {
+      // Keep dribbling so the caller must abort. This is the billing case that
+      // matters: real tokens were produced and the stream has no final chunk.
+      while (!aborted) {
+        res.write(sseChunk(deltaChunk(model, " more")));
+        await new Promise((r) => setTimeout(r, 40));
+      }
+      return;
+    }
+
+    res.write(
+      sseChunk({
+        id: "chatcmpl-mock",
+        object: "chat.completion.chunk",
+        created: 1,
+        model,
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        ...(mode === "usage-in-final-chunk"
+          ? {
+              usage: {
+                prompt_tokens: MOCK_PROMPT_TOKENS,
+                completion_tokens: MOCK_COMPLETION_TOKENS,
+                total_tokens: MOCK_PROMPT_TOKENS + MOCK_COMPLETION_TOKENS,
+              },
+            }
+          : {}),
+      }),
+    );
+    res.write("data: [DONE]\n\n");
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections?.();
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/examples/exchange-metering/run.ts
+++ b/examples/exchange-metering/run.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * E3 — can the exchange bill what it sold?
+ *
+ * Every money decision we have recorded (ADR 0007, ADR 0008) assumes the
+ * exchange can count what a request consumed. Nothing had checked that. This
+ * spike drives the real runner against a mock upstream and reports what token
+ * counts and cost come back in three situations:
+ *
+ *   1. the upstream reports usage in its final chunk — the happy path
+ *   2. the upstream reports no usage at all — common, and real
+ *   3. the client hangs up mid-stream — the one that decides whether the
+ *      ledger can be gamed
+ *
+ * Run:  pnpm tsx examples/exchange-metering/run.ts
+ */
+
+import { Stimulus } from "@umwelten/core/stimulus/stimulus.js";
+import { Interaction } from "@umwelten/core/interaction/core/interaction.js";
+import type { ModelDetails, ModelResponse } from "@umwelten/core/cognition/types.js";
+import {
+  MOCK_COMPLETION_TOKENS,
+  MOCK_PROMPT_TOKENS,
+  startMockUpstream,
+  type UpstreamMode,
+} from "./mock-upstream.js";
+
+interface Observation {
+  scenario: string;
+  contentChars: number;
+  promptTokens: number | undefined;
+  completionTokens: number | undefined;
+  totalCost: number | undefined;
+  partial: boolean;
+  note: string;
+}
+
+const MODEL: ModelDetails = { name: "mock-model", provider: "llamaswap" };
+
+function stimulus() {
+  return new Stimulus({ role: "a helpful assistant" });
+}
+
+/** Nothing here should take long; a hang is itself a finding worth reporting. */
+const SCENARIO_TIMEOUT_MS = 20_000;
+
+async function runScenario(
+  scenario: string,
+  mode: UpstreamMode,
+  opts: { abortAfterMs?: number } = {},
+): Promise<Observation> {
+  process.stdout.write(`  ${scenario} … `);
+  const upstream = await startMockUpstream(mode);
+  // The provider reads this at construction, so it has to be set before the
+  // registry builds the provider for this call.
+  process.env.LLAMASWAP_HOST = upstream.baseUrl;
+
+  const interaction = new Interaction(MODEL, stimulus());
+  interaction.addMessage({ role: "user", content: "Say something." });
+
+  const controller = new AbortController();
+  if (opts.abortAfterMs !== undefined) {
+    setTimeout(() => controller.abort(new Error("client hung up")), opts.abortAfterMs);
+  }
+
+  let response: ModelResponse | undefined;
+  let note = "";
+  try {
+    response = await Promise.race([
+      interaction.streamText(controller.signal),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`no result after ${SCENARIO_TIMEOUT_MS}ms`)),
+          SCENARIO_TIMEOUT_MS,
+        ).unref?.(),
+      ),
+    ]);
+  } catch (error) {
+    note = `threw: ${error instanceof Error ? error.message : String(error)}`;
+  }
+
+  await upstream.close();
+  console.log(note || "ok");
+
+  const meta = response?.metadata as
+    | (ModelResponse["metadata"] & { partial?: boolean })
+    | undefined;
+
+  return {
+    scenario,
+    contentChars: response?.content.length ?? 0,
+    promptTokens: meta?.tokenUsage?.promptTokens,
+    completionTokens: meta?.tokenUsage?.completionTokens,
+    totalCost: meta?.cost?.totalCost,
+    partial: Boolean(meta?.partial),
+    note,
+  };
+}
+
+function report(observations: Observation[]) {
+  console.log("\n─── What the ledger would see ───\n");
+  const head =
+    "scenario".padEnd(26) +
+    "chars".padStart(7) +
+    "prompt".padStart(8) +
+    "compl".padStart(8) +
+    "cost".padStart(12) +
+    "  partial";
+  console.log(head);
+  console.log("-".repeat(head.length));
+  for (const o of observations) {
+    console.log(
+      o.scenario.padEnd(26) +
+        String(o.contentChars).padStart(7) +
+        String(o.promptTokens ?? "—").padStart(8) +
+        String(o.completionTokens ?? "—").padStart(8) +
+        String(o.totalCost ?? "—").padStart(12) +
+        "  " +
+        (o.partial ? "yes" : "no") +
+        (o.note ? `  ${o.note}` : ""),
+    );
+  }
+
+  console.log(
+    `\nUpstream truth for a completed stream: prompt=${MOCK_PROMPT_TOKENS}, ` +
+      `completion=${MOCK_COMPLETION_TOKENS}.\n`,
+  );
+
+  const aborted = observations.find((o) => o.partial);
+  if (aborted) {
+    console.log("Findings:");
+    console.log(
+      `  • On a client hang-up the ledger sees promptTokens=${aborted.promptTokens} ` +
+        `even though the full prompt was processed and paid for.`,
+    );
+    console.log(
+      `  • completionTokens=${aborted.completionTokens} is a chars/4 estimate, not a count.`,
+    );
+    console.log(
+      `  • cost=${aborted.totalCost ?? "undefined"} — so an aborted request is free ` +
+        `if Charge is derived from metadata.cost.`,
+    );
+    console.log(
+      "  • Attack: send a long prompt, abort near the end of generation. You pay",
+    );
+    console.log("    upstream for nearly all of it and record nothing.");
+  }
+}
+
+const observations: Observation[] = [];
+console.log("Running scenarios against a mock upstream:\n");
+observations.push(await runScenario("usage in final chunk", "usage-in-final-chunk"));
+observations.push(await runScenario("upstream reports no usage", "no-usage"));
+observations.push(
+  await runScenario("client hangs up mid-stream", "never-finishes", { abortAfterMs: 900 }),
+);
+report(observations);
+
+// The local providers install a global undici dispatcher whose keep-alive
+// sockets hold the event loop open, so the process will not exit on its own
+// once we have touched one. Everything above has already resolved.
+process.exit(0);

--- a/examples/supplier-agent/README.md
+++ b/examples/supplier-agent/README.md
@@ -1,0 +1,98 @@
+# Supplier Agent (prototype)
+
+> "I'm running a DGX Spark / M4 Max and I want to plug it into the exchange."
+
+The box-side half of the token exchange. It finds out what this machine can
+actually do, and publishes that up as **Offer** drafts. Vocabulary follows
+[`packages/exchange/CONTEXT.md`](../../packages/exchange/CONTEXT.md).
+
+**Status: prototype.** Written against real interfaces and typechecked, but not
+yet run against real hardware — there is no GPU or local runtime in CI. The
+first real run is the point of the exercise.
+
+## The four stages
+
+| Stage | Question | Where it lives |
+|---|---|---|
+| **Estimate** | What *should* fit on this hardware? | [`whichllm`](https://github.com/Andyyyy64/whichllm) — external, optional |
+| **Discover** | What runtimes are up, and what do they serve? | `discover.ts` |
+| **Probe** | What does this box *actually* do? | `probe.ts` |
+| **Publish** | Turn that into Offers the exchange can route to | `publish.ts` |
+
+Only the probe produces facts. `whichllm` estimates from VRAM math (weights +
+KV cache + activation + overhead) and ranks using other people's leaderboard
+scores — it never executes a model. Ollama reports context windows from a
+hardcoded lookup table in `providers/ollama.ts`. Neither knows what *this*
+build of *this* quantization does on *this* machine, which is precisely what an
+Offer's Capabilities are supposed to record.
+
+## Usage
+
+```bash
+dotenvx run -- pnpm tsx examples/supplier-agent/run.ts discover
+dotenvx run -- pnpm tsx examples/supplier-agent/run.ts probe --provider ollama
+dotenvx run -- pnpm tsx examples/supplier-agent/run.ts probe --model gemma --concurrency 1,4
+dotenvx run -- pnpm tsx examples/supplier-agent/run.ts publish --supplier office-spark
+```
+
+`probe` writes `output/supplier-agent/probes.json`; `publish` reads it, so the
+slow stage runs once and can be republished freely. Set `EXCHANGE_URL` and
+`EXCHANGE_TOKEN` (or pass `--to`) to actually POST.
+
+Flags: `--provider` and `--model` filter targets, `--concurrency 1,4` samples
+throughput at multiple levels, `--no-throughput` runs capabilities only.
+
+## What it probes
+
+Five capabilities, each pass/fail with recorded evidence: **chat**,
+**streaming** (more than one delta — a runtime that buffers and dumps is not
+streaming, whatever the API shape says), **tool-calling** (a real handler
+executes, or it didn't happen), **structured-output** (schema-valid JSON), and
+**reasoning** (a separate reasoning channel exists).
+
+Throughput is sampled at each requested concurrency: median TTFT and aggregate
+completion tokens/sec. Run at 1 for the number a buyer feels, and at N to find
+where the box stops scaling — that inflection is the **Headroom** the exchange
+needs, and it is measured rather than declared precisely so nobody can claim it.
+
+After a run, `probe` prints any model where two runtimes serving the same
+weights disagreed about capabilities. That disagreement is the whole argument
+for probing instead of trusting a model card.
+
+## Design constraints
+
+Three things this prototype deliberately does not do:
+
+- **It does not set prices.** The exchange sets Cost and Charge. Price is the
+  exchange's routing lever — a supplier that prices itself takes that away.
+- **It does not assert Guarantees.** `SupplierProfile.guarantees` is echoed for
+  confirmation only. The operator is liable for a Guarantee, so the operator
+  owns it.
+- **It does not cap output tokens on the throughput probe.** Per CLAUDE.md's
+  HARD RULES, the binary capability probes set `maxTokens` on their own
+  `Stimulus` — the sanctioned per-task escape hatch, since we are testing
+  whether a tool call happens, not how long a model can talk. The throughput
+  probe uses a self-terminating prompt instead, because a cap would truncate
+  mid-generation and inflate tokens/sec.
+
+## Adapt vs serve
+
+This runs in **adapt mode**: it probes whatever OpenAI-compatible runtimes are
+already up. That is right for a laptop, where the owner picked their models and
+an agent that fights for the GPU gets uninstalled.
+
+**Serve mode** — where the agent owns the serving layer so it can pin context
+size and quantization — is not built. It is mostly `generateLlamaSwapConfig()`
+from `packages/core/src/providers/llamaswap-config.ts`, which already scans GGUF
+caches and emits a llama-swap config, run before discovery.
+
+## Not built yet
+
+- **Connect.** Publishing is an HTTP POST, which covers a tunnelled box and is
+  the same shape a commercial vendor presents. Dial-out — the box holds an
+  outbound connection and never listens on a port — is what makes the "no
+  inbound surface" claim sellable, and is still an open decision.
+- **Context probe.** `ProbedOffer.contextChars` is in the type and unpopulated.
+  Finding the real usable context means a needle test at increasing sizes,
+  which is slow and evicts other models.
+- **Re-probing.** A probe is a snapshot. Nothing yet decides when it goes stale.

--- a/examples/supplier-agent/discover.ts
+++ b/examples/supplier-agent/discover.ts
@@ -1,0 +1,75 @@
+/**
+ * Stage 2 of the supplier agent: discover.
+ *
+ * Stage 1 (estimate) is `whichllm` or equivalent — it reads your hardware and
+ * predicts which models *should* fit, from VRAM math plus published
+ * leaderboards. It never executes a model, so it cannot tell you what this box
+ * actually does. That is stage 3's job (`probe.ts`).
+ *
+ * This stage sits between them and answers a narrower question: which local
+ * runtimes are up right now, and what do they say they are serving? We ask the
+ * runtimes rather than the disk, because in adapt-mode the box's existing
+ * Ollama/LM Studio config is the thing we are reselling.
+ *
+ * `findLlamaSwapModels()` in core scans GGUF caches on disk instead — use that
+ * when the agent owns the serving layer and needs to generate a llama-swap
+ * config, rather than adapting to what is already running.
+ */
+
+import { createOllamaProvider } from "@umwelten/core/providers/ollama.js";
+import { createLMStudioProvider } from "@umwelten/core/providers/lmstudio.js";
+import { createLlamaBarnProvider } from "@umwelten/core/providers/llamabarn.js";
+import { createLlamaSwapProvider } from "@umwelten/core/providers/llamaswap.js";
+import type { BaseProvider } from "@umwelten/core/providers/base.js";
+import type { DiscoveredRuntime } from "./types.js";
+
+const RUNTIMES: { provider: string; create: () => BaseProvider }[] = [
+  { provider: "ollama", create: () => createOllamaProvider() },
+  { provider: "lmstudio", create: () => createLMStudioProvider() },
+  { provider: "llamabarn", create: () => createLlamaBarnProvider() },
+  { provider: "llamaswap", create: () => createLlamaSwapProvider() },
+];
+
+/**
+ * Knock on every local runtime we know about. Unreachable runtimes are
+ * reported rather than thrown — a box running only Ollama is the normal case,
+ * not an error.
+ */
+export async function discoverRuntimes(
+  only?: string[],
+): Promise<DiscoveredRuntime[]> {
+  const wanted = only?.length
+    ? RUNTIMES.filter((r) => only.includes(r.provider))
+    : RUNTIMES;
+
+  return Promise.all(
+    wanted.map(async ({ provider, create }): Promise<DiscoveredRuntime> => {
+      try {
+        const models = await create().listModels();
+        return {
+          provider,
+          reachable: true,
+          models: models.map((m) => m.name).sort(),
+        };
+      } catch (error) {
+        return {
+          provider,
+          reachable: false,
+          models: [],
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  );
+}
+
+/** Flatten discovery into the (provider, model) pairs a probe run iterates. */
+export function toProbeTargets(
+  runtimes: DiscoveredRuntime[],
+  modelFilter?: string,
+): { provider: string; model: string }[] {
+  return runtimes
+    .filter((r) => r.reachable)
+    .flatMap((r) => r.models.map((model) => ({ provider: r.provider, model })))
+    .filter((t) => !modelFilter || t.model.includes(modelFilter));
+}

--- a/examples/supplier-agent/pairing.ts
+++ b/examples/supplier-agent/pairing.ts
@@ -1,0 +1,94 @@
+/**
+ * Pairing model names across runtimes.
+ *
+ * The Q11 experiment — does adapt-mode give capabilities stable enough to
+ * resell? — only works if we can tell that Ollama's `gemma4:26b` and
+ * llama-swap's `ggml-org/gemma-4-26B-A4B-it-GGUF:Q4_K_M` are the same weights.
+ * Nothing in either name makes that obvious, so we normalize both to a
+ * (family, size) identity and compare that.
+ *
+ * This is a heuristic and it will be wrong sometimes. That is why the probe
+ * prints the full matrix rather than only the rows it managed to pair — a
+ * missed pair should cost you a squint, not the finding.
+ */
+
+/** Publishers that prefix a repo name without being part of the model family. */
+const VENDOR_PREFIXES = new Set([
+  "nvidia",
+  "meta",
+  "google",
+  "microsoft",
+  "mistralai",
+  "ggml",
+  "ggmlorg",
+  "ggml-org",
+  "unsloth",
+  "bartowski",
+  "thebloke",
+  "lmstudio",
+]);
+
+/** Quantization, format, and tuning tokens that say nothing about identity. */
+const NOISE = /^(gguf|it|instruct|chat|latest|q\d\w*|k|m|s|mxfp\d+|bf16|f16|fp\d+)$/;
+
+/** A size token: 4b, 26b, 1.5b, e2b (Gemma's efficiency variants). */
+const SIZE = /^e?\d+(\.\d+)?b$/;
+
+export interface ModelIdentity {
+  /** Best guess at the model family, e.g. "gemma4", "gptoss", "nemotron3nano". */
+  family: string;
+  /** Parameter size token if one is present, e.g. "26b". */
+  size?: string;
+  /** family plus size when both are known — the strict pairing key. */
+  key: string;
+}
+
+/**
+ * Reduce a runtime-specific model name to a comparable identity.
+ *
+ * Deliberately does not split on `.` — `qwen3.6` is a family name, not a
+ * family and a minor version.
+ */
+export function modelIdentity(model: string): ModelIdentity {
+  const withoutOrg = model.toLowerCase().split("/").pop() ?? model.toLowerCase();
+  const tokens = withoutOrg.split(/[-_:\s]+/).filter(Boolean);
+
+  const familyParts: string[] = [];
+  let size: string | undefined;
+
+  for (const [i, token] of tokens.entries()) {
+    if (SIZE.test(token)) {
+      // The first size token wins. Gemma MoE names carry a second one (the
+      // active-parameter count, e.g. "a4b"), which we ignore.
+      size ??= token;
+      continue;
+    }
+    if (NOISE.test(token)) continue;
+    // A vendor prefix only counts as noise in leading position.
+    if (i === 0 && VENDOR_PREFIXES.has(token) && tokens.length > 1) continue;
+    // Once we have a size, later alphabetic tokens are quant/tuning detail.
+    if (size) continue;
+    familyParts.push(token);
+  }
+
+  const family = familyParts.join("");
+  return { family, size, key: size ? `${family}:${size}` : family };
+}
+
+/**
+ * Group probed models so the same weights sit adjacent regardless of runtime.
+ * Groups on family, not on the strict key, because a runtime that reports
+ * `gpt-oss:latest` has no size to pair on and would otherwise be orphaned.
+ */
+export function groupByFamily<T extends { model: string }>(
+  items: T[],
+): Map<string, (T & { identity: ModelIdentity })[]> {
+  const groups = new Map<string, (T & { identity: ModelIdentity })[]>();
+  for (const item of items) {
+    const identity = modelIdentity(item.model);
+    const existing = groups.get(identity.family) ?? [];
+    existing.push({ ...item, identity });
+    groups.set(identity.family, existing);
+  }
+  return groups;
+}

--- a/examples/supplier-agent/probe.ts
+++ b/examples/supplier-agent/probe.ts
@@ -311,6 +311,7 @@ async function measureThroughput(
   concurrency: number,
 ): Promise<ThroughputSample> {
   const ttfts: number[] = [];
+  const decodeRates: number[] = [];
   let completionTokens = 0;
   let errors = 0;
 
@@ -347,8 +348,17 @@ async function measureThroughput(
         errors += 1;
         return;
       }
-      if (firstTokenAt) ttfts.push(firstTokenAt - started);
-      completionTokens += outcome.value.metadata.tokenUsage.completionTokens ?? 0;
+
+      const tokens = outcome.value.metadata.tokenUsage.completionTokens ?? 0;
+      completionTokens += tokens;
+
+      if (firstTokenAt) {
+        ttfts.push(firstTokenAt - started);
+        // Decode rate excludes the wait before generation began, so it isolates
+        // how fast the box emits tokens from how long it made you queue.
+        const decodeSeconds = (Date.now() - firstTokenAt) / 1000;
+        if (decodeSeconds > 0 && tokens > 0) decodeRates.push(tokens / decodeSeconds);
+      }
     }),
   );
 
@@ -357,6 +367,7 @@ async function measureThroughput(
     concurrency,
     ttftMs: Math.round(median(ttfts)),
     tokensPerSecond: wallSeconds > 0 ? Number((completionTokens / wallSeconds).toFixed(1)) : 0,
+    decodeTokensPerSecond: Number(median(decodeRates).toFixed(1)),
     completionTokens,
     errors,
   };

--- a/examples/supplier-agent/probe.ts
+++ b/examples/supplier-agent/probe.ts
@@ -242,14 +242,26 @@ async function probeStructuredOutput(model: ModelDetails): Promise<CapabilityPro
   };
 }
 
-/** Does the runtime surface reasoning tokens separately from the answer? */
+/**
+ * Can this Offer surface reasoning tokens separately from the answer?
+ *
+ * Note the question: *can it*, not *does it by default*. Those differ, and the
+ * difference was worth a bug — llama-server splits thinking into its own
+ * channel unprompted, while Ollama only does so when asked via `think: true`.
+ * Probing without asking measured a default, not a capability, and reported
+ * that four models had no reasoning when they had it all along.
+ *
+ * So we ask, by setting `reasoningEffort`. Providers that ignore it are
+ * unaffected; providers that honor it now answer the question we meant.
+ */
 async function probeReasoning(model: ModelDetails): Promise<CapabilityProbe> {
   const start = Date.now();
+  const asking: ModelDetails = { ...model, reasoningEffort: "medium" };
   const outcome = await runWithWatchdog({
     timeoutMs: CAPABILITY_TIMEOUT_MS,
     task: async (signal) => {
       const interaction = new Interaction(
-        model,
+        asking,
         new Stimulus({ role: "a careful reasoner", maxTokens: 1024 }),
       );
       interaction.addMessage({

--- a/examples/supplier-agent/probe.ts
+++ b/examples/supplier-agent/probe.ts
@@ -1,0 +1,392 @@
+/**
+ * Stage 3 of the supplier agent: probe.
+ *
+ * This is the only stage that produces facts. `whichllm` estimates from VRAM
+ * math and other people's leaderboard scores; Ollama reports context windows
+ * from a hardcoded lookup table (`providers/ollama.ts`). Neither knows what
+ * *this* box does with *this* build of *this* quantization — which is exactly
+ * the thing an Offer's Capabilities are supposed to record.
+ *
+ * So we run the model and watch what happens.
+ *
+ * On token limits: the binary capability probes set `maxTokens` on their own
+ * Stimulus, which is the sanctioned per-task escape hatch in CLAUDE.md's HARD
+ * RULES — we are testing whether a tool call happens, not how long a model can
+ * talk. The throughput probe deliberately sets **no** cap; it uses a
+ * self-terminating prompt so the measurement window is bounded by the task
+ * rather than by a truncation that would distort tokens/sec.
+ */
+
+import { z } from "zod";
+import { tool } from "ai";
+import { Stimulus } from "@umwelten/core/stimulus/stimulus.js";
+import { Interaction } from "@umwelten/core/interaction/core/interaction.js";
+import type { ModelDetails } from "@umwelten/core/cognition/types.js";
+import { runWithWatchdog } from "../local-providers/harness/index.js";
+import type { CapabilityProbe, ProbedOffer, ThroughputSample } from "./types.js";
+
+/** Binary probes are short by construction; 3 minutes is already generous. */
+const CAPABILITY_TIMEOUT_MS = 3 * 60_000;
+/** Throughput generates ~200 lines, and a cold model load can be slow. */
+const THROUGHPUT_TIMEOUT_MS = 10 * 60_000;
+
+function elapsedSince(start: number): number {
+  return Date.now() - start;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+// ── Individual capability probes ─────────────────────────────────────────────
+
+/** Does it answer at all, and does it follow a trivial instruction? */
+async function probeChat(model: ModelDetails): Promise<CapabilityProbe> {
+  const start = Date.now();
+  const outcome = await runWithWatchdog({
+    timeoutMs: CAPABILITY_TIMEOUT_MS,
+    task: async (signal) => {
+      const interaction = new Interaction(
+        model,
+        new Stimulus({
+          role: "a terse assistant",
+          instructions: ["Answer with the single requested word and nothing else."],
+          maxTokens: 32,
+        }),
+      );
+      interaction.addMessage({
+        role: "user",
+        content: 'Reply with exactly the word: READY',
+      });
+      return interaction.generateText(signal);
+    },
+  });
+
+  if (!outcome.ok) {
+    return {
+      name: "chat",
+      supported: false,
+      evidence: outcome.reason === "timeout" ? "timed out" : String(outcome.error),
+      elapsedMs: elapsedSince(start),
+    };
+  }
+
+  const said = outcome.value.content.trim().toUpperCase().includes("READY");
+  return {
+    name: "chat",
+    supported: said,
+    evidence: said
+      ? "responded with the requested token"
+      : `unexpected response: ${outcome.value.content.slice(0, 120)}`,
+    elapsedMs: elapsedSince(start),
+  };
+}
+
+/** Do deltas actually arrive incrementally, or does it buffer and dump? */
+async function probeStreaming(model: ModelDetails): Promise<CapabilityProbe> {
+  const start = Date.now();
+  let deltas = 0;
+
+  const outcome = await runWithWatchdog({
+    timeoutMs: CAPABILITY_TIMEOUT_MS,
+    task: async (signal) => {
+      const interaction = new Interaction(
+        model,
+        new Stimulus({ role: "a helpful assistant", maxTokens: 128 }),
+      );
+      interaction.addMessage({
+        role: "user",
+        content: "Count from one to twenty, in words, separated by commas.",
+      });
+      return interaction.streamText(signal, {
+        onTextDelta: () => {
+          deltas += 1;
+        },
+      });
+    },
+  });
+
+  if (!outcome.ok) {
+    return {
+      name: "streaming",
+      supported: false,
+      evidence: outcome.reason === "timeout" ? "timed out" : String(outcome.error),
+      elapsedMs: elapsedSince(start),
+    };
+  }
+
+  // A single delta means the runtime buffered the whole completion and handed
+  // it over at the end. That is not streaming, whatever the API shape claims.
+  return {
+    name: "streaming",
+    supported: deltas > 1,
+    evidence: `${deltas} text delta(s) observed`,
+    elapsedMs: elapsedSince(start),
+  };
+}
+
+/**
+ * Will it call a tool? This is the capability most likely to differ between
+ * two runtimes serving the same weights — chat template and grammar support
+ * decide it, not the model.
+ */
+async function probeToolCalling(model: ModelDetails): Promise<CapabilityProbe> {
+  const start = Date.now();
+  let called = false;
+
+  const outcome = await runWithWatchdog({
+    timeoutMs: CAPABILITY_TIMEOUT_MS,
+    task: async (signal) => {
+      const interaction = new Interaction(
+        model,
+        new Stimulus({
+          role: "an assistant that uses tools",
+          instructions: ["Use the provided tool to answer. Do not compute it yourself."],
+          maxToolSteps: 3,
+          maxTokens: 256,
+          tools: {
+            multiply: tool({
+              description: "Multiply two integers. The only way to get a correct product.",
+              inputSchema: z.object({ a: z.number(), b: z.number() }),
+              execute: async ({ a, b }: { a: number; b: number }) => {
+                called = true;
+                return { product: a * b };
+              },
+            }),
+          },
+        }),
+      );
+      interaction.addMessage({
+        role: "user",
+        content: "What is 3737 multiplied by 1319? Use the tool.",
+      });
+      return interaction.streamText(signal);
+    },
+  });
+
+  if (!outcome.ok) {
+    return {
+      name: "tool-calling",
+      supported: false,
+      evidence: outcome.reason === "timeout" ? "timed out" : String(outcome.error),
+      elapsedMs: elapsedSince(start),
+    };
+  }
+
+  return {
+    name: "tool-calling",
+    supported: called,
+    evidence: called
+      ? "tool handler executed"
+      : `no tool call; model answered directly: ${outcome.value.content.slice(0, 120)}`,
+    elapsedMs: elapsedSince(start),
+  };
+}
+
+/** Can it produce output that validates against a schema? */
+async function probeStructuredOutput(model: ModelDetails): Promise<CapabilityProbe> {
+  const start = Date.now();
+  const schema = z.object({
+    city: z.string(),
+    countryCode: z.string().length(2),
+    populationMillions: z.number(),
+  });
+
+  const outcome = await runWithWatchdog({
+    timeoutMs: CAPABILITY_TIMEOUT_MS,
+    task: async (signal) => {
+      const interaction = new Interaction(
+        model,
+        new Stimulus({ role: "a precise data extractor", maxTokens: 256 }),
+      );
+      interaction.addMessage({
+        role: "user",
+        content: "Give me structured data about the capital city of Japan.",
+      });
+      return interaction.generateObject(schema, signal);
+    },
+  });
+
+  if (!outcome.ok) {
+    return {
+      name: "structured-output",
+      supported: false,
+      evidence: outcome.reason === "timeout" ? "timed out" : String(outcome.error),
+      elapsedMs: elapsedSince(start),
+    };
+  }
+
+  const parsed = schema.safeParse(JSON.parse(outcome.value.content || "{}"));
+  return {
+    name: "structured-output",
+    supported: parsed.success,
+    evidence: parsed.success
+      ? "returned schema-valid JSON"
+      : `schema mismatch: ${outcome.value.content.slice(0, 120)}`,
+    elapsedMs: elapsedSince(start),
+  };
+}
+
+/** Does the runtime surface reasoning tokens separately from the answer? */
+async function probeReasoning(model: ModelDetails): Promise<CapabilityProbe> {
+  const start = Date.now();
+  const outcome = await runWithWatchdog({
+    timeoutMs: CAPABILITY_TIMEOUT_MS,
+    task: async (signal) => {
+      const interaction = new Interaction(
+        model,
+        new Stimulus({ role: "a careful reasoner", maxTokens: 1024 }),
+      );
+      interaction.addMessage({
+        role: "user",
+        content:
+          "A bat and a ball cost $1.10 together. The bat costs $1.00 more than the ball. How much does the ball cost?",
+      });
+      return interaction.generateText(signal);
+    },
+  });
+
+  if (!outcome.ok) {
+    return {
+      name: "reasoning",
+      supported: false,
+      evidence: outcome.reason === "timeout" ? "timed out" : String(outcome.error),
+      elapsedMs: elapsedSince(start),
+    };
+  }
+
+  const hasReasoning = Boolean(outcome.value.reasoning?.trim());
+  return {
+    name: "reasoning",
+    supported: hasReasoning,
+    // Deliberately not scored for correctness — that is an eval's job, not a
+    // capability probe's. We only record whether the channel exists.
+    evidence: hasReasoning
+      ? `${outcome.value.reasoning!.length} chars of reasoning surfaced`
+      : "no separate reasoning channel",
+    elapsedMs: elapsedSince(start),
+  };
+}
+
+// ── Throughput ───────────────────────────────────────────────────────────────
+
+/**
+ * Measure TTFT and tokens/sec at a given concurrency. Run at 1 to get the
+ * single-stream number a buyer experiences, and at N to find where the box
+ * stops scaling — that inflection is the Headroom the exchange needs.
+ *
+ * No `maxTokens` here on purpose: the prompt self-terminates, so the window is
+ * defined by the task. Capping would truncate mid-generation and inflate the
+ * rate.
+ */
+async function measureThroughput(
+  model: ModelDetails,
+  concurrency: number,
+): Promise<ThroughputSample> {
+  const ttfts: number[] = [];
+  let completionTokens = 0;
+  let errors = 0;
+
+  const wallStart = Date.now();
+
+  await Promise.all(
+    Array.from({ length: concurrency }, async () => {
+      const started = Date.now();
+      let firstTokenAt: number | undefined;
+
+      const outcome = await runWithWatchdog({
+        timeoutMs: THROUGHPUT_TIMEOUT_MS,
+        task: async (signal) => {
+          const interaction = new Interaction(
+            model,
+            new Stimulus({
+              role: "a counting machine",
+              instructions: ["Output only the numbers. No commentary."],
+            }),
+          );
+          interaction.addMessage({
+            role: "user",
+            content: "Count from 1 to 200. One number per line.",
+          });
+          return interaction.streamText(signal, {
+            onTextDelta: () => {
+              firstTokenAt ??= Date.now();
+            },
+          });
+        },
+      });
+
+      if (!outcome.ok) {
+        errors += 1;
+        return;
+      }
+      if (firstTokenAt) ttfts.push(firstTokenAt - started);
+      completionTokens += outcome.value.metadata.tokenUsage.completionTokens ?? 0;
+    }),
+  );
+
+  const wallSeconds = (Date.now() - wallStart) / 1000;
+  return {
+    concurrency,
+    ttftMs: Math.round(median(ttfts)),
+    tokensPerSecond: wallSeconds > 0 ? Number((completionTokens / wallSeconds).toFixed(1)) : 0,
+    completionTokens,
+    errors,
+  };
+}
+
+// ── Orchestration ────────────────────────────────────────────────────────────
+
+export interface ProbeOptions {
+  /** Concurrency levels to sample. Default [1]. Try [1, 4] to find the knee. */
+  concurrency?: number[];
+  /** Skip the throughput stage — capabilities only, much faster. */
+  skipThroughput?: boolean;
+}
+
+/**
+ * Probe one (runtime, model) pair. Capability probes run in sequence rather
+ * than in parallel: on a single-GPU box, concurrent probes would contend and
+ * the throughput numbers would measure our own interference.
+ */
+export async function probeOffer(
+  provider: string,
+  model: string,
+  opts: ProbeOptions = {},
+): Promise<ProbedOffer> {
+  const details: ModelDetails = { name: model, provider };
+  const probedAt = new Date().toISOString();
+
+  const chat = await probeChat(details);
+  if (!chat.supported) {
+    // Nothing downstream is meaningful if it cannot hold a conversation.
+    return {
+      provider,
+      model,
+      probedAt,
+      capabilities: [chat],
+      throughput: [],
+      failed: `chat probe failed: ${chat.evidence}`,
+    };
+  }
+
+  const capabilities: CapabilityProbe[] = [chat];
+  capabilities.push(await probeStreaming(details));
+  capabilities.push(await probeToolCalling(details));
+  capabilities.push(await probeStructuredOutput(details));
+  capabilities.push(await probeReasoning(details));
+
+  const throughput: ThroughputSample[] = [];
+  if (!opts.skipThroughput) {
+    for (const level of opts.concurrency ?? [1]) {
+      throughput.push(await measureThroughput(details, level));
+    }
+  }
+
+  return { provider, model, probedAt, capabilities, throughput };
+}

--- a/examples/supplier-agent/probe.ts
+++ b/examples/supplier-agent/probe.ts
@@ -221,13 +221,23 @@ async function probeStructuredOutput(model: ModelDetails): Promise<CapabilityPro
     };
   }
 
-  const parsed = schema.safeParse(JSON.parse(outcome.value.content || "{}"));
+  // The runner stringifies generateObject's result into `content`, so this
+  // parses in practice — but a probe that crashes the whole run because one
+  // model returned something odd is worse than a probe that records a failure.
+  let parsedOk = false;
+  let detail = "";
+  try {
+    const parsed = schema.safeParse(JSON.parse(outcome.value.content || "{}"));
+    parsedOk = parsed.success;
+    if (!parsed.success) detail = `schema mismatch: ${outcome.value.content.slice(0, 120)}`;
+  } catch {
+    detail = `unparseable output: ${outcome.value.content.slice(0, 120)}`;
+  }
+
   return {
     name: "structured-output",
-    supported: parsed.success,
-    evidence: parsed.success
-      ? "returned schema-valid JSON"
-      : `schema mismatch: ${outcome.value.content.slice(0, 120)}`,
+    supported: parsedOk,
+    evidence: parsedOk ? "returned schema-valid JSON" : detail,
     elapsedMs: elapsedSince(start),
   };
 }

--- a/examples/supplier-agent/publish.ts
+++ b/examples/supplier-agent/publish.ts
@@ -1,0 +1,88 @@
+/**
+ * Stage 4 of the supplier agent: publish.
+ *
+ * Turn probe results into OfferDrafts and hand them to the exchange. Two
+ * things this stage deliberately does not do:
+ *
+ *   - It does not set a price. The exchange sets Cost and Charge; letting a
+ *     supplier price itself would hand away the exchange's routing lever.
+ *   - It does not assert Guarantees. `SupplierProfile.guarantees` is echoed
+ *     for confirmation only. The operator is liable for a Guarantee, so the
+ *     operator is where it is recorded.
+ *
+ * Transport is plain HTTP POST, which is the bootstrap case from Q10: it
+ * covers a box reachable over a tunnel, and it is the same shape a commercial
+ * vendor presents. Dial-out — where the box holds an outbound connection and
+ * never listens on a port — replaces this later, and is what makes the
+ * "no inbound surface" claim sellable.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { CapabilityName, OfferDraft, ProbedOffer, SupplierProfile } from "./types.js";
+
+/** Drop failed probes; keep only capabilities that actually passed. */
+export function toOfferDrafts(
+  probed: ProbedOffer[],
+  profile: SupplierProfile,
+): OfferDraft[] {
+  return probed
+    .filter((p) => !p.failed)
+    .map((p) => ({
+      supplierId: profile.supplierId,
+      provider: p.provider,
+      model: p.model,
+      probedAt: p.probedAt,
+      capabilities: p.capabilities
+        .filter((c) => c.supported)
+        .map((c) => c.name as CapabilityName),
+      throughput: p.throughput,
+      contextChars: p.contextChars,
+    }));
+}
+
+export interface PublishResult {
+  written: string;
+  posted: boolean;
+  status?: number;
+  error?: string;
+}
+
+/**
+ * Write the drafts to disk, and POST them if an exchange URL is configured.
+ * The file is written either way — a publish run that cannot reach the
+ * exchange should still leave you something to inspect.
+ */
+export async function publishOffers(
+  drafts: OfferDraft[],
+  profile: SupplierProfile,
+  opts: { outDir: string; exchangeUrl?: string; token?: string } = {
+    outDir: "output/supplier-agent",
+  },
+): Promise<PublishResult> {
+  const body = { profile, offers: drafts };
+
+  fs.mkdirSync(opts.outDir, { recursive: true });
+  const written = path.join(opts.outDir, `offers-${profile.supplierId}.json`);
+  fs.writeFileSync(written, JSON.stringify(body, null, 2));
+
+  if (!opts.exchangeUrl) return { written, posted: false };
+
+  try {
+    const res = await fetch(new URL("/suppliers/offers", opts.exchangeUrl), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(opts.token ? { authorization: `Bearer ${opts.token}` } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+    return { written, posted: res.ok, status: res.status };
+  } catch (error) {
+    return {
+      written,
+      posted: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/examples/supplier-agent/report.ts
+++ b/examples/supplier-agent/report.ts
@@ -1,0 +1,106 @@
+/**
+ * The Q11 output.
+ *
+ * Prints every probed offer grouped so the same weights sit together across
+ * runtimes, then calls out rows that disagree. The full matrix prints
+ * unconditionally — the name-pairing heuristic in `pairing.ts` will sometimes
+ * miss, and a missed pair should cost a squint, not the finding.
+ */
+
+import { groupByFamily } from "./pairing.js";
+import type { CapabilityName, ProbedOffer } from "./types.js";
+
+const CAPS: CapabilityName[] = [
+  "chat",
+  "streaming",
+  "tool-calling",
+  "structured-output",
+  "reasoning",
+];
+
+const RUNTIME_W = 11;
+const MODEL_W = 46;
+const CAP_W = 7;
+
+export interface MatrixReport {
+  lines: string[];
+  /** Pairing keys where two runtimes serving the same weights disagreed. */
+  disagreements: string[];
+}
+
+export function buildCapabilityMatrix(results: ProbedOffer[]): MatrixReport {
+  const groups = groupByFamily(results);
+  const lines: string[] = [];
+  const disagreements: string[] = [];
+
+  const header =
+    "runtime".padEnd(RUNTIME_W) +
+    "model".padEnd(MODEL_W) +
+    CAPS.map((c) => c.slice(0, CAP_W - 1).padEnd(CAP_W)).join("");
+  lines.push(header);
+
+  for (const [, rows] of [...groups.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    lines.push("-".repeat(header.length));
+
+    // Sort by pairing key first so the same weights land on adjacent lines —
+    // the comparison is the whole point of the table.
+    const ordered = [...rows].sort(
+      (a, b) =>
+        a.identity.key.localeCompare(b.identity.key) || a.provider.localeCompare(b.provider),
+    );
+
+    for (const row of ordered) {
+      const cells = CAPS.map((cap) => {
+        const probe = row.capabilities.find((c) => c.name === cap);
+        if (row.failed) return "?".padEnd(CAP_W);
+        return (probe?.supported ? "yes" : "·").padEnd(CAP_W);
+      }).join("");
+      lines.push(
+        row.provider.padEnd(RUNTIME_W) + row.model.slice(0, MODEL_W - 1).padEnd(MODEL_W) + cells,
+      );
+    }
+
+    // Strict comparison: same family *and* same size means same weights. Rows
+    // with no size token (Ollama's ":latest") can't be compared this way, and
+    // are left for the reader.
+    const byKey = new Map<string, typeof rows>();
+    for (const row of rows) {
+      if (row.failed) continue;
+      byKey.set(row.identity.key, [...(byKey.get(row.identity.key) ?? []), row]);
+    }
+    for (const [key, sameWeights] of byKey) {
+      if (sameWeights.length < 2) continue;
+      const signatures = new Set(
+        sameWeights.map((r) =>
+          r.capabilities
+            .filter((c) => c.supported)
+            .map((c) => c.name)
+            .sort()
+            .join(","),
+        ),
+      );
+      if (signatures.size > 1) disagreements.push(key);
+    }
+  }
+
+  return { lines, disagreements };
+}
+
+export function printCapabilityMatrix(results: ProbedOffer[]): void {
+  const { lines, disagreements } = buildCapabilityMatrix(results);
+
+  console.log("\nCapabilities by family (· = unsupported, ? = probe failed):\n");
+  for (const line of lines) console.log(`  ${line}`);
+
+  if (disagreements.length) {
+    console.log(
+      `\n⚠  Same weights, different capabilities: ${disagreements.join(", ")}\n` +
+        `   Adapt-mode cannot guarantee what it resells — serve-mode is required.`,
+    );
+  } else {
+    console.log(
+      `\n✓  No capability disagreements among paired models.\n` +
+        `   Adapt-mode is safe for the models probed here.`,
+    );
+  }
+}

--- a/examples/supplier-agent/run.ts
+++ b/examples/supplier-agent/run.ts
@@ -24,6 +24,7 @@ import "@umwelten/core/env/load.js";
 import { discoverRuntimes, toProbeTargets } from "./discover.js";
 import { probeOffer } from "./probe.js";
 import { publishOffers, toOfferDrafts } from "./publish.js";
+import { printCapabilityMatrix } from "./report.js";
 import type { ProbedOffer, SupplierProfile } from "./types.js";
 
 const OUT_DIR = "output/supplier-agent";
@@ -102,29 +103,7 @@ async function cmdProbe() {
   fs.writeFileSync(PROBES_FILE, JSON.stringify(results, null, 2));
   console.log(`\nWrote ${PROBES_FILE}`);
 
-  // The whole point of probing rather than declaring: show where two runtimes
-  // serving the same weights disagree.
-  const byModel = new Map<string, ProbedOffer[]>();
-  for (const r of results) {
-    const key = r.model.split(":")[0];
-    byModel.set(key, [...(byModel.get(key) ?? []), r]);
-  }
-  const disagreements = [...byModel.entries()].filter(([, rs]) => {
-    if (rs.length < 2) return false;
-    const sets = rs.map((r) =>
-      r.capabilities.filter((c) => c.supported).map((c) => c.name).sort().join(","),
-    );
-    return new Set(sets).size > 1;
-  });
-  if (disagreements.length) {
-    console.log("\nSame weights, different capabilities — this is why we probe:");
-    for (const [model, rs] of disagreements) {
-      for (const r of rs) {
-        const caps = r.capabilities.filter((c) => c.supported).map((c) => c.name);
-        console.log(`  ${model}  ${r.provider.padEnd(11)} ${caps.join(", ") || "none"}`);
-      }
-    }
-  }
+  printCapabilityMatrix(results);
 }
 
 async function cmdPublish() {

--- a/examples/supplier-agent/run.ts
+++ b/examples/supplier-agent/run.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Supplier agent — prototype CLI.
+ *
+ * "I'm running a DGX Spark / M4 Max and I want to plug it into the exchange."
+ *
+ *   discover   which local runtimes are up, and what they serve
+ *   probe      run each model and record what it can actually do
+ *   publish    turn probe results into OfferDrafts and send them up
+ *
+ * Usage:
+ *   dotenvx run -- pnpm tsx examples/supplier-agent/run.ts discover
+ *   dotenvx run -- pnpm tsx examples/supplier-agent/run.ts probe --provider ollama
+ *   dotenvx run -- pnpm tsx examples/supplier-agent/run.ts probe --model gemma --concurrency 1,4
+ *   dotenvx run -- pnpm tsx examples/supplier-agent/run.ts publish --supplier office-spark
+ *
+ * `probe` writes its results to output/supplier-agent/probes.json; `publish`
+ * reads that file, so the slow stage runs once and can be republished freely.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import "@umwelten/core/env/load.js";
+import { discoverRuntimes, toProbeTargets } from "./discover.js";
+import { probeOffer } from "./probe.js";
+import { publishOffers, toOfferDrafts } from "./publish.js";
+import type { ProbedOffer, SupplierProfile } from "./types.js";
+
+const OUT_DIR = "output/supplier-agent";
+const PROBES_FILE = path.join(OUT_DIR, "probes.json");
+
+const argv = process.argv.slice(2);
+const command = argv.find((a) => !a.startsWith("--")) ?? "discover";
+
+function flag(name: string): string | undefined {
+  const withEquals = argv.find((a) => a.startsWith(`--${name}=`));
+  if (withEquals) return withEquals.split("=").slice(1).join("=");
+  const idx = argv.indexOf(`--${name}`);
+  return idx >= 0 ? argv[idx + 1] : undefined;
+}
+
+function has(name: string): boolean {
+  return argv.includes(`--${name}`);
+}
+
+async function cmdDiscover() {
+  const providerFilter = flag("provider")?.split(",");
+  const runtimes = await discoverRuntimes(providerFilter);
+
+  for (const r of runtimes) {
+    if (!r.reachable) {
+      console.log(`✗ ${r.provider.padEnd(11)} unreachable — ${r.error}`);
+      continue;
+    }
+    console.log(`✓ ${r.provider.padEnd(11)} ${r.models.length} model(s)`);
+    for (const m of r.models) console.log(`    ${m}`);
+  }
+
+  const reachable = runtimes.filter((r) => r.reachable).length;
+  console.log(`\n${reachable}/${runtimes.length} runtimes reachable.`);
+  return runtimes;
+}
+
+async function cmdProbe() {
+  const runtimes = await discoverRuntimes(flag("provider")?.split(","));
+  const targets = toProbeTargets(runtimes, flag("model"));
+
+  if (targets.length === 0) {
+    console.error("No probe targets. Is a local runtime running?");
+    process.exitCode = 1;
+    return;
+  }
+
+  const concurrency = (flag("concurrency") ?? "1")
+    .split(",")
+    .map((n) => Number(n.trim()))
+    .filter((n) => Number.isFinite(n) && n > 0);
+
+  console.log(`Probing ${targets.length} offer(s) at concurrency ${concurrency.join(", ")}\n`);
+
+  const results: ProbedOffer[] = [];
+  for (const [i, t] of targets.entries()) {
+    process.stdout.write(`[${i + 1}/${targets.length}] ${t.provider}:${t.model} … `);
+    const probed = await probeOffer(t.provider, t.model, {
+      concurrency,
+      skipThroughput: has("no-throughput"),
+    });
+    results.push(probed);
+
+    if (probed.failed) {
+      console.log(`FAILED — ${probed.failed}`);
+      continue;
+    }
+    const supported = probed.capabilities.filter((c) => c.supported).map((c) => c.name);
+    const single = probed.throughput.find((s) => s.concurrency === 1);
+    console.log(
+      `${supported.join(", ") || "none"}${single ? ` · ${single.tokensPerSecond} tok/s · ${single.ttftMs}ms TTFT` : ""}`,
+    );
+  }
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.writeFileSync(PROBES_FILE, JSON.stringify(results, null, 2));
+  console.log(`\nWrote ${PROBES_FILE}`);
+
+  // The whole point of probing rather than declaring: show where two runtimes
+  // serving the same weights disagree.
+  const byModel = new Map<string, ProbedOffer[]>();
+  for (const r of results) {
+    const key = r.model.split(":")[0];
+    byModel.set(key, [...(byModel.get(key) ?? []), r]);
+  }
+  const disagreements = [...byModel.entries()].filter(([, rs]) => {
+    if (rs.length < 2) return false;
+    const sets = rs.map((r) =>
+      r.capabilities.filter((c) => c.supported).map((c) => c.name).sort().join(","),
+    );
+    return new Set(sets).size > 1;
+  });
+  if (disagreements.length) {
+    console.log("\nSame weights, different capabilities — this is why we probe:");
+    for (const [model, rs] of disagreements) {
+      for (const r of rs) {
+        const caps = r.capabilities.filter((c) => c.supported).map((c) => c.name);
+        console.log(`  ${model}  ${r.provider.padEnd(11)} ${caps.join(", ") || "none"}`);
+      }
+    }
+  }
+}
+
+async function cmdPublish() {
+  if (!fs.existsSync(PROBES_FILE)) {
+    console.error(`No ${PROBES_FILE}. Run \`probe\` first.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const probed: ProbedOffer[] = JSON.parse(fs.readFileSync(PROBES_FILE, "utf8"));
+  const profile: SupplierProfile = {
+    supplierId: flag("supplier") ?? "local-dev",
+    description: flag("description"),
+    guarantees: (flag("guarantees") ?? "on-premise,no-training").split(","),
+  };
+
+  const drafts = toOfferDrafts(probed, profile);
+  const result = await publishOffers(drafts, profile, {
+    outDir: OUT_DIR,
+    exchangeUrl: flag("to") ?? process.env.EXCHANGE_URL,
+    token: process.env.EXCHANGE_TOKEN,
+  });
+
+  console.log(`${drafts.length} offer draft(s) → ${result.written}`);
+  if (result.posted) console.log(`Posted to exchange (${result.status}).`);
+  else if (result.error) console.log(`Not posted — ${result.error}`);
+  else console.log("Not posted — no --to / EXCHANGE_URL set.");
+}
+
+const commands: Record<string, () => Promise<unknown>> = {
+  discover: cmdDiscover,
+  probe: cmdProbe,
+  publish: cmdPublish,
+};
+
+const run = commands[command];
+if (!run) {
+  console.error(`Unknown command: ${command}. Try discover | probe | publish.`);
+  process.exit(1);
+}
+await run();

--- a/examples/supplier-agent/run.ts
+++ b/examples/supplier-agent/run.ts
@@ -77,16 +77,40 @@ async function cmdProbe() {
     .map((n) => Number(n.trim()))
     .filter((n) => Number.isFinite(n) && n > 0);
 
-  console.log(`Probing ${targets.length} offer(s) at concurrency ${concurrency.join(", ")}\n`);
+  // A full matrix takes tens of minutes and the operator will Ctrl-C it. Load
+  // whatever a previous run got through, and write after every model so an
+  // interrupt costs one probe rather than the whole run.
+  const results: ProbedOffer[] = loadExistingProbes();
+  const done = new Set(results.map((r) => `${r.provider}:${r.model}`));
 
-  const results: ProbedOffer[] = [];
-  for (const [i, t] of targets.entries()) {
-    process.stdout.write(`[${i + 1}/${targets.length}] ${t.provider}:${t.model} … `);
+  const pending = has("fresh")
+    ? targets
+    : targets.filter((t) => !done.has(`${t.provider}:${t.model}`));
+
+  if (results.length && !has("fresh")) {
+    console.log(`Resuming: ${results.length} already probed, ${pending.length} to go.`);
+    console.log(`(Pass --fresh to re-probe everything.)\n`);
+  }
+  if (pending.length === 0) {
+    console.log("Nothing left to probe.");
+    printCapabilityMatrix(results);
+    return;
+  }
+
+  console.log(`Probing ${pending.length} offer(s) at concurrency ${concurrency.join(", ")}\n`);
+
+  for (const [i, t] of pending.entries()) {
+    process.stdout.write(`[${i + 1}/${pending.length}] ${t.provider}:${t.model} … `);
     const probed = await probeOffer(t.provider, t.model, {
       concurrency,
       skipThroughput: has("no-throughput"),
     });
-    results.push(probed);
+
+    // Replace any stale entry for this pair rather than accumulating duplicates.
+    const idx = results.findIndex((r) => r.provider === t.provider && r.model === t.model);
+    if (idx >= 0) results[idx] = probed;
+    else results.push(probed);
+    saveProbes(results);
 
     if (probed.failed) {
       console.log(`FAILED — ${probed.failed}`);
@@ -99,11 +123,24 @@ async function cmdProbe() {
     );
   }
 
+  console.log(`\nWrote ${PROBES_FILE}`);
+  printCapabilityMatrix(results);
+}
+
+function loadExistingProbes(): ProbedOffer[] {
+  if (!fs.existsSync(PROBES_FILE)) return [];
+  try {
+    const parsed = JSON.parse(fs.readFileSync(PROBES_FILE, "utf8"));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    console.warn(`Could not read ${PROBES_FILE}; starting fresh.`);
+    return [];
+  }
+}
+
+function saveProbes(results: ProbedOffer[]): void {
   fs.mkdirSync(OUT_DIR, { recursive: true });
   fs.writeFileSync(PROBES_FILE, JSON.stringify(results, null, 2));
-  console.log(`\nWrote ${PROBES_FILE}`);
-
-  printCapabilityMatrix(results);
 }
 
 async function cmdPublish() {

--- a/examples/supplier-agent/run.ts
+++ b/examples/supplier-agent/run.ts
@@ -81,14 +81,30 @@ async function cmdProbe() {
   // whatever a previous run got through, and write after every model so an
   // interrupt costs one probe rather than the whole run.
   const results: ProbedOffer[] = loadExistingProbes();
-  const done = new Set(results.map((r) => `${r.provider}:${r.model}`));
+  const skipThroughput = has("no-throughput");
+
+  // "Already probed" has to account for what was asked for. A previous
+  // --no-throughput run leaves entries with no throughput data, and treating
+  // those as complete would make a subsequent --concurrency run silently skip
+  // every offer and measure nothing.
+  const isComplete = (r: ProbedOffer): boolean => {
+    if (r.failed) return true;
+    if (skipThroughput) return true;
+    return concurrency.every((level) =>
+      r.throughput.some((s) => s.concurrency === level),
+    );
+  };
+
+  const complete = new Set(
+    results.filter(isComplete).map((r) => `${r.provider}:${r.model}`),
+  );
 
   const pending = has("fresh")
     ? targets
-    : targets.filter((t) => !done.has(`${t.provider}:${t.model}`));
+    : targets.filter((t) => !complete.has(`${t.provider}:${t.model}`));
 
   if (results.length && !has("fresh")) {
-    console.log(`Resuming: ${results.length} already probed, ${pending.length} to go.`);
+    console.log(`Resuming: ${complete.size} complete, ${pending.length} to go.`);
     console.log(`(Pass --fresh to re-probe everything.)\n`);
   }
   if (pending.length === 0) {
@@ -103,7 +119,7 @@ async function cmdProbe() {
     process.stdout.write(`[${i + 1}/${pending.length}] ${t.provider}:${t.model} … `);
     const probed = await probeOffer(t.provider, t.model, {
       concurrency,
-      skipThroughput: has("no-throughput"),
+      skipThroughput,
     });
 
     // Replace any stale entry for this pair rather than accumulating duplicates.
@@ -117,10 +133,15 @@ async function cmdProbe() {
       continue;
     }
     const supported = probed.capabilities.filter((c) => c.supported).map((c) => c.name);
-    const single = probed.throughput.find((s) => s.concurrency === 1);
-    console.log(
-      `${supported.join(", ") || "none"}${single ? ` · ${single.tokensPerSecond} tok/s · ${single.ttftMs}ms TTFT` : ""}`,
-    );
+    console.log(supported.join(", ") || "none");
+    for (const s of probed.throughput) {
+      console.log(
+        `      c=${s.concurrency}  ${String(s.tokensPerSecond).padStart(6)} tok/s agg` +
+          `  ${String(s.decodeTokensPerSecond).padStart(6)} tok/s decode` +
+          `  ${String(s.ttftMs).padStart(6)}ms TTFT` +
+          (s.errors ? `  ${s.errors} error(s)` : ""),
+      );
+    }
   }
 
   console.log(`\nWrote ${PROBES_FILE}`);

--- a/examples/supplier-agent/types.ts
+++ b/examples/supplier-agent/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Supplier-agent domain types.
+ *
+ * Vocabulary follows `packages/exchange/CONTEXT.md` — Supplier, Offer,
+ * Capability, Headroom. Two rules from that glossary are load-bearing here:
+ *
+ *   1. Capabilities belong to the **Offer**, not the Model. The same model
+ *      served by Ollama and by llama.cpp is two Offers with two capability
+ *      sets, because quantization, chat template, and build flags differ.
+ *   2. Headroom is **measured, never declared.** Nothing in this file lets a
+ *      supplier assert its own throughput.
+ *
+ * Note what is absent: prices. The agent publishes evidence about what a box
+ * can do; the exchange decides what to pay for it and what to charge. Price is
+ * the exchange's routing lever, so a supplier must not be able to set it.
+ */
+
+/** A capability an Offer either has or doesn't. Established by probing. */
+export type CapabilityName =
+  | "chat"
+  | "streaming"
+  | "tool-calling"
+  | "structured-output"
+  | "reasoning";
+
+export interface CapabilityProbe {
+  name: CapabilityName;
+  supported: boolean;
+  /** Why we concluded that. Kept so a human can audit a surprising result. */
+  evidence: string;
+  elapsedMs: number;
+}
+
+/** One throughput measurement at a given level of concurrency. */
+export interface ThroughputSample {
+  /** Requests in flight during the sample. */
+  concurrency: number;
+  /** Median time to first token across the sample, in milliseconds. */
+  ttftMs: number;
+  /** Completion tokens per second, aggregated across all in-flight requests. */
+  tokensPerSecond: number;
+  completionTokens: number;
+  errors: number;
+}
+
+/** A local runtime that answered when we knocked. */
+export interface DiscoveredRuntime {
+  /** Umwelten provider id: ollama, lmstudio, llamabarn, llamaswap. */
+  provider: string;
+  reachable: boolean;
+  models: string[];
+  /** Populated when `reachable` is false. */
+  error?: string;
+}
+
+/** What a probe run learned about one (runtime, model) pair. */
+export interface ProbedOffer {
+  provider: string;
+  model: string;
+  probedAt: string;
+  capabilities: CapabilityProbe[];
+  throughput: ThroughputSample[];
+  /**
+   * Largest prompt we successfully round-tripped, in characters. Absent unless
+   * `--context` was passed, because the probe is slow and evicts other models.
+   */
+  contextChars?: number;
+  /** Set when the model could not be probed at all. */
+  failed?: string;
+}
+
+/**
+ * What the agent sends up to the exchange. A draft because the exchange
+ * completes it with Cost and Charge before it becomes a live Offer.
+ */
+export interface OfferDraft {
+  supplierId: string;
+  provider: string;
+  model: string;
+  probedAt: string;
+  /** Capability names that probed true. Anything absent is unsupported. */
+  capabilities: CapabilityName[];
+  /** Best observed single-stream and concurrent throughput. */
+  throughput: ThroughputSample[];
+  contextChars?: number;
+}
+
+/** Identity and claims about the box itself, not about any one model. */
+export interface SupplierProfile {
+  supplierId: string;
+  /** Free-text, e.g. "DGX Spark, office" or "M4 Max 128GB". */
+  description?: string;
+  /**
+   * Guarantee names this supplier is offered under, e.g. ["on-premise",
+   * "no-training"]. Recorded here only so the agent can echo them back for
+   * confirmation — the exchange is the source of truth, because the operator
+   * is the one liable for a Guarantee, not the box.
+   */
+  guarantees: string[];
+}

--- a/examples/supplier-agent/types.ts
+++ b/examples/supplier-agent/types.ts
@@ -31,14 +31,31 @@ export interface CapabilityProbe {
   elapsedMs: number;
 }
 
-/** One throughput measurement at a given level of concurrency. */
+/**
+ * One throughput measurement at a given level of concurrency.
+ *
+ * Three numbers, because they move in different directions and only together
+ * locate the point where a box stops scaling:
+ *
+ *   - `tokensPerSecond` is the box's aggregate output. It should *rise* with
+ *     concurrency until saturation, then flatten.
+ *   - `decodeTokensPerSecond` is what one stream feels once it starts. It
+ *     *falls* as concurrency climbs.
+ *   - `ttftMs` is how long a request waits to start. It *rises* under queueing.
+ *
+ * A flat aggregate with rising TTFT means queueing; a falling aggregate means
+ * genuine contention. Those want different Dispatch responses, which is why
+ * one throughput number is not enough.
+ */
 export interface ThroughputSample {
   /** Requests in flight during the sample. */
   concurrency: number;
   /** Median time to first token across the sample, in milliseconds. */
   ttftMs: number;
-  /** Completion tokens per second, aggregated across all in-flight requests. */
+  /** Aggregate completion tokens/sec across all in-flight requests, end to end. */
   tokensPerSecond: number;
+  /** Median per-stream decode rate, excluding time spent waiting to start. */
+  decodeTokensPerSecond: number;
   completionTokens: number;
   errors: number;
 }

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  // Typecheck gate for examples.
+  //
+  // `pnpm typecheck` only globbed packages/*/tsconfig.json, so nothing under
+  // examples/ was ever checked by CI — the prototypes here typechecked only
+  // because someone ran tsc against them by hand.
+  //
+  // `include` is an explicit opt-in list rather than "**/*.ts" on purpose: the
+  // older examples carry 36 pre-existing errors across roughly a dozen files,
+  // and switching them all on at once would break CI for everyone. Add a
+  // directory here once it is clean. Fixing the rest is separate work.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    // examples/ is not a workspace package, so @types/node does not resolve
+    // from here by the usual walk-up.
+    "typeRoots": ["../node_modules/@types", "../packages/core/node_modules/@types"],
+    "types": ["node"]
+  },
+  "include": ["supplier-agent/**/*.ts", "exchange-metering/**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:run": "vitest run --reporter=verbose",
     "test:integration": "vitest run --config vitest.integration.config.ts --reporter=verbose",
     "test:all": "pnpm test:run && pnpm test:integration",
-    "lint": "eslint \"packages/*/src/**/*.{ts,tsx}\"",
+    "lint": "eslint \"packages/*/src/**/*.{ts,tsx}\" && eslint --no-ignore \"examples/supplier-agent/**/*.ts\" \"examples/exchange-metering/**/*.ts\"",
     "cli": "NODE_OPTIONS='--no-deprecation' tsx packages/cli/src/entry.ts",
     "smoke:cascade": "tsx scripts/smoke-test-cascade.ts",
     "docs:sync-assets": "rm -rf docs/public/dialogue && mkdir -p docs/public/dialogue && cp examples/dialogue-web/index.html docs/public/dialogue/index.html",
@@ -17,7 +17,7 @@
     "docs:build": "pnpm run docs:sync-assets && vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "knip": "knip",
-    "typecheck": "for d in packages/*/tsconfig.json; do tsc --noEmit -p \"$d\" || exit 1; done"
+    "typecheck": "for d in packages/*/tsconfig.json examples/tsconfig.json; do tsc --noEmit -p \"$d\" || exit 1; done"
   },
   "keywords": [
     "llm",

--- a/packages/core/src/cognition/provider-options.test.ts
+++ b/packages/core/src/cognition/provider-options.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { buildReasoningProviderOptions } from "./provider-options.js";
+
+describe("buildReasoningProviderOptions — ollama", () => {
+  it("sends nothing when no effort is set, leaving existing behavior intact", () => {
+    // Load-bearing: benchmark data collected before the ollama branch existed
+    // must stay comparable, which requires the default request to be unchanged.
+    expect(buildReasoningProviderOptions("ollama", undefined)).toBeUndefined();
+  });
+
+  it("enables thinking for any non-none effort", () => {
+    // Ollama's think is a boolean, so all three levels collapse to true.
+    for (const effort of ["low", "medium", "high"] as const) {
+      expect(buildReasoningProviderOptions("ollama", effort)).toEqual({
+        ollama: { think: true },
+      });
+    }
+  });
+
+  it("disables thinking explicitly on 'none', for models that think by default", () => {
+    expect(buildReasoningProviderOptions("ollama", "none")).toEqual({
+      ollama: { think: false },
+    });
+  });
+
+  it("does not disturb other providers", () => {
+    expect(buildReasoningProviderOptions("openrouter", "high")).toEqual({
+      openrouter: { reasoning: { effort: "high" } },
+    });
+    expect(buildReasoningProviderOptions("llamaswap", "high")).toBeUndefined();
+  });
+});

--- a/packages/core/src/cognition/provider-options.ts
+++ b/packages/core/src/cognition/provider-options.ts
@@ -36,6 +36,18 @@ export function buildReasoningProviderOptions(
     };
   }
 
+  // Ollama exposes thinking as a boolean, not a budget — `think: true` splits
+  // the model's reasoning into a separate channel from its answer. Handled
+  // before the guard below so that an explicit "none" can turn thinking *off*
+  // for models that think by default (gpt-oss), the same way Google's branch
+  // does. Leaving `effort` unset sends nothing, so existing behavior — and the
+  // comparability of benchmark data collected without it — is unchanged.
+  if (provider === "ollama") {
+    if (effort === "none") return { ollama: { think: false } };
+    if (!effort) return undefined;
+    return { ollama: { think: true } };
+  }
+
   if (!effort || effort === "none") return undefined;
 
   if (provider === "openrouter") {

--- a/packages/core/src/providers/llamabarn.ts
+++ b/packages/core/src/providers/llamabarn.ts
@@ -93,6 +93,9 @@ export class LlamaBarnProvider extends BaseProvider {
       name: "llamabarn",
       baseURL: baseUrl,
       includeUsage: true,
+      // LlamaBarn serves llama.cpp, which implements json_schema response
+      // formats. See the note in llamaswap.ts for what omitting this costs.
+      supportsStructuredOutputs: true,
       ...(this.extraBody ? { fetch: fetchWithExtraBody(this.extraBody) } : {}),
     });
     return llamabarn(route.name);

--- a/packages/core/src/providers/llamaswap.ts
+++ b/packages/core/src/providers/llamaswap.ts
@@ -93,6 +93,13 @@ export class LlamaSwapProvider extends BaseProvider {
       name: "llamaswap",
       baseURL: baseUrl,
       includeUsage: true,
+      // llama-server implements `response_format: { type: 'json_schema' }`
+      // (and GBNF grammars underneath it). Without this flag the AI SDK never
+      // sends the schema, warns "responseFormat is not supported", and falls
+      // back to asking for JSON in the prompt — so generateObject returns
+      // well-formed JSON in a shape the model invented, which then fails
+      // validation. See reports/2026-07-26-supplier-probe-capability-divergence.md.
+      supportsStructuredOutputs: true,
       ...(this.extraBody ? { fetch: fetchWithExtraBody(this.extraBody) } : {}),
     });
     return llamaswap(route.name);

--- a/packages/core/src/providers/lmstudio.ts
+++ b/packages/core/src/providers/lmstudio.ts
@@ -54,6 +54,9 @@ export class LMStudioProvider extends BaseProvider {
       name: "lmstudio",
       baseURL: baseUrl,
       includeUsage: true,
+      // LM Studio's server supports json_schema response formats. See the note
+      // in llamaswap.ts for what omitting this costs.
+      supportsStructuredOutputs: true,
     });
     return lmstudio(route.name);
   }

--- a/packages/exchange/CONTEXT.md
+++ b/packages/exchange/CONTEXT.md
@@ -1,0 +1,77 @@
+# Exchange
+
+The exchange buys model tokens wholesale from Suppliers and resells them retail
+to Applications. Its job is to decide which Supplier serves a given request,
+meter what that request consumed, debit the buyer, and credit the Supplier.
+
+## Language
+
+### Supply
+
+**Supplier**:
+A party that produces model tokens for the exchange — hardware the operator
+owns, a partner's on-premise machine, or a commercial vendor.
+_Avoid_: Provider (means an Umwelten vendor integration), factory, host, node, worker
+
+**Guarantee**:
+A promise about the conditions under which a Supplier produces tokens, such as
+staying on-premise or not being trained on. Asserted by the operator, who is
+liable for it, rather than self-declared by the Supplier.
+_Avoid_: Capability, policy, SLA, tag
+
+**Headroom**:
+A Supplier's capacity to accept more work right now. Always measured, never
+declared.
+_Avoid_: capacity, availability, load, SLA
+
+**Model**:
+The named thing a buyer asks for, independent of who produces its tokens.
+_Avoid_: deployment, variant, endpoint
+
+**Offer**:
+A commitment by one Supplier to serve one Model, carrying its own prices and its
+own Capabilities.
+_Avoid_: listing, endpoint, deployment, model entry
+
+**Capability**:
+Something an Offer can do, such as tool calling or a context length. Belongs to
+the Offer rather than the Model, because the same Model differs by where it runs.
+_Avoid_: feature, Guarantee, capacity
+
+**Dispatch**:
+The choice of which Offer serves one request.
+_Avoid_: routing, scheduling, load balancing, proxying
+
+### Demand
+
+**Client**:
+An organization invoiced for the usage of the Applications it owns.
+_Avoid_: customer, tenant, account, org
+
+**Application**:
+A product built on the exchange. Holds a signing key, a set of permitted Offers,
+and a Balance.
+_Avoid_: project, app, service, tenant
+
+**End User**:
+A person using an Application, known to the exchange only through a claim that
+Application signs.
+_Avoid_: user, customer, account, subject
+
+### Money
+
+**Balance**:
+Money available to be spent, held by a Client, an Application, or an End User.
+_Avoid_: credits, wallet, quota
+
+**Cost**:
+What a Supplier is owed for a request. Zero when the operator owns the hardware.
+_Avoid_: Charge, price, spend
+
+**Charge**:
+What the exchange debits from a Balance for a request. Set independently of Cost.
+_Avoid_: Cost, price, rate
+
+**Settlement**:
+Periodic reconciliation of what each Supplier is owed for the requests it served.
+_Avoid_: payout, invoice, billing

--- a/packages/exchange/CONTEXT.md
+++ b/packages/exchange/CONTEXT.md
@@ -39,6 +39,12 @@ the Offer rather than the Model, because it is a property of the whole serving
 path — client integration, runtime, build, quantization, and weights together.
 _Avoid_: feature, Guarantee, capacity
 
+**Serving Mode**:
+Whether a Supplier controls the runtime behind an Offer (*managed*) or resells a
+runtime it does not control (*adapted*). Only managed Offers can commit to
+capability and resource properties.
+_Avoid_: mode, tier, hosting, deployment
+
 **Dispatch**:
 The choice of which Offer serves one request.
 _Avoid_: routing, scheduling, load balancing, proxying

--- a/packages/exchange/CONTEXT.md
+++ b/packages/exchange/CONTEXT.md
@@ -35,7 +35,8 @@ _Avoid_: listing, endpoint, deployment, model entry
 
 **Capability**:
 Something an Offer can do, such as tool calling or a context length. Belongs to
-the Offer rather than the Model, because the same Model differs by where it runs.
+the Offer rather than the Model, because it is a property of the whole serving
+path — client integration, runtime, build, quantization, and weights together.
 _Avoid_: feature, Guarantee, capacity
 
 **Dispatch**:

--- a/reports/2026-07-26-can-the-exchange-bill-what-it-sold.md
+++ b/reports/2026-07-26-can-the-exchange-bill-what-it-sold.md
@@ -1,0 +1,116 @@
+# E3 — Can the exchange bill what it sold?
+
+Experiment report, 2026-07-26. Run via `pnpm tsx examples/exchange-metering/run.ts`
+against a mock OpenAI-compatible upstream (no API keys, no GPU).
+
+> **Headline:** no, not from `ModelResponse.metadata` as it stands. Two of three
+> realistic situations hand the ledger a request that appears free while real
+> tokens were served. The fix is structural: **the exchange must meter at its own
+> boundary and treat upstream usage as reconciliation, not as the source of
+> truth.**
+
+## Why this needed asking
+
+ADR 0007 (Charge independent of Cost) and ADR 0008 (balances keyed on
+`(Application, sub)`) both assume the exchange can count what a request
+consumed. Nothing had checked that assumption, and there was already a hint it
+was shaky: `runner.ts` carries a fallback that warns *"Usage statistics
+(prompt/completion tokens) not available… Cost cannot be calculated"* and
+`usage-extractor.ts` normalizes across six different field spellings. Code that
+defensive exists because the underlying data is unreliable.
+
+Live providers are the wrong instrument here. The cases that decide whether a
+ledger is sound are the awkward ones — a client hanging up mid-stream, an
+upstream reporting no usage — and those are hard to provoke on demand and
+impossible to provoke repeatably. So `mock-upstream.ts` serves them deliberately,
+and `LLAMASWAP_HOST` points the **real** runner, provider, and usage-extraction
+cascade at it, unmodified.
+
+## Results
+
+Upstream truth for a completed stream: `prompt=137, completion=18`.
+
+| Scenario | chars served | promptTokens | completionTokens | cost | partial |
+| --- | --- | --- | --- | --- | --- |
+| usage in final chunk | 89 | **137** ✓ | **18** ✓ | 0 | no |
+| upstream reports no usage | 89 | **0** | **0** | *undefined* | no |
+| client hangs up mid-stream | 114 | **0** | 29 (estimate) | *undefined* | **yes** |
+
+### The happy path works
+
+When the upstream reports usage, extraction is exact. Note that `cost` is `0`
+rather than absent — llama-swap has no pricing table, because it is local
+hardware. That is ADR 0007's argument made concrete: if Charge tracked Cost, every
+request to your own GPU would be free and the box would be defenceless.
+
+### An upstream that reports no usage yields a free request
+
+89 characters of real output, `promptTokens: 0`, `completionTokens: 0`, cost
+undefined. The interesting detail is *why*: the usage object arrives with all the
+expected keys — `inputTokens`, `outputTokens`, `totalTokens` — and every value
+`undefined`. `normalizeTokenUsage` correctly refuses shaped-but-undefined data
+rather than coercing it to zeros it would then bill on. The refusal is right; the
+consequence is that nothing is billable.
+
+### An aborted stream is worse than unbillable — it is exploitable
+
+`runner.ts:483-506` salvages what it can on abort, and is honest about doing so:
+it sets `partial: true`, `partialApproxTokens`, `partialContentChars`. But for
+money:
+
+- **`promptTokens: 0`** — hardcoded, even though the full prompt was submitted and
+  processed. For a long-context request this silently zeroes the *majority* of
+  the cost.
+- **`completionTokens`** is `(content.length + reasoning.length) / 4`. Here that
+  happened to land near the truth; it will drift badly on code, non-English text,
+  or heavy reasoning output.
+- **`cost: undefined`** — so if Charge derives from `metadata.cost`, an aborted
+  request costs the buyer nothing.
+
+That is a griefing vector, and a cheap one: submit a long prompt, abort near the
+end of generation. The exchange pays the upstream for full prompt processing plus
+nearly all the decode, and records nothing. Repeat.
+
+None of this is a bug in `runner.ts`. That metadata was built for benchmark
+reporting, where "model burned N tokens thinking and produced nothing" is exactly
+the right thing to record. It is fit for its purpose and unfit for ours.
+
+## What follows for the design
+
+**Meter at the exchange boundary, not from the response object.** The exchange is
+a proxy — it sees the request before forwarding and every delta as it streams —
+so it can count both sides itself and does not need an upstream final chunk that
+may never arrive.
+
+Two properties make this tractable:
+
+1. **Prompt tokens are knowable before the request is made.** Count them locally
+   at admission with a tokenizer. This is the single highest-value fix: it makes
+   prompt charge always collectable, including on abort, and it is the larger
+   half of the bill for long-context work.
+2. **Completion tokens are countable as they pass through.** The exchange is
+   already relaying each chunk. Counting is incremental and survives an abort by
+   construction, because the count lives on our side of the wire.
+
+Upstream usage then becomes a **reconciliation signal** — compare it against our
+own count, and a persistent discrepancy is a data point about that Supplier
+rather than a billing failure.
+
+This also settles what to do when Charge and reality disagree mid-stream. Because
+the exchange counts as it relays, it can enforce a Balance *during* generation and
+cut the stream when credit runs out, rather than discovering the overdraft
+afterwards.
+
+## Follow-ups
+
+1. **ADR 0011** records the metering boundary decision.
+2. **Choose a tokenizer for admission-time counting.** It only has to be
+   accurate enough to charge on, and it must be the same one for every Supplier
+   so Charge is comparable — which means it will disagree with each upstream's
+   own count. That disagreement is the reconciliation signal, not an error.
+3. **Decide the abort policy explicitly.** Prompt charge always collected;
+   completion charged on our relayed count. Worth stating so nobody later
+   "fixes" it into refunding aborted requests.
+4. **Streaming tool calls are unmeasured.** A multi-step tool loop issues several
+   upstream requests for one buyer request. Whether usage aggregates across steps
+   or reports only the last was not tested here.

--- a/reports/2026-07-26-headroom-ollama-does-not-batch.md
+++ b/reports/2026-07-26-headroom-ollama-does-not-batch.md
@@ -1,0 +1,125 @@
+# Headroom: Ollama serializes, llama-server batches
+
+Experiment report, 2026-07-26. M4 Max, via
+`pnpm tsx examples/supplier-agent/run.ts probe --concurrency 1,4`.
+
+> **Headline:** Ollama serves concurrent requests **one at a time**. Every model
+> shows flat aggregate throughput, an unchanged per-stream decode rate, and TTFT
+> rising 40–60× under four concurrent requests. llama-server batches, scaling
+> aggregate throughput 2.9×–6.8×. For an exchange these are not two speeds of the
+> same thing; one of them cannot serve concurrent traffic at all.
+
+## Method
+
+Three numbers per concurrency level, because they move in different directions
+and only together locate saturation:
+
+- **aggregate tok/s** — total completion tokens ÷ wall clock. Rises with
+  concurrency until the box saturates.
+- **decode tok/s** — per-stream rate excluding time spent waiting to start.
+  Falls as concurrency climbs, if the box is genuinely contended.
+- **TTFT** — median time to first token. Rises when requests queue.
+
+The discriminator: *flat aggregate with rising TTFT means queueing; falling
+aggregate means real contention.* Those want different Dispatch responses.
+
+## Results
+
+### Ollama — capacity 1
+
+| Model | agg c=1 | agg c=4 | decode c=1 | decode c=4 | TTFT c=1 | TTFT c=4 |
+| --- | --- | --- | --- | --- | --- | --- |
+| gemma4:e2b | 139.7 | 145.3 | 148.5 | 148.6 | 292ms | 7,374ms |
+| gemma4:12b | 48.0 | 48.6 | 49.5 | 49.1 | 457ms | 21,422ms |
+| gemma4:26b | 96.3 | 99.7 | 101.5 | 101.4 | 367ms | 10,654ms |
+| gemma4:31b | 21.4 | 20.8 | 21.9 | 21.3 | 772ms | 48,767ms |
+| gemma4:e4b | 89.0 | 91.7 | 93.1 | 93.0 | 344ms | 11,537ms |
+| gpt-oss:latest | 85.4 | 89.3 | 109.9 | 114.9 | 1,263ms | 9,919ms |
+| nemotron-3-nano:4b | 90.2 | 86.4 | 92.4 | 92.4 | 235ms | 2,115ms |
+| nemotron-cascade-2:30b | 88.9 | 91.5 | 92.4 | 92.3 | 301ms | 11,491ms |
+| qwen3.6:27b | 22.8 | 22.1 | 23.3 | 22.3 | 642ms | 46,117ms |
+
+Aggregate throughput is unchanged (ratios 0.96–1.04). Per-stream decode is
+**identical to three significant figures** at c=1 and c=4. TTFT rises 9×–63×.
+
+That is serialization, not contention. Each request runs alone at full speed
+while the others wait. There is no batching to degrade.
+
+### llama-swap — continuous batching
+
+| Model | agg c=1 | agg c=4 | scaling | decode c=1 | decode c=4 | TTFT c=1 | TTFT c=4 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| gemma-4-E2B | 148.7 | **1014.3** | 6.8× | 151.6 | 275.2 | 88ms | **195ms** |
+| nemotron-3-nano-4B | 89.0 | 389.1 | 4.4× | 96.6 | 188.6 | 658ms | 2,644ms |
+| gpt-oss-20b | 115.4 | 332.8 | 2.9× | 140.4 | 201.1 | 713ms | 2,892ms |
+| gemma-4-26B | 94.1 | 288.5 | 3.1× | 113.9 | 279.3 | 1,511ms | 6,346ms |
+| gemma-4-31B | — | — | — | — | — | — | — |
+
+**Measurement caveat:** per-stream decode *rose* with concurrency, which
+batching alone does not explain — in lockstep batched decode each sequence should
+hold roughly its single-stream rate. The likely cause is that the c=1 sample
+understates: on Apple Silicon a single stream underutilizes the GPU, and short
+samples are sensitive to clock ramp. The E2B 6.8× aggregate scaling exceeds the
+4× ceiling that four-way parallelism alone allows, which points the same way. The
+*direction* of every finding here is unambiguous; the c=1 absolute numbers should
+be treated as a floor, and re-measured with a longer sample before anyone prices
+against them.
+
+### A failure worth recording
+
+`ggml-org/gemma-4-31B-it-GGUF:Q4_K_M` failed its chat probe with
+`AI_RetryError → AI_APICallError: Compute error` after 3 attempts. **It passed in
+the capability-only run earlier the same day**, so this is intermittent and most
+likely memory pressure — four concurrent requests against a 31B, with the
+previous llama-swap model possibly still resident.
+
+`examples/local-providers/README.md` claim 5 records this same `Compute error`
+signature under LlamaBarn for `gpt-oss-20b`. Two different models, two different
+llama.cpp front-ends, same error. Worth treating as a load/memory symptom rather
+than a model-specific defect.
+
+The probe handled it correctly: recorded as failed, rendered `?` in the matrix,
+and excluded from capability comparison rather than counted as unsupported. Its
+absence is also why the disagreement list shrank from four pairs to three — no
+pair, no comparison.
+
+## What this means for the exchange
+
+**1. Ollama is effectively single-tenant.** At four concurrent requests, a buyer
+waits 21 seconds for gemma4:12b and 48 seconds for gemma4:31b to *start*. An
+exchange reselling an adapted Ollama cannot serve concurrent traffic at all. This
+is a considerably stronger argument for ADR 0010 (serve-mode) than the reasoning
+capability gap that originally motivated it — that gap costs you a feature, this
+costs you the ability to have two customers.
+
+**2. Headroom is a curve, and its shape is runtime-specific.** Ollama's capacity
+is 1 regardless of model size. llama-server's is 3–7×, varying by model. A single
+"tok/s" field on an Offer would have shown Ollama's gemma4:12b (48) and
+llama-swap's gemma-4-26B (94) as roughly comparable. Under load they differ by
+6× in aggregate and 3,000ms in TTFT.
+
+**3. Small-and-cheap wins overwhelmingly under load.** gemma-4-E2B on llama-swap
+delivers 1014 tok/s aggregate at 195ms TTFT. qwen3.6:27b on Ollama delivers 22
+tok/s at 46 seconds. That is a ~46× throughput difference and a ~236× latency
+difference between two Offers on the same machine. Pricing that steers traffic
+toward the former is not a micro-optimization; it is most of the economics.
+
+**4. TTFT is the admission-control signal.** Ollama's TTFT explosion is what
+queueing looks like from outside. Dispatch must cap concurrency per Offer from
+measured Headroom rather than discovering the limit by degrading real requests —
+which is ADR 0007's "money answers how much this month, concurrency answers how
+much right now," now with a number attached.
+
+## Follow-ups
+
+1. **Re-measure c=1 with a longer sample** before pricing against these
+   absolutes. Direction is solid; the c=1 numbers look like a floor.
+2. **Sample beyond c=4** on llama-swap. Nothing here has found its knee — E2B was
+   still scaling at 6.8×, so the ceiling is above the range tested.
+3. **Investigate whether Ollama can batch at all** (`OLLAMA_NUM_PARALLEL`). If it
+   can, this is a configuration finding rather than an architectural one, and
+   adapt-mode over Ollama becomes viable again. If it cannot, ADR 0010 is settled
+   on throughput grounds as well as capability grounds.
+4. **Cold-start is still unpriced.** llama-swap's on-demand loads were 14–28s
+   earlier. Dispatch preferring a warm Offer over a nominally faster cold one is
+   likely correct, and unquantified.

--- a/reports/2026-07-26-supplier-probe-capability-divergence.md
+++ b/reports/2026-07-26-supplier-probe-capability-divergence.md
@@ -140,6 +140,57 @@ This is the result that matters for ADR 0009. We identified a client-side cause,
 fixed it, and **every pair still diverges**. Capability sets cannot be declared
 even after the known bug is gone.
 
+## Third round: asking Ollama to think, and being refused
+
+`buildReasoningProviderOptions` had no `ollama` branch, so nothing could ask an
+Ollama model to think, and the probe had never asked — it was measuring each
+runtime's *default* rather than the Offer's *capability*. Added the branch and
+made the probe set `reasoningEffort` (commit 54d018c), predicting the four
+gemma/nemotron reasoning disagreements would collapse.
+
+**They did not.** Ollama still reports no reasoning for any gemma-4 or nemotron
+Offer.
+
+The fix works mechanically. `resolveOllamaThinkFlag` (ollama-ai-provider-v2
+`index.js:1314`) reads `providerOptions.ollama.think` and puts `think` in the
+request body; the provider emits a reasoning part only when
+`response.message.thinking` comes back non-empty (`index.js:741`). So Ollama
+received `think: true` for gemma-4 and returned nothing. The provider documents
+the limit: *"Only supported by certain models like DeepSeek R1 and Qwen 3."*
+Which is precisely the observed pattern — Ollama surfaces reasoning for
+`gpt-oss:latest` and for nothing else.
+
+**This divergence is real and is not ours.** The likely mechanism is the chat
+template: llama.cpp with `--jinja` uses the GGUF's embedded Jinja template,
+Ollama applies its own Go template, and Gemma-4 emits `<think>` blocks that
+llama-server parses into `reasoning_content` while Ollama does not. That
+explanation is inference. What is established is narrower and sufficient: the
+flag is sent, Ollama declines, llama-server delivers 197–1402 characters on the
+same weights.
+
+### Final matrix
+
+| Offer | chat | stream | tool | struct | reason |
+| --- | --- | --- | --- | --- | --- |
+| llamaswap × 5 (gemma-4 26B/31B/E2B, gpt-oss-20b, nemotron-3-nano-4B) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| ollama gemma-4 (12b, 26b, 31b, e2b, e4b, latest) | ✓ | ✓ | ✓ | ✓ | ✗ |
+| ollama nemotron (3-nano 4b/latest, cascade-2 30b), qwen3.6:27b | ✓ | ✓ | ✓ | ✓ | ✗ |
+| ollama gpt-oss:latest | ✓ | ✓ | ✓ | **✗** | ✓ |
+
+Four pairs still diverge on reasoning; the gpt-oss pair diverges on structured
+output. **llama-server is strictly more capable than Ollama on this box** — it
+serves reasoning on models Ollama will not, and structured output on a model
+Ollama fails.
+
+### What this settles about Q11
+
+The first two rounds found bugs of ours and told us nothing about adapt vs serve.
+This round does. A client cannot fix the reasoning gap: if the exchange adapts to
+someone's Ollama, it cannot sell reasoning on gemma-4, and if it serves the same
+weights through llama-server, it can. **That is a capability difference
+determined by which runtime serves, and it is the first real argument for
+serve-mode.** It took eliminating two self-inflicted divergences to see it.
+
 ## Secondary observations
 
 - **Cold-start cost is large and uneven.** First-probe latency through

--- a/reports/2026-07-26-supplier-probe-capability-divergence.md
+++ b/reports/2026-07-26-supplier-probe-capability-divergence.md
@@ -1,0 +1,137 @@
+# Probing local Offers: capability divergence is caused by our client, not the runtime
+
+Experiment report, 2026-07-26. Run on an M4 Max via
+`examples/supplier-agent/run.ts probe --no-throughput`.
+
+> **Headline:** the same weights served by Ollama and by llama-swap expose
+> *complementary* capability sets — each runtime has a capability the other
+> lacks. Both divergences trace to umwelten's provider integrations, not to
+> llama.cpp, Ollama, or the models. The design consequence is that an Offer's
+> Capabilities must be probed **through the exact code path that will serve
+> production traffic**; a table derived from model cards, runtime docs, or a
+> different client library is wrong.
+
+## What the experiment was for
+
+The exchange (see `packages/exchange/CONTEXT.md`) needs to know what each Offer
+can do before it dispatches to one. The open question was whether a supplier
+agent can simply **adapt** — resell whatever runtimes are already up on a box —
+or whether it must **serve** the models itself to make any guarantee stick.
+
+The test: probe models that exist in two runtimes on the same machine and see
+whether the capability sets agree.
+
+## Results
+
+Five capability probes per Offer, each pass/fail with recorded evidence.
+
+| Runtime | Model | chat | stream | tool | struct | reason |
+| --- | --- | --- | --- | --- | --- | --- |
+| ollama | `gemma4:e2b` | ✓ | ✓ | ✓ | **✓** | **✗** |
+| llamaswap | `unsloth/gemma-4-E2B-it-GGUF:Q4_K_M` | ✓ | ✓ | ✓ | **✗** | **✓** |
+| llamaswap | `ggml-org/gemma-4-26B-A4B-it-GGUF:Q4_K_M` | ✓ | ✓ | ✓ | ✗ | ✓ |
+| llamaswap | `ggml-org/gemma-4-31B-it-GGUF:Q4_K_M` | ✓ | ✓ | ✓ | ✗ | ✓ |
+| llamaswap | `ggml-org/gpt-oss-20b-GGUF:MXFP4` | ✓ | ✓ | ✓ | ✗ | ✓ |
+| llamaswap | `unsloth/NVIDIA-Nemotron-3-Nano-4B-GGUF:Q4_K_M` | ✓ | ✓ | ✓ | ✗ | ✓ |
+| ollama | `gpt-oss:latest` | ✓ | ✓ | ✓ | **✗** | ✓ |
+| ollama | `gemma4:{12b,26b,31b,e4b,latest}` | ✓ | ✓ | ✓ | ✓ | ✗ |
+| ollama | `nemotron-3-nano:{4b,latest}` | ✓ | ✓ | ✓ | ✓ | ✗ |
+
+The `gemma-4 E2B` row pair is the cleanest evidence: identical weights,
+inverted on exactly two of five capabilities.
+
+**5/5 llama-swap Offers fail structured output. 5/5 expose reasoning.** The
+uniformity is the tell — a model-level or quantization-level cause would not
+produce a perfect split along runtime lines.
+
+## Root cause
+
+Neither divergence is a property of the runtime or the weights.
+
+### Structured output
+
+`@ai-sdk/openai-compatible` exposes a `supportsStructuredOutputs` flag on
+`createOpenAICompatible`. Neither `providers/llamaswap.ts` nor
+`providers/lmstudio.ts` passes it, so it defaults to `false`, the SDK never
+sends `response_format: { type: 'json_schema', … }`, and it degrades to asking
+for JSON in the prompt. The runtime says so explicitly:
+
+```
+AI SDK Warning (llamaswap.chat / ggml-org/gemma-4-26B-A4B-it-GGUF:Q4_K_M):
+The feature "responseFormat" is not supported.
+JSON response format schema is only supported with structuredOutputs
+```
+
+The models were not confused. Asked for `{city, countryCode, populationMillions}`,
+gemma-4-26B returned well-formed JSON with `city_metadata`, `geography`,
+`demographics`, `logistics`, and `key_landmarks` — 933 completion tokens of
+perfectly valid, entirely unrequested structure. It was never shown the schema.
+
+llama-server has supported `response_format` with json_schema and GBNF grammars
+for a long time, and the observed build is `b10098`. This is very likely a
+one-line provider fix rather than a llama.cpp limitation — **but it must be
+verified against that build before anyone commits to it**, and it changes
+behavior that every existing local-model benchmark was collected against.
+
+### Reasoning
+
+The mirror image, from the Ollama side:
+
+```
+AI SDK Warning (ollama.responses / gpt-oss:latest):
+reasoning parts in assistant messages are not supported for Ollama responses
+```
+
+llama-server splits thinking content into a separate channel that the
+OpenAI-compatible provider surfaces; the Ollama provider path does not. Gemma-4
+under llama-swap produced 207–1400 characters of reasoning on every model
+probed, including the 2B-class E2B variant. The same weights through Ollama
+reported no reasoning channel at all.
+
+## What this means
+
+**Q11 (adapt vs serve) was mis-framed.** Serve-mode would not have fixed either
+divergence: an agent that launched `llama-server` itself would still route
+through the same `llamaswap` provider and still fail structured output.
+Adapt-vs-serve is not the axis that controls capability variance. What
+serve-mode still buys is control over context size, quantization, and
+concurrency — *resource* properties, not *capability* properties. The question
+needs re-asking on those terms.
+
+**ADR 0009 falls out of this directly.** Capability is a property of the whole
+path — client integration × runtime × build × quantization × weights — and the
+only honest way to populate an Offer's capability set is to exercise it through
+the code path that will serve production traffic.
+
+**It also confirms ADR 0006's Supplier abstraction is right to be thin.** The
+exchange should know "can this Offer do X, at what price, with what headroom" —
+and nothing about *why*, because the why turns out to live in a layer the
+exchange has no business modelling.
+
+## Secondary observations
+
+- **Cold-start cost is large and uneven.** First-probe latency through
+  llama-swap's on-demand launch: 28.6s (26B), 14.4s (31B), versus 0.9–2.7s once
+  warm. Dispatch will need to price an idle Supplier differently from a warm
+  one; a naive "cheapest Offer wins" rule will route a latency-sensitive
+  request into a 30-second model load.
+- **The failure path works.** Every structured-output failure was caught by the
+  watchdog, recorded with evidence, and the run continued. The stack traces in
+  the console are `runner.ts` logging on the way out of a correctly handled
+  failure.
+- **`examples/local-providers/README.md` claim 6** ("broken structured output,
+  vision failures, GGML crashes") is listed as *not tested*. Structured output
+  is now tested: it is broken, and we broke it.
+
+## Follow-ups
+
+1. Verify `supportsStructuredOutputs: true` against llama-server b10098 and
+   propose a patch to `llamaswap.ts` / `lmstudio.ts`. Flag loudly that this
+   invalidates comparability with prior benchmark data.
+2. Re-probe after the fix. If both runtimes then agree, the capability
+   divergence was entirely self-inflicted — which is the best possible outcome
+   and still does not remove the need to probe.
+3. Re-ask Q11 on resource properties: does the agent need to pin context size
+   and quantization to make an Offer sellable?
+4. Throughput sampling (`--concurrency 1,4`) has not been run. That is the
+   Headroom half, and it is what E2 needs.

--- a/reports/2026-07-26-supplier-probe-capability-divergence.md
+++ b/reports/2026-07-26-supplier-probe-capability-divergence.md
@@ -108,6 +108,38 @@ exchange should know "can this Offer do X, at what price, with what headroom" �
 and nothing about *why*, because the why turns out to live in a layer the
 exchange has no business modelling.
 
+## Post-fix re-probe (same session)
+
+`supportsStructuredOutputs: true` was added to `llamaswap`, `llamabarn`, and
+`lmstudio` (commit 8b8975a) and the full 16-Offer matrix re-probed.
+
+**The fix worked: llama-swap went 0/5 → 5/5 on structured output.** Every model
+that had returned an invented shape now returns schema-valid JSON.
+`unsloth/gemma-4-E2B-it-GGUF:Q4_K_M` moved from "response did not match schema"
+to "returned schema-valid JSON".
+
+**And all five pairs still disagree.** The divergence moved rather than
+vanished:
+
+| Same weights | Ollama | llama-swap | Diverges on |
+| --- | --- | --- | --- |
+| gemma-4 26B | struct ✓, reason ✗ | struct ✓, reason ✓ | reasoning |
+| gemma-4 31B | struct ✓, reason ✗ | struct ✓, reason ✓ | reasoning |
+| gemma-4 E2B | struct ✓, reason ✗ | struct ✓, reason ✓ | reasoning |
+| nemotron-3-nano 4B | struct ✓, reason ✗ | struct ✓, reason ✓ | reasoning |
+| gpt-oss | struct **✗**, reason ✓ | struct ✓, reason ✓ | structured output |
+
+llama-swap is now 5/5 across all five capabilities. Ollama is 11/11 on chat,
+streaming, and tool calling; 10/11 on structured output; and **1/11 on
+reasoning** — the sole exception being `gpt-oss:latest`, which is also the only
+Ollama Offer that fails structured output ("the model did not return a
+response"). That failure is untouched by the fix because Ollama routes through
+`ollama-ai-provider-v2`, not `createOpenAICompatible`.
+
+This is the result that matters for ADR 0009. We identified a client-side cause,
+fixed it, and **every pair still diverges**. Capability sets cannot be declared
+even after the known bug is gone.
+
 ## Secondary observations
 
 - **Cold-start cost is large and uneven.** First-probe latency through
@@ -125,13 +157,28 @@ exchange has no business modelling.
 
 ## Follow-ups
 
-1. Verify `supportsStructuredOutputs: true` against llama-server b10098 and
-   propose a patch to `llamaswap.ts` / `lmstudio.ts`. Flag loudly that this
-   invalidates comparability with prior benchmark data.
-2. Re-probe after the fix. If both runtimes then agree, the capability
-   divergence was entirely self-inflicted — which is the best possible outcome
-   and still does not remove the need to probe.
-3. Re-ask Q11 on resource properties: does the agent need to pin context size
-   and quantization to make an Offer sellable?
-4. Throughput sampling (`--concurrency 1,4`) has not been run. That is the
-   Headroom half, and it is what E2 needs.
+1. ~~Verify and patch `supportsStructuredOutputs`.~~ Done (8b8975a), verified by
+   re-probe. Invalidates comparability with prior local structured-output
+   benchmark data.
+2. ~~Re-probe after the fix.~~ Done — see above. The divergence was *not*
+   entirely self-inflicted.
+3. **Reasoning through the Ollama path.** Ollama surfaces no reasoning channel
+   for any model except `gpt-oss:latest`, while the same weights through
+   llama-server produce 197–1402 characters of it. Ollama's API takes a `think`
+   parameter; the provider may simply never set it. Same bug class as the
+   structured-output flag, and not yet investigated.
+4. **`gpt-oss:latest` structured output on Ollama.** Fails with "the model did
+   not return a response" while `gpt-oss-20b` through llama-swap passes. Note
+   that it is also the only Ollama Offer *with* a reasoning channel — a
+   plausible mechanism is that the response is entirely reasoning tokens with no
+   object payload, but that is a guess, not a finding.
+5. **The six unpatched hosted providers.** `deepinfra`, `fireworks`,
+   `github-models`, `lunaroute`, `minimax`, `nvidia`, and `togetherai` all
+   construct `createOpenAICompatible` without the flag. LunaRoute is the most
+   likely to matter — its `/v1/models` advertises `json_schema` support
+   explicitly (see `reports/2026-07-06-lunaroute-provider-integration.md`).
+6. **Throughput sampling** (`--concurrency 1,4`) has still not been run. That is
+   the Headroom half, and what E2 needs.
+7. **`examples/local-providers/README.md` claim 6** can move from *not tested* to
+   resolved: structured output was broken, the cause was ours, and it is fixed
+   for the llama.cpp-family providers.


### PR DESCRIPTION
Lands the foundation the Exchange tickets build on: the domain model, six ADRs, two working prototypes, three measurement reports, and two fixes in `core` that the measurements uncovered.

**Merging this unblocks the factory.** #293 and #305 both assume `packages/exchange/CONTEXT.md` and the ADRs exist on `main`.

Specs: #291 (Exchange v1) and #303 (Supplier Agent v1). Tickets: #293–#301 and #305–#310, all `ready-for-agent`.

## Review this part carefully

Two commits change runtime behavior in `packages/core/src/providers/` and `cognition/`. They are small, they are correct, and **they invalidate comparability with existing local-model benchmark data.**

**`8b8975a` — structured outputs for llama.cpp-family providers.** `createOpenAICompatible` takes `supportsStructuredOutputs`, which defaults to `false`. `llamaswap`, `llamabarn`, and `lmstudio` all omitted it, so the AI SDK never sent `response_format: { type: 'json_schema' }` and silently degraded to asking for JSON in the prompt. Every `generateObject` against those three providers was going through that fallback.

Measured: 5/5 llama-swap offers failed a structured-output probe while the same weights through Ollama passed. Asked for `{city, countryCode, populationMillions}`, gemma-4-26B returned 933 tokens of immaculate JSON with `city_metadata`, `geography`, `demographics`, and `key_landmarks`. It was never shown the schema. After the fix: 5/5 pass.

Any prior local-model result involving `generateObject` or a structured task against those providers was collected through the broken path and does not compare with anything measured after this commit.

**`54d018c` — `ReasoningEffort` can request thinking from Ollama.** `buildReasoningProviderOptions` handled google, openrouter, anthropic, deepinfra, and togetherai but had no `ollama` branch, so nothing could ask an Ollama model to think. Leaving `reasoningEffort` unset still sends nothing, so default requests are byte-identical — there is a test asserting exactly that, because it is the property most likely to get broken later. `'none'` maps to `think: false`, which gives a way to turn thinking *off* for gpt-oss.

Six other providers construct `createOpenAICompatible` without the structured-outputs flag — `deepinfra`, `fireworks`, `github-models`, `lunaroute`, `minimax`, `nvidia`, `togetherai`. Same bug class, deliberately **not** touched here: they are hosted paths this experiment did not cover and re-probing locally cannot verify. LunaRoute is the most likely to matter, since its `/v1/models` advertises `json_schema` support explicitly.

Happy to split these two commits into their own PR if you would rather review them apart from the docs.

## Domain model

- `CONTEXT-MAP.md` makes this a multi-context repo. The existing `CONTEXT.md` is untouched; the Exchange gets its own vocabulary under `packages/exchange/`.
- The map records the dependency direction — `core/providers/` reaches a running Exchange over HTTP and imports nothing, so the DAG stays acyclic — and tabulates the false friends. `Provider`, `Capability`, `User`, and `Cost` each mean different things on either side of the boundary. `Provider` was the important catch: an on-prem box and a commercial vendor are both **Suppliers**, and `providers/` keeps its existing meaning.

## ADRs

| | |
|---|---|
| 0006 | Marketplace in its model, closed in its membership. Guarantees are unenforceable against strangers, and a reseller is liable for every guarantee it passes through. |
| 0007 | Charge is recorded independently of Cost, so owned hardware can be rationed and price becomes the routing lever. |
| 0008 | The Exchange never authenticates End Users; Applications assert identity via ADR 0003's pattern. |
| 0009 | Capabilities are probed through the serving path, never declared. |
| 0010 | The supplier agent serves by default; adapting is a lesser Offer tier. |
| 0011 | The Exchange meters at its own boundary; upstream usage is reconciliation, not the basis for a Charge. |

## What the measurements found

Three reports, and each overturned something.

**Capability divergence.** The same weights served by Ollama and llama-swap exposed *complementary* capability sets — one had structured output and no reasoning, the other reasoning and no structured output. Both causes turned out to be our own client code. We fixed one, re-probed, and all five pairs still disagreed. Fixed the second, re-probed, and they *still* disagreed — Ollama accepts `think: true` for gemma-4 and returns nothing, because the flag is only honored by certain models. Two rounds of eliminating self-inflicted noise to find the one real divergence. That is ADR 0009 in its strongest form.

**Metering.** Two of three realistic situations hand the ledger a request that looks free while real tokens were served. An upstream reporting no usage yields zero tokens and no cost. An aborted stream reports **zero prompt tokens** despite the whole prompt being processed and paid for, a `chars/4` completion estimate, and undefined cost — so a long prompt aborted near the end of generation costs us upstream and records nothing. `runner.ts` is not at fault; that metadata was built for benchmark reporting and is fit for it. ADR 0011 is the consequence.

**Headroom.** Ollama serves concurrent requests one at a time — aggregate throughput flat from c=1 to c=4, per-stream decode identical to three significant figures, TTFT rising 9×–63×, up to 48 seconds. llama-server batches, scaling 2.9×–6.8×. A single tok/s field would have shown a serializing runtime and a batching one as comparable Offers.

Measurement caveats are recorded rather than smoothed: per-stream decode rose with concurrency, which batching alone does not explain, and one model's scaling exceeded the ceiling four-way parallelism allows. Both point at the c=1 sample understating. Direction is unambiguous; the c=1 absolutes are a floor.

## Prototypes

- **`examples/supplier-agent`** — discover, probe, publish. Verified against 16 Offers across two runtimes on an M4 Max. Checkpoints per model so an interrupt costs one probe, and pairs model names across runtimes so the comparison is possible at all. Becomes `packages/supplier` in #305.
- **`examples/exchange-metering`** — drives the real runner against a mock OpenAI-compatible upstream via `LLAMASWAP_HOST`, with nothing stubbed on our side. No keys, no GPU. Live providers are the wrong instrument here: a client hanging up mid-stream cannot be provoked on cue.

## Verification

- `pnpm test:run` — 1785 tests, 155 files, all passing (adds `provider-options.test.ts`, which the module lacked)
- `packages/core` typechecks; both examples typecheck
- `discover` and the metering spike run end-to-end here; the probe path was verified on real hardware across 16 Offers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG)_