### PR TITLE
Let Gaia apply a habitat declaration from a repo

### DIFF
--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -12,6 +12,8 @@ import { sendA2AMessage } from "@umwelten/protocols";
 import { CapabilityResolver } from "../capability-resolver.js";
 import { seedOrgReadonly, seedStandardsAgent } from "../gaia-seed.js";
 import { type GaiaToolsContext, entryToEndpoint, discoverHabitats, entryOpenUrl } from "./context.js";
+import { applyHabitatDeclaration } from "../apply-declaration.js";
+import { readDeclarationFromRepo } from "../read-declaration.js";
 import { buildSeedFiles } from "./seed-files.js";
 
 export function createHabitatLifecycleTools(
@@ -407,6 +409,58 @@ export function createHabitatLifecycleTools(
 						? " Rebuild the habitat for changes to take effect."
 						: "";
 				return `Updated habitat "${id}": ${changes.join(", ")}.${hint}`;
+			},
+		}),
+
+		apply_habitat_declaration: tool({
+			description:
+				"Stand a habitat up from the habitat.json in its own repo (ADR 0006), creating it if it does not exist and updating it if it does. This is the sanctioned way to provision a repo-backed habitat — it reads the declaration and derives the GitHub read scope from the mounts it declares, so mounts and scopes cannot drift. Rebuild the habitat afterwards for the changes to reach a running container.",
+			inputSchema: z.object({
+				id: z.string().describe("Habitat id to create or update"),
+				gitUrl: z
+					.string()
+					.describe("The habitat's Owned repo — where habitat.json lives"),
+				gitBranch: z
+					.string()
+					.optional()
+					.describe("Branch to read the declaration from (default: the repo's default branch)"),
+			}),
+			execute: async ({ id, gitUrl, gitBranch }) => {
+				try {
+					// Ambient read: the narrowed scope is not knowable until the
+					// declaration has been read (ADR 0006's bootstrap circularity).
+					const ambient = await githubTokens?.tokenFor(
+						{ id, github: { read: "org" } },
+						"read",
+					);
+
+					const result = await applyHabitatDeclaration(registry, {
+						id,
+						gitUrl,
+						...(gitBranch ? { gitBranch } : {}),
+						readDeclaration: (url, ref) =>
+							readDeclarationFromRepo(url, ref, { token: ambient?.token }),
+					});
+
+					const read = result.entry.github?.read;
+					const scope = read === "org" ? "org-wide" : (read ?? []).join(", ");
+					const mounts = result.entry.config.agents
+						.filter((a) => (a.kind ?? "repo") === "repo" && a.mode === "read")
+						.map((a) => a.id);
+
+					return [
+						`${result.action === "created" ? "Created" : "Updated"} habitat "${id}" from ${gitUrl}.`,
+						`Mounts: ${mounts.length ? mounts.join(", ") : "(none)"}`,
+						`Derived read scope: ${scope || "(none)"}`,
+						result.entry.github?.write?.length
+							? `Write scope (declared, never derived): ${result.entry.github.write.join(", ")}`
+							: "Write scope: (none declared)",
+						`Rebuild "${id}" for this to reach a running container.`,
+					].join("\n");
+				} catch (err) {
+					// Nothing was registered — apply validates before it writes.
+					return `Could not apply the declaration for "${id}": ${err instanceof Error ? err.message : String(err)}`;
+				}
 			},
 		}),
 

