### PR TITLE
Wake a Dormant habitat when it is asked

### DIFF
--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -15,7 +15,40 @@ import { type GaiaToolsContext, entryToEndpoint, discoverHabitats, entryOpenUrl 
 import { applyHabitatDeclaration } from "../apply-declaration.js";
 import { readDeclarationFromRepo } from "../read-declaration.js";
 import { recordHabitatActivity } from "../reaper.js";
+import { HabitatWaker, createWakeTools } from "../waker.js";
 import { buildSeedFiles } from "./seed-files.js";
+
+/**
+ * The whole start path, in one place (#279).
+ *
+ * It used to live inline in `start_habitat`, which meant wake-on-ask would
+ * have had to duplicate it — and a second copy of "seed, mint boot tokens,
+ * run, record the port" is exactly the kind of thing that drifts until two
+ * ways of starting a habitat produce two different containers.
+ */
+export async function startHabitatContainer(
+	ctx: GaiaToolsContext,
+	id: string,
+): Promise<number> {
+	const { registry, vault, docker, catalog, githubTokens } = ctx;
+	const entry = registry.get(id);
+	if (!entry) throw new Error(`Habitat "${id}" not found`);
+
+	// Seed volume with fresh config + secrets
+	await docker.seedVolume(id, buildSeedFiles(entry, vault, catalog));
+
+	// Fresh GitHub boot tokens per start (ADR 0004; never throws —
+	// a GitHub outage degrades to a token-less boot, not a failure).
+	const bootTokens = await githubTokens?.bootTokensFor(entry);
+	const port = await docker.startContainer(entry, "", registry.list(), {
+		githubTokens: bootTokens,
+	});
+	await registry.update(id, { containerPort: port });
+	// A start counts as activity, so a habitat is not reaped in the
+	// window between being started and first being asked anything.
+	await recordHabitatActivity(registry, id);
+	return port;
+}
 
 export function createHabitatLifecycleTools(
 	ctx: GaiaToolsContext,
@@ -31,7 +64,14 @@ export function createHabitatLifecycleTools(
 		githubTokens,
 	} = ctx;
 
+	const waker = new HabitatWaker({
+		getEntry: (id) => registry.get(id),
+		getStatus: (id) => docker.getStatus(id),
+		start: (id) => startHabitatContainer(ctx, id),
+	});
+
 	return {
+		...createWakeTools(waker, { listIds: () => registry.list().map((h) => h.id) }),
 		list_habitats: tool({
 			description:
 				"List all registered habitats with their container status. Includes the web UI URL with auth token for running habitats.",
@@ -212,19 +252,12 @@ export function createHabitatLifecycleTools(
 				const entry = registry.get(id);
 				if (!entry) return `Habitat "${id}" not found`;
 
-				// Seed volume with fresh config + secrets
-				await docker.seedVolume(id, buildSeedFiles(entry, vault, catalog));
-
-				// Fresh GitHub boot tokens per start (ADR 0004; never throws —
-				// a GitHub outage degrades to a token-less boot, not a failure).
-				const bootTokens = await githubTokens?.bootTokensFor(entry);
-				const port = await docker.startContainer(entry, "", registry.list(), {
-					githubTokens: bootTokens,
-				});
-				await registry.update(id, { containerPort: port });
-				// A start counts as activity, so a habitat is not reaped in the
-				// window between being started and first being asked anything.
-				await recordHabitatActivity(registry, id);
+				// Through the waker so an explicit start and a wake-on-ask
+				// (#279) cannot race into two containers for one habitat.
+				const outcome = await waker.wake(id);
+				if (outcome.action === "failed") return outcome.detail;
+				const port = outcome.port;
+				if (port === undefined) return outcome.detail;
 
 				const warnings: string[] = [];
 				if (!entry.config.defaultProvider || !entry.config.defaultModel) {
@@ -309,15 +342,25 @@ export function createHabitatLifecycleTools(
 
 		ask_habitat: tool({
 			description:
-				"Send a message to a running habitat via A2A and get the response.",
+				"Send a message to a habitat via A2A and get the response. A dormant habitat is woken first, so this works whether or not it is running — expect the first question after a period of quiet to take longer.",
 			inputSchema: z.object({
 				id: z.string().describe("Habitat ID"),
 				message: z.string().describe("Message to send"),
 			}),
 			execute: async ({ id, message }) => {
+				// Wake on ask (#279). Once habitats sleep by design, "not
+				// running" is the normal state of most of the fleet, so
+				// refusing here would make sleeping look like breakage.
+				const wake = await waker.wake(id);
+				if (wake.action === "not-found" || wake.action === "failed") {
+					return wake.detail;
+				}
+
+				// Re-read: waking rewrote containerPort on the entry.
 				const entry = registry.get(id);
-				if (!entry) return `Habitat "${id}" not found`;
-				if (!entry.containerPort) return `Habitat "${id}" is not running`;
+				if (!entry?.containerPort) {
+					return `Habitat "${id}" started but is not reachable — no port recorded.`;
+				}
 
 				// Asking a habitat is the clearest form of using it (#278).
 				await recordHabitatActivity(registry, id).catch(() => {});

--- a/packages/habitat/src/tools/gaia/waker.test.ts
+++ b/packages/habitat/src/tools/gaia/waker.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from "vitest";
+import { HabitatWaker, isServing, type WakeContext } from "./waker.js";
+import type { ContainerStatus, GaiaHabitatEntry } from "./types.js";
+
+function entry(overrides: Partial<GaiaHabitatEntry> = {}): GaiaHabitatEntry {
+	return {
+		id: "upperhand",
+		name: "UpperHand",
+		config: {} as GaiaHabitatEntry["config"],
+		secretBindings: [],
+		createdAt: "2026-07-01T00:00:00.000Z",
+		...overrides,
+	} as GaiaHabitatEntry;
+}
+
+/** A waker over a fake fleet, with the knobs each test needs. */
+function makeWaker(opts: {
+	entries?: Record<string, GaiaHabitatEntry>;
+	status?: ContainerStatus | (() => Promise<ContainerStatus>);
+	start?: WakeContext["start"];
+} = {}) {
+	const entries = opts.entries ?? { upperhand: entry({ containerPort: undefined }) };
+	const getStatus = vi.fn(async (_id: string) => {
+		if (typeof opts.status === "function") return await opts.status();
+		return opts.status ?? ("exited" as ContainerStatus);
+	});
+	const start =
+		opts.start ??
+		vi.fn(async (id: string) => {
+			entries[id] = { ...entries[id], containerPort: 7440 };
+			return 7440;
+		});
+	const waker = new HabitatWaker({
+		getEntry: (id) => entries[id],
+		getStatus,
+		start,
+	});
+	return { waker, entries, getStatus, start: start as ReturnType<typeof vi.fn> };
+}
+
+describe("isServing", () => {
+	it("requires both a running container and a known port", () => {
+		expect(isServing("running", { containerPort: 7440 })).toBe(true);
+		expect(isServing("running", { containerPort: undefined })).toBe(false);
+		expect(isServing("exited", { containerPort: 7440 })).toBe(false);
+	});
+});
+
+describe("HabitatWaker", () => {
+	it("starts a dormant habitat rather than refusing it", async () => {
+		const { waker, start } = makeWaker({ status: "exited" });
+
+		const outcome = await waker.wake("upperhand");
+
+		expect(outcome.action).toBe("woken");
+		expect(outcome.port).toBe(7440);
+		expect(start).toHaveBeenCalledOnce();
+	});
+
+	it("leaves a running habitat alone", async () => {
+		const { waker, start } = makeWaker({
+			entries: { upperhand: entry({ containerPort: 7440 }) },
+			status: "running",
+		});
+
+		const outcome = await waker.wake("upperhand");
+
+		expect(outcome.action).toBe("already-running");
+		expect(outcome.port).toBe(7440);
+		expect(start).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * A container Docker calls running but whose port Gaia has lost is not
+	 * serving anything a caller can reach. Restarting is the only way to
+	 * learn the port again.
+	 */
+	it("restarts a running container whose port Gaia has lost track of", async () => {
+		const { waker, start } = makeWaker({
+			entries: { upperhand: entry({ containerPort: undefined }) },
+			status: "running",
+		});
+
+		const outcome = await waker.wake("upperhand");
+
+		expect(outcome.action).toBe("woken");
+		expect(start).toHaveBeenCalledOnce();
+	});
+
+	it("reports a habitat it does not know, without starting anything", async () => {
+		const { waker, start } = makeWaker();
+
+		const outcome = await waker.wake("nope");
+
+		expect(outcome.action).toBe("not-found");
+		expect(outcome.detail).toContain("not found");
+		expect(start).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * The acceptance criterion is that a failed start surfaces its reason so
+	 * the caller's Task can move to `failed`. A Task left pending against a
+	 * container that will never come up is worse than an error.
+	 */
+	it("reports why a start failed instead of throwing", async () => {
+		const { waker } = makeWaker({
+			status: "exited",
+			start: async () => {
+				throw new Error("no such image: habitat:latest");
+			},
+		});
+
+		const outcome = await waker.wake("upperhand");
+
+		expect(outcome.action).toBe("failed");
+		expect(outcome.detail).toContain("no such image");
+	});
+
+	it("reports a docker status probe that fails, without starting blindly", async () => {
+		const { waker, start } = makeWaker({
+			status: async () => {
+				throw new Error("docker daemon unreachable");
+			},
+		});
+
+		const outcome = await waker.wake("upperhand");
+
+		expect(outcome.action).toBe("failed");
+		expect(outcome.detail).toContain("docker daemon unreachable");
+		expect(start).not.toHaveBeenCalled();
+	});
+
+	describe("concurrency", () => {
+		it("starts one container when several callers ask at once", async () => {
+			let release!: () => void;
+			const gate = new Promise<void>((r) => {
+				release = r;
+			});
+			const start = vi.fn(async () => {
+				await gate;
+				return 7441;
+			});
+			const { waker } = makeWaker({ status: "exited", start });
+
+			const asks = [
+				waker.wake("upperhand"),
+				waker.wake("upperhand"),
+				waker.wake("upperhand"),
+			];
+			expect(waker.pendingCount).toBe(1);
+			release();
+			const outcomes = await Promise.all(asks);
+
+			expect(start).toHaveBeenCalledOnce();
+			// Every caller gets the same answer; the ones that joined say so.
+			expect(outcomes.every((o) => o.action === "woken")).toBe(true);
+			expect(outcomes.every((o) => o.port === 7441)).toBe(true);
+			expect(outcomes.filter((o) => o.coalesced).length).toBe(2);
+		});
+
+		it("does not coalesce wakes of different habitats", async () => {
+			const entries = {
+				a: entry({ id: "a", containerPort: undefined }),
+				b: entry({ id: "b", containerPort: undefined }),
+			};
+			const start = vi.fn(async () => 7442);
+			const { waker } = makeWaker({ entries, status: "exited", start });
+
+			await Promise.all([waker.wake("a"), waker.wake("b")]);
+
+			expect(start).toHaveBeenCalledTimes(2);
+		});
+
+		/**
+		 * A failed wake must not be remembered as failed. The operator may
+		 * have fixed the thing that broke it between one ask and the next.
+		 */
+		it("retries on the next ask after a failed wake", async () => {
+			let attempt = 0;
+			const start = vi.fn(async () => {
+				attempt += 1;
+				if (attempt === 1) throw new Error("port 7440 already allocated");
+				return 7443;
+			});
+			const { waker } = makeWaker({ status: "exited", start });
+
+			const first = await waker.wake("upperhand");
+			const second = await waker.wake("upperhand");
+
+			expect(first.action).toBe("failed");
+			expect(second.action).toBe("woken");
+			expect(second.port).toBe(7443);
+			expect(start).toHaveBeenCalledTimes(2);
+		});
+
+		it("holds nothing in flight once a wake settles", async () => {
+			const { waker } = makeWaker({ status: "exited" });
+
+			await waker.wake("upperhand");
+
+			expect(waker.pendingCount).toBe(0);
+		});
+
+		it("holds nothing in flight once a wake fails", async () => {
+			const { waker } = makeWaker({
+				status: "exited",
+				start: async () => {
+					throw new Error("boom");
+				},
+			});
+
+			await waker.wake("upperhand");
+
+			expect(waker.pendingCount).toBe(0);
+		});
+	});
+});

--- a/packages/habitat/src/tools/gaia/waker.ts
+++ b/packages/habitat/src/tools/gaia/waker.ts
@@ -1,0 +1,181 @@
+/**
+ * Wake a Dormant habitat when it is asked (umwelten #279).
+ *
+ * Once habitats sleep by design (ADR 0007), "Habitat X is not running" stops
+ * being an error and starts being the normal state of most of the fleet most
+ * of the time. Refusing the caller would make sleeping visible as a failure
+ * rather than as latency, which is the whole thing sleeping is supposed to
+ * avoid.
+ *
+ * So asking wakes. Two properties make that safe to do on every ask:
+ *
+ *  - **Wakes coalesce.** Five callers asking a sleeping habitat at once must
+ *    start one container, not five. An in-flight map keyed by habitat id
+ *    gives every concurrent caller the same promise. The entry is dropped in
+ *    a `finally`, so a failed wake is retried by the next ask rather than
+ *    being cached as broken forever.
+ *
+ *  - **A failed start is reported, not swallowed.** The outcome carries the
+ *    reason so the caller's Task can move to `failed` with something
+ *    actionable in it. A Task left pending on a container that will never
+ *    come up is worse than an error.
+ *
+ * Refreshing a stale habitat on wake is deliberately *not* implemented here.
+ * #276 put the stale mark on the habitat's own volume precisely so the
+ * habitat's provisioner promotes its own next start to a refresh and clears
+ * the mark afterwards. Doing it from this side would mean Gaia clearing a
+ * mark it cannot know was acted on — "I asked" recorded as "it happened".
+ */
+
+import type { Tool } from "ai";
+import { tool } from "ai";
+import { z } from "zod";
+import type { ContainerStatus, GaiaHabitatEntry } from "./types.js";
+
+export type WakeAction = "already-running" | "woken" | "not-found" | "failed";
+
+export interface WakeOutcome {
+	id: string;
+	action: WakeAction;
+	detail: string;
+	/** Host port the habitat is serving on. Absent unless it is up. */
+	port?: number;
+	/** True when this caller's ask joined a wake another caller had started. */
+	coalesced?: boolean;
+}
+
+/** True when a habitat in this container state can serve a request as-is. */
+export function isServing(
+	status: ContainerStatus,
+	entry: Pick<GaiaHabitatEntry, "containerPort">,
+): boolean {
+	return status === "running" && typeof entry.containerPort === "number";
+}
+
+/**
+ * The seam the tests inject.
+ *
+ * `start` is the whole start path — seeding, boot tokens, `docker run`,
+ * recording the port and the activity. Injecting at that altitude keeps this
+ * module about *when and how often* to start, not about how starting works.
+ */
+export interface WakeContext {
+	getEntry(id: string): GaiaHabitatEntry | undefined;
+	getStatus(id: string): Promise<ContainerStatus>;
+	start(id: string): Promise<number>;
+}
+
+export class HabitatWaker {
+	private readonly inFlight = new Map<string, Promise<WakeOutcome>>();
+
+	constructor(private readonly ctx: WakeContext) {}
+
+	/** How many wakes are running right now. Diagnostics and tests. */
+	get pendingCount(): number {
+		return this.inFlight.size;
+	}
+
+	/**
+	 * Ensure a habitat is serving, starting it if it is not.
+	 *
+	 * Never throws — a caller asking a habitat wants an answer about the
+	 * habitat, and turning "it would not boot" into an exception several
+	 * frames up makes that answer harder to give, not easier.
+	 */
+	async wake(id: string): Promise<WakeOutcome> {
+		const existing = this.inFlight.get(id);
+		if (existing) {
+			const outcome = await existing;
+			return { ...outcome, coalesced: true };
+		}
+
+		const run = this.doWake(id).finally(() => {
+			// Dropped whatever the outcome was. A habitat that failed to boot
+			// may boot on the next ask — the operator may have just fixed the
+			// thing that broke it — and a habitat that woke fine has nothing
+			// left in flight to join.
+			this.inFlight.delete(id);
+		});
+		this.inFlight.set(id, run);
+		return await run;
+	}
+
+	private async doWake(id: string): Promise<WakeOutcome> {
+		const entry = this.ctx.getEntry(id);
+		if (!entry) {
+			return { id, action: "not-found", detail: `Habitat "${id}" not found` };
+		}
+
+		let status: ContainerStatus;
+		try {
+			status = await this.ctx.getStatus(id);
+		} catch (err) {
+			return {
+				id,
+				action: "failed",
+				detail: `Could not determine container status for "${id}": ${reasonOf(err)}`,
+			};
+		}
+
+		if (isServing(status, entry)) {
+			return {
+				id,
+				action: "already-running",
+				detail: `Habitat "${id}" is already running.`,
+				port: entry.containerPort,
+			};
+		}
+
+		try {
+			const port = await this.ctx.start(id);
+			return {
+				id,
+				action: "woken",
+				detail: `Woke habitat "${id}" on port ${port}.`,
+				port,
+			};
+		} catch (err) {
+			return {
+				id,
+				action: "failed",
+				detail: `Habitat "${id}" failed to start: ${reasonOf(err)}`,
+			};
+		}
+	}
+}
+
+function reasonOf(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	return String(err);
+}
+
+/**
+ * A habitat that is running but has no recorded port is not serving — it is
+ * a container Gaia has lost track of. Restarting it is the only way to learn
+ * the port again, so it takes the wake path rather than the already-running
+ * one, which is what `isServing` encodes.
+ */
+export function createWakeTools(
+	waker: HabitatWaker,
+	deps: { listIds(): string[] },
+): Record<string, Tool> {
+	return {
+		wake_habitat: tool({
+			description:
+				"Ensure a habitat is running, starting it if it is dormant. Asking a habitat already does this, so call it explicitly only when you want it warm before a burst of questions. Concurrent calls for the same habitat start it once.",
+			inputSchema: z.object({
+				id: z.string().describe("Habitat ID to wake"),
+			}),
+			execute: async ({ id }) => {
+				const outcome = await waker.wake(id);
+				if (outcome.action === "not-found") {
+					const known = deps.listIds();
+					return known.length
+						? `${outcome.detail}. Known habitats: ${known.join(", ")}`
+						: outcome.detail;
+				}
+				return outcome.detail;
+			},
+		}),
+	};
+}


### PR DESCRIPTION
Closes #279.

Once habitats sleep by design (ADR 0007), `Habitat "X" is not running` stops being an error and becomes the normal state of most of the fleet most of the time — including the first question of almost every day. Refusing there makes sleeping visible as breakage, which is exactly what sleeping is meant to avoid. So asking wakes.

## What makes waking-on-every-ask safe

**Wakes coalesce.** Five callers asking one sleeping habitat at once must start one container, not five. An in-flight map keyed by habitat id hands every concurrent caller the same promise. The entry is dropped in a `finally`, so a failed wake is retried by the next ask rather than cached as broken — the operator may have fixed the thing that broke it in between.

**A failed start is reported, not swallowed.** The outcome carries the reason so the caller's Task moves to `failed` with something actionable in it; a Task left pending against a container that will never come up is worse than an error. `wake()` therefore never throws, and a docker status probe that *itself* fails is reported rather than treated as licence to start blindly.

A container Docker calls `running` but whose port Gaia has lost is treated as **not serving** — nothing a caller holds can reach it, and restarting is the only way to learn the port again. That is what `isServing()` encodes.

## Two deliberate non-changes

**Refreshing a stale habitat on wake is not done from this side.** #276 put the stale mark on the habitat's *own volume* precisely so the habitat's provisioner promotes its own next start to a refresh and clears the mark afterwards. Clearing it from Gaia would record "I asked" as "it happened" — the distinction that placement exists to preserve. The acceptance criterion is met by #276's mechanism, not by new code here.

**No new caller-side concept for "Task in a non-terminal state without waiting for boot."** Gaia serves over A2A with the durable task store (#267) and non-blocking send (#268), so the caller already holds a Task id while this tool runs. Per ADR 0007 a Dormant habitat is not a special case — it is a Task that takes longer to reach `working`, which is why that criterion needed nothing new.

## Incidental change worth reviewing

`start_habitat` now goes through the waker too, so an explicit start racing a wake-on-ask cannot produce two containers for one habitat. Its start path moved to `startHabitatContainer()` rather than being copied — two ways of starting a habitat drift until they produce two different containers.

## Verification

12 new tests covering every acceptance criterion, including the concurrency ones (one start for three simultaneous asks; no coalescing across different habitats; retry after failure; nothing left in flight on either path).

- `pnpm test:run` — 184 files, 2263 tests passing
- `tsc --noEmit` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_