### PR TITLE
Exchange: relay a chat completion to a published Offer

### DIFF
--- a/packages/exchange/src/buyer/handler.test.ts
+++ b/packages/exchange/src/buyer/handler.test.ts
@@ -1,0 +1,235 @@
+/**
+ * The buyer surface, driven end to end against a mock Supplier.
+ *
+ * These run over a real socket rather than fabricated request objects, because
+ * what is under test here is *relaying* — streaming, aborts, upstream failures
+ * — and a fake response object cannot tell you whether chunks arrived
+ * incrementally or all at once.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { MemoryStore } from "../store/memory-store.js";
+import { supplierFixture } from "../store/conformance.js";
+import { startMockUpstream, type MockUpstream, type UpstreamMode } from "../testing/mock-upstream.js";
+import { createExchangeServer, type RunningExchange } from "../server.js";
+import { selectOffer } from "./handler.js";
+import type { Offer } from "../types.js";
+
+const MODEL = "gemma-4-26b";
+
+describe("buyer surface", () => {
+  let store: MemoryStore;
+  let upstream: MockUpstream;
+  let exchange: RunningExchange;
+
+  async function boot(mode: UpstreamMode = "ok") {
+    upstream = await startMockUpstream(mode);
+    store = new MemoryStore();
+    await store.createSupplier(
+      supplierFixture({ baseUrl: upstream.baseUrl, upstreamCredentialEnv: "MOCK_KEY" }),
+    );
+    await store.replaceOffers("office-spark", [
+      { model: MODEL, capabilities: ["chat", "streaming"], servingMode: "managed" },
+    ]);
+    exchange = await createExchangeServer({ store, port: 0, host: "127.0.0.1" });
+  }
+
+  async function chat(body: unknown, init: RequestInit = {}) {
+    return fetch(`${exchange.url}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      ...init,
+    });
+  }
+
+  beforeEach(async () => {
+    process.env.MOCK_KEY = "upstream-secret";
+  });
+
+  afterEach(async () => {
+    delete process.env.MOCK_KEY;
+    await exchange?.close();
+    await upstream?.close();
+  });
+
+  describe("non-streaming", () => {
+    it("returns an OpenAI-compatible response", async () => {
+      await boot();
+      const res = await chat({ model: MODEL, messages: [{ role: "user", content: "hi" }] });
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.object).toBe("chat.completion");
+      expect(json.choices[0].message.content).toContain("quick brown fox");
+    });
+
+    it("forwards to the supplier that published the offer", async () => {
+      await boot();
+      await chat({ model: MODEL, messages: [] });
+
+      expect(upstream.requests).toHaveLength(1);
+      expect(upstream.requests[0].path).toBe("/v1/chat/completions");
+      expect(upstream.requests[0].body.model).toBe(MODEL);
+    });
+
+    it("presents the supplier's upstream credential", async () => {
+      await boot();
+      await chat({ model: MODEL, messages: [] });
+
+      // Read from the env var the Supplier names — the secret is never stored
+      // in the database.
+      expect(upstream.requests[0].auth).toBe("Bearer upstream-secret");
+    });
+  });
+
+  describe("streaming", () => {
+    it("relays chunks as they arrive rather than buffering", async () => {
+      await boot();
+      const res = await chat({ model: MODEL, messages: [], stream: true });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let reads = 0;
+      let text = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        reads += 1;
+        text += decoder.decode(value);
+      }
+
+      // More than one read is the whole assertion: a single read means the
+      // response was buffered and handed over at the end, which is not
+      // streaming whatever the content-type claims.
+      expect(reads).toBeGreaterThan(1);
+      expect(text).toContain("[DONE]");
+    });
+
+    it("stops generation upstream when the caller hangs up", async () => {
+      await boot("never-finishes");
+      const controller = new AbortController();
+      const res = await chat(
+        { model: MODEL, messages: [], stream: true },
+        { signal: controller.signal },
+      );
+
+      const reader = res.body!.getReader();
+      await reader.read();
+      controller.abort();
+
+      // The upstream is still generating until it notices the socket closed.
+      await new Promise((r) => setTimeout(r, 250));
+      expect(upstream.sawAbort()).toBe(true);
+    });
+  });
+
+  describe("failures are distinguishable", () => {
+    it("reports no eligible offer with its own code", async () => {
+      await boot();
+      const res = await chat({ model: "a-model-nobody-serves", messages: [] });
+
+      expect(res.status).toBe(503);
+      expect((await res.json()).error).toBe("no_eligible_offer");
+    });
+
+    it("does not select a disabled offer", async () => {
+      await boot();
+      await store.setOfferEnabled("office-spark", MODEL, false);
+
+      const res = await chat({ model: MODEL, messages: [] });
+      expect((await res.json()).error).toBe("no_eligible_offer");
+    });
+
+    it("does not select an offer from a disabled supplier", async () => {
+      await boot();
+      await store.setSupplierEnabled("office-spark", false);
+
+      const res = await chat({ model: MODEL, messages: [] });
+      expect((await res.json()).error).toBe("no_eligible_offer");
+    });
+
+    it("surfaces an upstream error instead of disguising it as success", async () => {
+      await boot("error");
+      const res = await chat({ model: MODEL, messages: [] });
+
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.error).toBe("upstream_error");
+      expect(json.upstreamStatus).toBe(500);
+      expect(json.supplierId).toBe("office-spark");
+    });
+
+    it("rejects a body with no model", async () => {
+      await boot();
+      const res = await chat({ messages: [] });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe("invalid_body");
+    });
+
+    it("rejects invalid JSON", async () => {
+      await boot();
+      const res = await fetch(`${exchange.url}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{ not json",
+      });
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe("invalid_json");
+    });
+
+    it("refuses a non-POST", async () => {
+      await boot();
+      const res = await fetch(`${exchange.url}/v1/chat/completions`);
+      expect(res.status).toBe(405);
+    });
+  });
+
+  describe("the server itself", () => {
+    it("reports health, including whether the store answers", async () => {
+      await boot();
+      const res = await fetch(`${exchange.url}/health`);
+      expect(res.status).toBe(200);
+      expect((await res.json()).status).toBe("ok");
+    });
+
+    it("404s an unknown path rather than hanging", async () => {
+      await boot();
+      const res = await fetch(`${exchange.url}/nope`);
+      expect(res.status).toBe(404);
+    });
+  });
+});
+
+describe("selectOffer", () => {
+  // Kept as a pure function so #296 can replace the body — guarantee filter,
+  // capability filter, ranking by Charge — without touching the handler.
+  const offer = (overrides: Partial<Offer>): Offer => ({
+    supplierId: "s",
+    model: MODEL,
+    capabilities: ["chat"],
+    servingMode: "managed",
+    headroom: [],
+    wholesalePromptPerMillion: 0,
+    wholesaleCompletionPerMillion: 0,
+    retailPromptPerMillion: 1,
+    retailCompletionPerMillion: 1,
+    enabled: true,
+    publishedAt: new Date(),
+    ...overrides,
+  });
+
+  it("finds an enabled offer for the model", () => {
+    expect(selectOffer([offer({})], MODEL)?.model).toBe(MODEL);
+  });
+
+  it("ignores other models", () => {
+    expect(selectOffer([offer({ model: "other" })], MODEL)).toBeUndefined();
+  });
+
+  it("ignores a disabled offer", () => {
+    expect(selectOffer([offer({ enabled: false })], MODEL)).toBeUndefined();
+  });
+});

--- a/packages/exchange/src/buyer/handler.ts
+++ b/packages/exchange/src/buyer/handler.ts
@@ -1,0 +1,225 @@
+/**
+ * The buyer surface: `POST /v1/chat/completions`.
+ *
+ * OpenAI-compatible on purpose. That is the decision that lets an existing
+ * client — including umwelten's own provider layer — reach the Exchange by
+ * changing a base URL and a key, rather than adopting anything new.
+ *
+ * This ticket is the thinnest complete path: find an Offer for the requested
+ * Model, forward, relay the answer back. There is no authentication yet (#295)
+ * and no metering (#297), so nothing from this stage should reach a public
+ * address before those land. Dispatch here picks the first eligible Offer;
+ * filtering on Guarantees and ranking by Charge is #296.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Offer } from "../types.js";
+import type { ExchangeStore } from "../store/types.js";
+
+export const CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
+
+const MAX_BODY_BYTES = 10_000_000;
+
+export interface BuyerHandlerOptions {
+  store: ExchangeStore;
+  /**
+   * Resolves a Supplier's upstream credential from its declared env var name.
+   * Injectable so tests do not have to mutate process.env.
+   */
+  readCredential?: (envName: string | undefined) => string | undefined;
+  fetchImpl?: typeof fetch;
+}
+
+/** Error codes a caller can branch on. Stable, and worth keeping that way. */
+export const BuyerError = {
+  /** Nothing can serve this Model. Distinct from every other failure. */
+  NO_ELIGIBLE_OFFER: "no_eligible_offer",
+  INVALID_BODY: "invalid_body",
+  INVALID_JSON: "invalid_json",
+  UPSTREAM_ERROR: "upstream_error",
+  METHOD_NOT_ALLOWED: "method_not_allowed",
+  BODY_TOO_LARGE: "body_too_large",
+} as const;
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    let raw = "";
+    req.on("data", (chunk: Buffer | string) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error(BuyerError.BODY_TOO_LARGE));
+        return;
+      }
+      raw += chunk;
+    });
+    req.on("end", () => resolve(raw));
+    req.on("error", reject);
+  });
+}
+
+function sendJson(res: ServerResponse, status: number, payload: unknown): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+/**
+ * Pick an Offer for a Model.
+ *
+ * Deliberately naive: first enabled Offer wins. #296 replaces this with a
+ * Guarantee filter, a Capability filter, and a ranking by Charge. Keeping it
+ * a separate function means that change touches one place.
+ */
+export function selectOffer(offers: Offer[], model: string): Offer | undefined {
+  return offers.find((offer) => offer.model === model && offer.enabled);
+}
+
+export function createBuyerHandler(opts: BuyerHandlerOptions) {
+  const { store } = opts;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const readCredential =
+    opts.readCredential ?? ((envName?: string) => (envName ? process.env[envName] : undefined));
+
+  return async function handleChatCompletions(
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<boolean> {
+    const path = (req.url ?? "").split("?")[0];
+    if (path !== CHAT_COMPLETIONS_PATH) return false;
+
+    if (req.method !== "POST") {
+      sendJson(res, 405, { error: BuyerError.METHOD_NOT_ALLOWED });
+      return true;
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse((await readBody(req)) || "{}");
+    } catch (error) {
+      const code =
+        error instanceof Error && error.message === BuyerError.BODY_TOO_LARGE
+          ? BuyerError.BODY_TOO_LARGE
+          : BuyerError.INVALID_JSON;
+      sendJson(res, code === BuyerError.BODY_TOO_LARGE ? 413 : 400, { error: code });
+      return true;
+    }
+
+    const model = typeof body.model === "string" ? body.model : undefined;
+    if (!model) {
+      sendJson(res, 400, { error: BuyerError.INVALID_BODY, message: "`model` is required." });
+      return true;
+    }
+
+    const offer = selectOffer(await store.listOffers(), model);
+    if (!offer) {
+      // Its own status and code. A caller must be able to tell "nothing can
+      // serve this" from an upstream failure — and later, from being out of
+      // credit (#298). Conflating them makes every one of those undebuggable.
+      sendJson(res, 503, {
+        error: BuyerError.NO_ELIGIBLE_OFFER,
+        message: `No enabled Offer for model "${model}".`,
+      });
+      return true;
+    }
+
+    const supplier = await store.getSupplier(offer.supplierId);
+    if (!supplier) {
+      sendJson(res, 503, { error: BuyerError.NO_ELIGIBLE_OFFER });
+      return true;
+    }
+
+    // The caller hanging up must stop generation upstream, not leave a Supplier
+    // burning GPU seconds nobody will read.
+    //
+    // Aborting the fetch signal alone is not enough once the response body is
+    // already streaming: the body reader holds the socket open, so the upstream
+    // keeps generating and never sees the disconnect. The relay installs a
+    // cancel here as soon as it has a reader.
+    const upstream = new AbortController();
+    let cancelBody: (() => void) | undefined;
+    const clientGone = () => {
+      upstream.abort();
+      cancelBody?.();
+    };
+    // Only `res` close means the caller left. `req` emits "close" as soon as
+    // the request body has been read, which is before the response is even
+    // sent — listening to it aborts the controller immediately and leaves the
+    // real disconnect with nothing to fire.
+    req.on("aborted", clientGone);
+    res.on("close", () => {
+      if (!res.writableEnded) clientGone();
+    });
+
+    const credential = readCredential(supplier.upstreamCredentialEnv);
+    const streaming = body.stream === true;
+
+    let upstreamRes: Response;
+    try {
+      upstreamRes = await doFetch(`${supplier.baseUrl.replace(/\/$/, "")}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(credential ? { authorization: `Bearer ${credential}` } : {}),
+        },
+        body: JSON.stringify(body),
+        signal: upstream.signal,
+      });
+    } catch (error) {
+      if (upstream.signal.aborted) {
+        // The caller left. Nothing to report to.
+        if (!res.writableEnded) res.end();
+        return true;
+      }
+      sendJson(res, 502, {
+        error: BuyerError.UPSTREAM_ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      return true;
+    }
+
+    if (!upstreamRes.ok) {
+      // Surface it rather than dressing a failure up as a success. The status
+      // is preserved so a caller can tell a rate limit from a bad request.
+      const text = await upstreamRes.text().catch(() => "");
+      sendJson(res, upstreamRes.status, {
+        error: BuyerError.UPSTREAM_ERROR,
+        supplierId: supplier.id,
+        upstreamStatus: upstreamRes.status,
+        body: text.slice(0, 2000),
+      });
+      return true;
+    }
+
+    if (!streaming || !upstreamRes.body) {
+      const text = await upstreamRes.text();
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(text);
+      return true;
+    }
+
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+
+    // Relay chunk by chunk rather than buffering. #297 counts completion
+    // tokens right here, which is what makes the count survive an abort.
+    const reader = upstreamRes.body.getReader();
+    cancelBody = () => void reader.cancel().catch(() => {});
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (res.writableEnded) break;
+        res.write(Buffer.from(value));
+      }
+    } catch {
+      // An upstream that dies mid-stream leaves the caller with a truncated
+      // response and no way to signal an error — headers are already sent.
+    } finally {
+      if (!res.writableEnded) res.end();
+    }
+    return true;
+  };
+}

--- a/packages/exchange/src/index.ts
+++ b/packages/exchange/src/index.ts
@@ -16,3 +16,14 @@ export { NeonStore } from "./store/neon-store.js";
 
 export { createSupplyHandler, hashCredential, SUPPLY_PATH } from "./supply/handler.js";
 export type { SupplyHandlerOptions } from "./supply/handler.js";
+
+export {
+  BuyerError,
+  CHAT_COMPLETIONS_PATH,
+  createBuyerHandler,
+  selectOffer,
+} from "./buyer/handler.js";
+export type { BuyerHandlerOptions } from "./buyer/handler.js";
+
+export { createExchangeApp, createExchangeServer } from "./server.js";
+export type { ExchangeServerOptions, RunningExchange } from "./server.js";

--- a/packages/exchange/src/server.ts
+++ b/packages/exchange/src/server.ts
@@ -1,0 +1,97 @@
+/**
+ * The Exchange as a listening service.
+ *
+ * A tracer bullet has to be demoable, and for an HTTP service that means you
+ * can curl it. Everything the tests exercise runs in-process without this —
+ * `createExchangeServer` only wires the same handlers to a socket.
+ *
+ * Deployment (where it runs, TLS, secrets) is #301.
+ */
+
+import http from "node:http";
+import type { Server } from "node:http";
+import { createSupplyHandler } from "./supply/handler.js";
+import { createBuyerHandler } from "./buyer/handler.js";
+import type { ExchangeStore } from "./store/types.js";
+
+export interface ExchangeServerOptions {
+  store: ExchangeStore;
+  port?: number;
+  host?: string;
+}
+
+export interface RunningExchange {
+  server: Server;
+  port: number;
+  url: string;
+  close: () => Promise<void>;
+}
+
+export function createExchangeApp(store: ExchangeStore) {
+  const handlers = [createSupplyHandler({ store }), createBuyerHandler({ store })];
+
+  return async function handle(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<void> {
+    if (req.url === "/health") {
+      // Reports whether the store is reachable, not merely whether the process
+      // is up — a service that answers while its database is gone is worse
+      // than one that does not answer.
+      try {
+        await store.listSuppliers();
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+      } catch (error) {
+        res.writeHead(503, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            status: "degraded",
+            store: error instanceof Error ? error.message : String(error),
+          }),
+        );
+      }
+      return;
+    }
+
+    for (const handler of handlers) {
+      if (await handler(req, res)) return;
+    }
+
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  };
+}
+
+export async function createExchangeServer(
+  opts: ExchangeServerOptions,
+): Promise<RunningExchange> {
+  const app = createExchangeApp(opts.store);
+  await opts.store.setup();
+
+  const server = http.createServer((req, res) => {
+    app(req, res).catch(() => {
+      if (!res.writableEnded) {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "internal_error" }));
+      }
+    });
+  });
+
+  const host = opts.host ?? "0.0.0.0";
+  await new Promise<void>((resolve) => server.listen(opts.port ?? 7450, host, resolve));
+
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : (opts.port ?? 0);
+
+  return {
+    server,
+    port,
+    url: `http://${host}:${port}`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections?.();
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/packages/exchange/src/store/conformance.ts
+++ b/packages/exchange/src/store/conformance.ts
@@ -21,6 +21,8 @@ export function supplierFixture(overrides: Partial<Supplier> = {}): Supplier {
     displayName: "Office DGX Spark",
     grantedGuarantees: ["on-premise", "no-training"],
     credentialHash: "hash-office",
+    baseUrl: "http://127.0.0.1:9/v1",
+    upstreamCredentialEnv: "OFFICE_SPARK_KEY",
     enabled: true,
     createdAt: new Date("2026-07-26T00:00:00Z"),
     ...overrides,
@@ -63,6 +65,10 @@ export function runExchangeStoreConformance(
         const found = await store.getSupplier(supplier.id);
         expect(found?.displayName).toBe("Office DGX Spark");
         expect(found?.grantedGuarantees).toEqual(["on-premise", "no-training"]);
+        expect(found?.baseUrl).toBe("http://127.0.0.1:9/v1");
+        // The env var *name*, never the secret — a database compromise must
+        // not hand over the keys we buy with.
+        expect(found?.upstreamCredentialEnv).toBe("OFFICE_SPARK_KEY");
         expect(found?.enabled).toBe(true);
       });
 

--- a/packages/exchange/src/store/neon-store.ts
+++ b/packages/exchange/src/store/neon-store.ts
@@ -39,6 +39,8 @@ export class NeonStore implements ExchangeStore {
         display_name TEXT NOT NULL,
         granted_guarantees JSONB NOT NULL DEFAULT '[]'::jsonb,
         credential_hash TEXT NOT NULL,
+        base_url TEXT NOT NULL DEFAULT '',
+        upstream_credential_env TEXT,
         enabled BOOLEAN NOT NULL DEFAULT true,
         created_at TIMESTAMPTZ NOT NULL DEFAULT now()
       )
@@ -86,16 +88,21 @@ export class NeonStore implements ExchangeStore {
   async createSupplier(supplier: Supplier): Promise<void> {
     await this.sql`
       INSERT INTO exchange_supplier
-        (id, display_name, granted_guarantees, credential_hash, enabled, created_at)
+        (id, display_name, granted_guarantees, credential_hash, base_url,
+         upstream_credential_env, enabled, created_at)
       VALUES (
         ${supplier.id}, ${supplier.displayName},
         ${JSON.stringify(supplier.grantedGuarantees)}::jsonb,
-        ${supplier.credentialHash}, ${supplier.enabled}, ${supplier.createdAt.toISOString()}
+        ${supplier.credentialHash}, ${supplier.baseUrl},
+        ${supplier.upstreamCredentialEnv ?? null},
+        ${supplier.enabled}, ${supplier.createdAt.toISOString()}
       )
       ON CONFLICT (id) DO UPDATE SET
         display_name = EXCLUDED.display_name,
         granted_guarantees = EXCLUDED.granted_guarantees,
         credential_hash = EXCLUDED.credential_hash,
+        base_url = EXCLUDED.base_url,
+        upstream_credential_env = EXCLUDED.upstream_credential_env,
         enabled = EXCLUDED.enabled
     `;
   }
@@ -221,6 +228,11 @@ function toSupplier(row: Row): Supplier {
     displayName: String(row.display_name),
     grantedGuarantees: (row.granted_guarantees as string[]) ?? [],
     credentialHash: String(row.credential_hash),
+    baseUrl: String(row.base_url ?? ""),
+    upstreamCredentialEnv:
+      row.upstream_credential_env === null || row.upstream_credential_env === undefined
+        ? undefined
+        : String(row.upstream_credential_env),
     enabled: Boolean(row.enabled),
     createdAt: new Date(row.created_at as string),
   };

--- a/packages/exchange/src/testing/mock-upstream.ts
+++ b/packages/exchange/src/testing/mock-upstream.ts
@@ -1,0 +1,169 @@
+/**
+ * A mock OpenAI-compatible Supplier, for driving the buyer surface without a
+ * network or a GPU.
+ *
+ * Live providers are the wrong instrument for the cases that decide whether
+ * the Exchange behaves: an upstream that errors on demand, one that never
+ * finishes so the caller has to hang up, one that reports no usage at all.
+ * None of those can be provoked repeatably against a real API, so we serve
+ * them deliberately.
+ */
+
+import http from "node:http";
+
+export type UpstreamMode =
+  /** Streams tokens, then usage in the final chunk. The happy path. */
+  | "ok"
+  /** Streams tokens and never reports usage. Real providers do this. */
+  | "no-usage"
+  /** Streams slowly and forever, so the caller must abort. */
+  | "never-finishes"
+  /** Refuses with a 500 and an error body. */
+  | "error";
+
+export interface MockUpstream {
+  baseUrl: string;
+  /** Requests received, so a test can assert what actually went upstream. */
+  requests: { path: string; auth?: string; body: Record<string, unknown> }[];
+  /** Resolves once a request has been aborted by the caller. */
+  sawAbort: () => boolean;
+  close: () => Promise<void>;
+}
+
+const WORDS = ["The", " quick", " brown", " fox", " jumps", " over", " the", " lazy", " dog"];
+
+export const MOCK_PROMPT_TOKENS = 137;
+export const MOCK_COMPLETION_TOKENS = WORDS.length;
+
+function chunk(model: string, content: string) {
+  return {
+    id: "chatcmpl-mock",
+    object: "chat.completion.chunk",
+    created: 1,
+    model,
+    choices: [{ index: 0, delta: { content }, finish_reason: null }],
+  };
+}
+
+export async function startMockUpstream(mode: UpstreamMode = "ok"): Promise<MockUpstream> {
+  const requests: MockUpstream["requests"] = [];
+  let aborted = false;
+
+  const server = http.createServer(async (req, res) => {
+    const raw = await new Promise<string>((resolve) => {
+      let acc = "";
+      req.on("data", (c) => (acc += c));
+      req.on("end", () => resolve(acc));
+    });
+
+    let body: Record<string, unknown> = {};
+    try {
+      body = JSON.parse(raw || "{}");
+    } catch {
+      /* leave empty */
+    }
+    requests.push({ path: req.url ?? "", auth: req.headers.authorization, body });
+
+    if (mode === "error") {
+      res.writeHead(500, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: { message: "upstream exploded", type: "server_error" } }));
+      return;
+    }
+
+    const model = String(body.model ?? "mock-model");
+    const streaming = body.stream === true;
+
+    if (!streaming) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          id: "chatcmpl-mock",
+          object: "chat.completion",
+          created: 1,
+          model,
+          choices: [
+            { index: 0, message: { role: "assistant", content: WORDS.join("") }, finish_reason: "stop" },
+          ],
+          ...(mode === "no-usage"
+            ? {}
+            : {
+                usage: {
+                  prompt_tokens: MOCK_PROMPT_TOKENS,
+                  completion_tokens: MOCK_COMPLETION_TOKENS,
+                  total_tokens: MOCK_PROMPT_TOKENS + MOCK_COMPLETION_TOKENS,
+                },
+              }),
+        }),
+      );
+      return;
+    }
+
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+
+    // Detect a disconnect on both streams. A server notices a caller leaving
+    // when the socket dies, which surfaces on `res` — `req` may already have
+    // completed normally and stay quiet.
+    let closed = false;
+    const disconnected = () => {
+      closed = true;
+      if (mode === "never-finishes") aborted = true;
+    };
+    req.on("close", disconnected);
+    res.on("close", disconnected);
+    res.on("error", disconnected);
+
+    for (const word of WORDS) {
+      if (closed) return;
+      res.write(`data: ${JSON.stringify(chunk(model, word))}\n\n`);
+      await new Promise((r) => setTimeout(r, 15));
+    }
+
+    if (mode === "never-finishes") {
+      while (!closed) {
+        res.write(`data: ${JSON.stringify(chunk(model, " more"))}\n\n`);
+        await new Promise((r) => setTimeout(r, 15));
+      }
+      return;
+    }
+
+    res.write(
+      `data: ${JSON.stringify({
+        id: "chatcmpl-mock",
+        object: "chat.completion.chunk",
+        created: 1,
+        model,
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        ...(mode === "no-usage"
+          ? {}
+          : {
+              usage: {
+                prompt_tokens: MOCK_PROMPT_TOKENS,
+                completion_tokens: MOCK_COMPLETION_TOKENS,
+                total_tokens: MOCK_PROMPT_TOKENS + MOCK_COMPLETION_TOKENS,
+              },
+            }),
+      })}\n\n`,
+    );
+    res.write("data: [DONE]\n\n");
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    requests,
+    sawAbort: () => aborted,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections?.();
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/packages/exchange/src/types.ts
+++ b/packages/exchange/src/types.ts
@@ -66,6 +66,19 @@ export interface Supplier {
   grantedGuarantees: string[];
   /** sha256 of the bearer credential. The credential itself is never stored. */
   credentialHash: string;
+  /**
+   * Where the Exchange sends work. An OpenAI-compatible base URL, which covers
+   * a commercial vendor and a tunnelled on-prem box identically — the point of
+   * unifying them as one concept (ADR 0006).
+   */
+  baseUrl: string;
+  /**
+   * Name of the environment variable holding the credential we present *to*
+   * this Supplier. The name, not the secret: keeping upstream keys out of
+   * Postgres means a database compromise does not hand over every Supplier
+   * we buy from.
+   */
+  upstreamCredentialEnv?: string;
   enabled: boolean;
   createdAt: Date;
 }


### PR DESCRIPTION
Closes #294. The thinnest complete path through the Exchange — a request goes in, an Offer is selected, the response comes back — plus an entry point that boots and listens.

**Merging this unblocks #295 and #296.**

⚠️ **There is no authentication yet** (#295) and no metering (#297). Nothing from this stage should reach a public address before those land — right now the Exchange relays for anyone. That is the accepted cost of tracer-bullet ordering, not an oversight.

## Decisions

**`Supplier` gains `baseUrl` and `upstreamCredentialEnv`.** The env var *name*, not the secret. Keeping upstream keys out of Postgres means a database compromise doesn't hand over every provider we buy from — worth establishing before there are enough Suppliers for it to be a migration.

**`selectOffer` is a pure function**, deliberately naive: first enabled Offer for the model wins. #296 replaces the body with the Guarantee filter, Capability filter, and ranking by Charge — keeping it separate means that change touches one place and the handler stays still.

**"No eligible Offer" has its own status and code.** A caller must be able to tell it from an upstream failure, and later from being out of credit (#298). Conflating them makes all three undebuggable, which is exactly the kind of thing that gets conflated when the third case is added.

**Upstream errors are surfaced with their status preserved**, not dressed up as success — a caller needs to tell a rate limit from a bad request.

## Three things that cost time, recorded so they don't cost it again

**`req.on("close")` is not a disconnect signal.** It fires as soon as the request *body* has been read — before the response is even sent. Listening to it aborted the upstream controller immediately, which left the real disconnect with nothing to fire. Only `res.on("close")` means the caller left.

**Aborting the fetch signal isn't enough once the body is streaming.** The reader holds the socket open, so the upstream keeps generating. The relay installs a `reader.cancel()` as soon as it has a reader.

**The third diagnosis was the right one.** After both fixes the abort test still failed — because the *mock* was watching `req` for a disconnect, when a server notices a caller leaving on `res`. I'd guessed twice; instrumenting the actual event order found it in one pass. All three are commented at the point where someone would otherwise repeat them.

## Testing

The buyer tests run over a real socket rather than fabricated request objects, because what's under test is *relaying* — streaming, aborts, upstream failure — and a fake response object can't tell you whether chunks arrived incrementally or all at once. The streaming assertion is that more than one read completes; a single read means the response was buffered and handed over at the end, which isn't streaming whatever the content-type claims.

`src/testing/mock-upstream.ts` serves four modes: normal, no-usage, never-finishes, and error. The last two exist because a real provider can't be made to hang up or fail on cue.

## Verification

- `pnpm test:run` — 2108 tests, all passing (54 in this package, 17 new)
- `pnpm typecheck` and `pnpm lint` — clean
- `NeonStore` still unrun against real Postgres, unchanged from #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG)_