--- a/packages/habitat/src/tools/gaia/read-declaration.test.ts
+++ b/packages/habitat/src/tools/gaia/read-declaration.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	DeclarationFetchError,
+	parseGitHubRepo,
+	readDeclarationFromRepo,
+} from "./read-declaration.js";
+
+const REPO = "https://github.com/The-Focus-AI/client-upperhand.git";
+
+function json(body: unknown, status = 200) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+const contents = (text: string) =>
+	json({ content: Buffer.from(text).toString("base64"), encoding: "base64" });
+
+describe("parseGitHubRepo", () => {
+	it.each([
+		["https://github.com/The-Focus-AI/client-upperhand.git", "client-upperhand"],
+		["https://github.com/The-Focus-AI/client-upperhand", "client-upperhand"],
+		["git@github.com:The-Focus-AI/client-upperhand.git", "client-upperhand"],
+		["ssh://git@github.com/The-Focus-AI/client-upperhand.git", "client-upperhand"],
+	])("parses %s", (url, repo) => {
+		expect(parseGitHubRepo(url)).toEqual({ owner: "The-Focus-AI", repo });
+	});
+
+	it.each(["", "   ", "nonsense", "https://github.com/only-owner"])(
+		"returns undefined for %s",
+		(url) => expect(parseGitHubRepo(url)).toBeUndefined(),
+	);
+});
+
+describe("readDeclarationFromRepo", () => {
+	it("returns the declaration", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(contents('{"name":"UpperHand"}'));
+		await expect(
+			readDeclarationFromRepo(REPO, undefined, { fetchImpl }),
+		).resolves.toBe('{"name":"UpperHand"}');
+	});
+
+	it("asks for habitat.json at the repo root", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(contents("{}"));
+		await readDeclarationFromRepo(REPO, undefined, { fetchImpl });
+		expect(String(fetchImpl.mock.calls[0][0])).toBe(
+			"https://api.github.com/repos/The-Focus-AI/client-upperhand/contents/habitat.json",
+		);
+	});
+
+	it("reads a named ref when asked", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(contents("{}"));
+		await readDeclarationFromRepo(REPO, "release", { fetchImpl });
+		expect(String(fetchImpl.mock.calls[0][0])).toContain("ref=release");
+	});
+
+	it("sends the ambient-read token", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(contents("{}"));
+		await readDeclarationFromRepo(REPO, undefined, { fetchImpl, token: "ghs_x" });
+		expect(fetchImpl.mock.calls[0][1].headers.authorization).toBe("Bearer ghs_x");
+	});
+
+	it("handles a plain-text response as well as base64", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(
+			json({ content: '{"name":"x"}', encoding: "none" }),
+		);
+		await expect(
+			readDeclarationFromRepo(REPO, undefined, { fetchImpl }),
+		).resolves.toBe('{"name":"x"}');
+	});
+
+	/**
+	 * GitHub answers 404 for "no such file" and for "no such repo, as far as
+	 * your token is concerned". Those need opposite fixes — add a declaration
+	 * versus install the App — so they must not read alike.
+	 */
+	it("returns undefined when the repo is visible but has no declaration", async () => {
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValueOnce(json({ message: "Not Found" }, 404))
+			.mockResolvedValueOnce(json({ name: "client-upperhand" }, 200));
+
+		await expect(
+			readDeclarationFromRepo(REPO, undefined, { fetchImpl }),
+		).resolves.toBeUndefined();
+	});
+
+	it("points at the App installation when the repo itself is invisible", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(json({ message: "Not Found" }, 404));
+		await expect(
+			readDeclarationFromRepo(REPO, undefined, { fetchImpl }),
+		).rejects.toThrow(/GitHub App is probably not installed/);
+	});
+
+	it("surfaces other HTTP failures rather than treating them as absent", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(json({}, 500));
+		await expect(
+			readDeclarationFromRepo(REPO, undefined, { fetchImpl }),
+		).rejects.toThrow(/HTTP 500/);
+	});
+
+	it("rejects a URL it cannot read a repo out of", async () => {
+		await expect(
+			readDeclarationFromRepo("nonsense", undefined, { fetchImpl: vi.fn() }),
+		).rejects.toThrow(DeclarationFetchError);
+	});
+
+	it("complains clearly when the path is a directory", async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(json([{ name: "a" }]));
+		await expect(
+			readDeclarationFromRepo(REPO, undefined, { fetchImpl }),
+		).rejects.toThrow(/no content field/);
+	});
+});

--- a/packages/habitat/src/tools/gaia/read-declaration.ts
+++ b/packages/habitat/src/tools/gaia/read-declaration.ts
@@ -1,0 +1,128 @@
+/**
+ * Reading a habitat's declaration out of its Owned repo.
+ *
+ * ADR 0006 leaves a bootstrap circularity: Gaia must read the repo to learn
+ * the scopes it needs a token to read it with. Cloning would make that worse —
+ * a working tree, a disk, and a full history for one small file.
+ *
+ * Fetching the single file over the contents API resolves it cleanly. The
+ * fetch runs under an **ambient-read** token (org-wide `contents: read`, which
+ * is what a declaration-less habitat's scope amounts to), and everything after
+ * it uses the scope derived from what it read. One request, no working tree,
+ * and the widest credential is used for the shortest possible moment.
+ */
+
+import { HABITAT_DECLARATION_FILE } from "./declaration.js";
+
+/** `https://github.com/owner/repo(.git)` or `git@github.com:owner/repo` → `owner/repo`. */
+export function parseGitHubRepo(
+	gitUrl: string,
+): { owner: string; repo: string } | undefined {
+	const trimmed = gitUrl.trim();
+	if (!trimmed) return undefined;
+
+	const ssh = /^[^@\s]+@[^:\s]+:(?<path>[^\s]+)$/.exec(trimmed);
+	let path = ssh?.groups?.path;
+	if (!path) {
+		try {
+			path = new URL(trimmed).pathname;
+		} catch {
+			return undefined;
+		}
+	}
+
+	const parts = path.replace(/\.git$/i, "").split("/").filter(Boolean);
+	if (parts.length < 2) return undefined;
+	const [owner, repo] = parts.slice(-2);
+	return { owner, repo };
+}
+
+export interface ReadDeclarationDeps {
+	/** Ambient-read installation token. */
+	token?: string;
+	fetchImpl?: typeof fetch;
+	/** GitHub API base, for GHE or tests. */
+	apiBase?: string;
+}
+
+export class DeclarationFetchError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "DeclarationFetchError";
+	}
+}
+
+/**
+ * Fetch `habitat.json` from a repo's default branch, or a named ref.
+ *
+ * Returns undefined when the file is absent — that is a normal answer, and
+ * the caller decides what to do about it. Everything else throws, because a
+ * repo the App cannot see and a repo with no declaration need very different
+ * fixes and must not look alike.
+ */
+export async function readDeclarationFromRepo(
+	gitUrl: string,
+	ref?: string,
+	deps: ReadDeclarationDeps = {},
+): Promise<string | undefined> {
+	const parsed = parseGitHubRepo(gitUrl);
+	if (!parsed) {
+		throw new DeclarationFetchError(
+			`Could not read a GitHub owner/repo out of "${gitUrl}".`,
+		);
+	}
+
+	const base = deps.apiBase ?? "https://api.github.com";
+	const url = new URL(
+		`/repos/${parsed.owner}/${parsed.repo}/contents/${HABITAT_DECLARATION_FILE}`,
+		base,
+	);
+	if (ref) url.searchParams.set("ref", ref);
+
+	const fetchImpl = deps.fetchImpl ?? fetch;
+	const res = await fetchImpl(url, {
+		headers: {
+			accept: "application/vnd.github+json",
+			"x-github-api-version": "2022-11-28",
+			...(deps.token ? { authorization: `Bearer ${deps.token}` } : {}),
+		},
+	});
+
+	if (res.status === 404) {
+		// GitHub answers 404 both for "no such file" and for "no such repo, as
+		// far as your token is concerned". Those need opposite fixes — add a
+		// declaration, versus install the App — so they must not read alike.
+		const repoRes = await fetchImpl(
+			new URL(`/repos/${parsed.owner}/${parsed.repo}`, base),
+			{
+				headers: {
+					accept: "application/vnd.github+json",
+					...(deps.token ? { authorization: `Bearer ${deps.token}` } : {}),
+				},
+			},
+		);
+		if (repoRes.status === 404) {
+			throw new DeclarationFetchError(
+				`Cannot see ${parsed.owner}/${parsed.repo}. If the repo exists and is private, the @habitats GitHub App is probably not installed on it — that is what a 404 looks like from here.`,
+			);
+		}
+		return undefined;
+	}
+
+	if (!res.ok) {
+		throw new DeclarationFetchError(
+			`GitHub returned HTTP ${res.status} reading ${HABITAT_DECLARATION_FILE} from ${parsed.owner}/${parsed.repo}.`,
+		);
+	}
+
+	const body = (await res.json()) as { content?: string; encoding?: string };
+	if (typeof body.content !== "string") {
+		throw new DeclarationFetchError(
+			`Unexpected contents-API response for ${HABITAT_DECLARATION_FILE} — no content field. Is it a directory?`,
+		);
+	}
+
+	return body.encoding === "base64"
+		? Buffer.from(body.content, "base64").toString("utf-8")
+		: body.content;
+}


### PR DESCRIPTION
Closes #315.

#282 built `applyHabitatDeclaration` but nothing called it. It was a library function with no caller, so standing a habitat up was still a human running scripts — which defeats the point of declaring the environment in the repo at all. This wires it to a Gaia tool.

## Reading the declaration

ADR 0006 leaves a bootstrap circularity: Gaia must read the repo to learn the scopes it needs a token to read that repo with. Cloning would make it worse — a working tree, a disk, and a full history for one small file.

`readDeclarationFromRepo()` fetches `habitat.json` over the GitHub contents API instead. One request under an **ambient-read** token (org-wide `contents: read`, which is what a declaration-less habitat's scope amounts to anyway), then everything after it runs on the scope *derived* from what was read. The widest credential is held for the shortest possible moment, and no write scope is ever derived — ADR 0004 blind spot #1 stays closed.

## Why the second request

GitHub answers 404 both for "no such file" and for "no such repo, as far as your token is concerned". Those need opposite fixes — add a declaration versus install the @habitats App — so a missing installation must not masquerade as a missing file. A follow-up request to the repo endpoint disambiguates:

- repo visible, no file → `undefined` (a normal answer; the caller decides)
- repo invisible → throws, pointing at the App installation
- any other status → throws with the status, rather than being read as absent

## Changes

- `packages/habitat/src/tools/gaia/read-declaration.ts` — `parseGitHubRepo`, `readDeclarationFromRepo`, `DeclarationFetchError`
- `packages/habitat/src/tools/gaia/read-declaration.test.ts` — 18 tests
- `packages/habitat/src/tools/gaia/gaia-tools/habitats.ts` — `apply_habitat_declaration` tool, minting the ambient-read token via `githubTokens?.tokenFor({ id, github: { read: "org" } }, "read")`

## Verification

- `pnpm test:run` — 172 files, 2109 tests passing
- `tsc --noEmit` clean across every package

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_