### PR TITLE
Every answer carries its checkout commit and age

### DIFF
--- a/packages/habitat/src/a2a-handler.test.ts
+++ b/packages/habitat/src/a2a-handler.test.ts
@@ -174,14 +174,33 @@ describe("HabitatAgentExecutor — execute", () => {
 
 		const final = events.find((e) => e.kind === "message");
 		expect(final).toBeDefined();
-		expect(final!.metadata).toEqual({
+		expect(final!.metadata).toMatchObject({
 			usage: { promptTokens: 42, completionTokens: 7, totalTokens: 49 },
 			provider: "google",
 			model: "gemini-3-flash-preview",
 		});
 	});
 
-	it("omits metadata when the bridge result has none (non-default runtimes)", async () => {
+	/**
+	 * #277: every answer carries what it was computed from, so metadata is no
+	 * longer optional — a habitat with nothing checked out reports an empty
+	 * repo list, which is a claim, not an absence.
+	 */
+	it("carries provenance on every answer, even one with no repos", async () => {
+		const executor = new HabitatAgentExecutor(await makeHost(), instantBridge());
+		const { bus, events } = fakeEventBus();
+
+		await executor.execute(requestContext(), bus);
+
+		const final = events.find((e) => e.kind === "message");
+		expect(final!.metadata?.provenance).toMatchObject({
+			stale: false,
+			repos: [],
+		});
+		expect(final!.metadata?.provenance?.capturedAt).toEqual(expect.any(String));
+	});
+
+	it("omits usage when the bridge result has none (non-default runtimes)", async () => {
 		const bridge = {
 			handleMessage: async (msg: ChannelMessage, events: BridgeEventHandlers) => {
 				await events.onDone({
@@ -197,7 +216,9 @@ describe("HabitatAgentExecutor — execute", () => {
 		await executor.execute(requestContext(), bus);
 
 		const final = events.find((e) => e.kind === "message");
-		expect(final!.metadata).toBeUndefined();
+		expect(final!.metadata?.usage).toBeUndefined();
+		expect(final!.metadata?.provider).toBeUndefined();
+		expect(final!.metadata?.model).toBeUndefined();
 	});
 });
 

--- a/packages/habitat/src/a2a-handler.ts
+++ b/packages/habitat/src/a2a-handler.ts
@@ -48,6 +48,12 @@ import {
   uiResourceToA2APart,
   UI_OUTPUT_MODE,
 } from "./ui-resources.js";
+import {
+  ProvenanceCache,
+  readHabitatProvenance,
+  type HabitatProvenance,
+} from "./provision/provenance.js";
+import { realProvenanceProbe } from "./provision/provenance-probe.js";
 import { getSpeaker } from "./identity/agent-speaker-context.js";
 import { withInboundAgentCallChain } from "./identity/agent-call-context.js";
 import {
@@ -286,6 +292,14 @@ export class HabitatAgentExecutor implements AgentExecutor {
    */
   private resolvePublicOrigin?: () => string | undefined;
 
+  /**
+   * What this habitat's answers are computed from (#277). Cached because it
+   * goes on every answer and reading it shells out to git once per repo —
+   * for the rollup habitat, the one with the most mounts, that is the
+   * difference between a fact and a cost.
+   */
+  private provenance: ProvenanceCache;
+
   constructor(
     habitat: AgentHost,
     bridge: ChannelBridge,
@@ -294,6 +308,27 @@ export class HabitatAgentExecutor implements AgentExecutor {
     this.habitat = habitat;
     this.bridge = bridge;
     this.resolvePublicOrigin = resolvePublicOrigin;
+    this.provenance = new ProvenanceCache(() =>
+      readHabitatProvenance({
+        workDir: habitat.getWorkDir(),
+        config: habitat.getConfig(),
+        probe: realProvenanceProbe,
+      }),
+    );
+  }
+
+  /**
+   * Never throws: provenance is context on a result, not the result. A
+   * habitat that cannot describe its checkout must still be able to answer —
+   * the caller then sees provenance absent, which is itself informative and
+   * distinct from provenance claiming everything is current.
+   */
+  private async readProvenance(): Promise<HabitatProvenance | undefined> {
+    try {
+      return await this.provenance.get();
+    } catch {
+      return undefined;
+    }
   }
 
   async execute(
@@ -418,6 +453,17 @@ export class HabitatAgentExecutor implements AgentExecutor {
                 }
               : undefined;
 
+            // What this answer was computed from (#277). Structured, on the
+            // same metadata channel as usage, because prose provenance gets
+            // summarised away by the next model in the chain — and a rollup
+            // that cannot tell a current habitat from a three-week-stale one
+            // is confidently wrong in a way nobody notices.
+            const provenance = await this.readProvenance();
+            const answerMetadata =
+              usageMetadata || provenance
+                ? { ...usageMetadata, ...(provenance ? { provenance } : {}) }
+                : undefined;
+
             // Artifacts BEFORE the final message: the A2A transport treats the
             // agent message as the stream's terminal event, so anything
             // published after it never reaches the wire (verified against the
@@ -450,7 +496,7 @@ export class HabitatAgentExecutor implements AgentExecutor {
               parts: responseParts,
               contextId,
               taskId,
-              ...(usageMetadata ? { metadata: usageMetadata } : {}),
+              ...(answerMetadata ? { metadata: answerMetadata } : {}),
             } satisfies A2AMessage);
 
             eventBus.finished();

--- a/packages/habitat/src/index.ts
+++ b/packages/habitat/src/index.ts
@@ -66,6 +66,21 @@ export type {
 	ProvisionResult,
 } from "./provision/execute.js";
 export { COSTLY_STEP_KINDS } from "./provision/types.js";
+// Where an answer came from (#277). Consumers that aggregate across habitats
+// — the operations rollup, the control plane workstream — read this to decide
+// whether an answer is fit to combine, so it has to be reachable from outside.
+export {
+	readHabitatProvenance,
+	describeProvenance,
+	ProvenanceCache,
+} from "./provision/provenance.js";
+export { realProvenanceProbe } from "./provision/provenance-probe.js";
+export type {
+	HabitatProvenance,
+	RepoProvenance,
+	RepoRole,
+	ProvenanceProbe,
+} from "./provision/provenance.js";
 export type {
 	ProvisionIntent,
 	ProvisionMode,

--- a/packages/habitat/src/provision/provenance-probe.ts
+++ b/packages/habitat/src/provision/provenance-probe.ts
@@ -1,0 +1,77 @@
+/**
+ * The real volume probe behind `readHabitatProvenance` (umwelten #277).
+ *
+ * Split from `provenance.ts` for the same reason `volume-state.ts` is split
+ * from `plan.ts`: the shape of a provenance record is worth testing against
+ * literals, and nothing here is.
+ *
+ * Every read is local. `rev-parse` and `log -1` read the object database;
+ * the refresh time comes from the mtime of `FETCH_HEAD`, which git touches on
+ * every fetch and pull whether or not anything came back — that "we checked
+ * and there was nothing" case is exactly the one a rollup needs to be able to
+ * distinguish from "we never checked". A repo cloned and never fetched has no
+ * `FETCH_HEAD`, so it falls back to the mtime of `.git`, which is its clone
+ * time.
+ */
+
+import { execFile } from "node:child_process";
+import { stat, readFile as fsReadFile } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { fileExists } from "../config.js";
+import type { ProvenanceProbe } from "./provenance.js";
+
+const run = promisify(execFile);
+
+/** Git commands are read-only and local; a hung one must not hang an answer. */
+const GIT_TIMEOUT_MS = 5_000;
+
+async function git(dir: string, args: string[]): Promise<string | undefined> {
+	try {
+		const { stdout } = await run("git", ["-C", dir, ...args], {
+			timeout: GIT_TIMEOUT_MS,
+		});
+		const out = stdout.trim();
+		return out.length > 0 ? out : undefined;
+	} catch {
+		// A repo that cannot be read reports as unknown rather than failing
+		// the answer. Provenance is context on a result, not the result.
+		return undefined;
+	}
+}
+
+async function mtime(path: string): Promise<string | undefined> {
+	try {
+		return (await stat(path)).mtime.toISOString();
+	} catch {
+		return undefined;
+	}
+}
+
+export const realProvenanceProbe: ProvenanceProbe = {
+	exists: fileExists,
+
+	async readFile(path) {
+		try {
+			return await fsReadFile(path, "utf-8");
+		} catch {
+			return undefined;
+		}
+	},
+
+	headCommit(dir) {
+		return git(dir, ["rev-parse", "HEAD"]);
+	},
+
+	async headCommittedAt(dir) {
+		// %cI is strict ISO 8601 — no locale, no parsing ambiguity.
+		return await git(dir, ["log", "-1", "--format=%cI"]);
+	},
+
+	async lastFetchedAt(dir) {
+		return (
+			(await mtime(join(dir, ".git", "FETCH_HEAD"))) ??
+			(await mtime(join(dir, ".git")))
+		);
+	},
+};

--- a/packages/habitat/src/provision/provenance.test.ts
+++ b/packages/habitat/src/provision/provenance.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	ProvenanceCache,
+	describeProvenance,
+	readHabitatProvenance,
+	type HabitatProvenance,
+	type ProvenanceProbe,
+} from "./provenance.js";
+import { STALE_MARKER_FILE } from "./stale.js";
+import type { HabitatConfig } from "../types.js";
+
+const WORK = "/habitat";
+const NOW = new Date("2026-07-28T12:00:00.000Z");
+
+/**
+ * A fake volume. `repos` maps a checkout directory to what git would say
+ * about it; anything not listed is not cloned.
+ */
+function probeFor(opts: {
+	repos?: Record<
+		string,
+		{ commit?: string; committedAt?: string; fetchedAt?: string }
+	>;
+	staleMark?: string | false;
+}): ProvenanceProbe {
+	const repos = opts.repos ?? {};
+	const markPath = `${WORK}/${STALE_MARKER_FILE}`;
+	const dirOf = (gitPath: string) => gitPath.replace(/\/\.git$/, "");
+
+	return {
+		exists: vi.fn(async (path: string) => {
+			if (path === markPath) return opts.staleMark !== false && opts.staleMark !== undefined;
+			if (path.endsWith("/.git")) return dirOf(path) in repos;
+			return false;
+		}),
+		readFile: vi.fn(async (path: string) =>
+			path === markPath && typeof opts.staleMark === "string"
+				? opts.staleMark
+				: undefined,
+		),
+		headCommit: vi.fn(async (dir: string) => repos[dir]?.commit),
+		headCommittedAt: vi.fn(async (dir: string) => repos[dir]?.committedAt),
+		lastFetchedAt: vi.fn(async (dir: string) => repos[dir]?.fetchedAt),
+	};
+}
+
+function config(overrides: Partial<HabitatConfig> = {}): HabitatConfig {
+	return {
+		name: "upperhand",
+		gitUrl: "https://github.com/The-Focus-AI/client-upperhand.git",
+		...overrides,
+	} as HabitatConfig;
+}
+
+const read = (cfg: HabitatConfig, probe: ProvenanceProbe) =>
+	readHabitatProvenance({ workDir: WORK, config: cfg, probe, now: () => NOW });
+
+describe("readHabitatProvenance", () => {
+	it("reports the Owned repo's commit and when it was last refreshed", async () => {
+		const probe = probeFor({
+			repos: {
+				[`${WORK}/project`]: {
+					commit: "a".repeat(40),
+					committedAt: "2026-07-20T09:00:00.000Z",
+					fetchedAt: "2026-07-27T12:00:00.000Z",
+				},
+			},
+		});
+
+		const p = await read(config(), probe);
+
+		expect(p.repos).toHaveLength(1);
+		expect(p.repos[0]).toMatchObject({
+			id: "owned",
+			role: "owned",
+			present: true,
+			commit: "a".repeat(40),
+			committedAt: "2026-07-20T09:00:00.000Z",
+			refreshedAt: "2026-07-27T12:00:00.000Z",
+			refreshedAgeSeconds: 86_400,
+		});
+		expect(p.capturedAt).toBe(NOW.toISOString());
+	});
+
+	it("reports the same for each Mounted repo", async () => {
+		const cfg = config({
+			agents: [
+				{ id: "api", gitRemote: "https://github.com/x/api.git", mode: "read" },
+				{ id: "web", gitRemote: "https://github.com/x/web.git", mode: "read" },
+			],
+		} as Partial<HabitatConfig>);
+		const probe = probeFor({
+			repos: {
+				[`${WORK}/project`]: { commit: "a".repeat(40), fetchedAt: NOW.toISOString() },
+				[`${WORK}/agents/api/repo`]: {
+					commit: "b".repeat(40),
+					fetchedAt: "2026-07-28T11:00:00.000Z",
+				},
+				[`${WORK}/agents/web/repo`]: {
+					commit: "c".repeat(40),
+					fetchedAt: "2026-07-21T12:00:00.000Z",
+				},
+			},
+		});
+
+		const p = await read(cfg, probe);
+
+		const mounted = p.repos.filter((r) => r.role === "mounted");
+		expect(mounted.map((r) => r.id)).toEqual(["api", "web"]);
+		expect(mounted[0].refreshedAgeSeconds).toBe(3_600);
+		expect(mounted[1].refreshedAgeSeconds).toBe(7 * 86_400);
+		expect(mounted[0].gitRemote).toBe("https://github.com/x/api.git");
+	});
+
+	it("says so explicitly when a refresh is owed, with when it was marked", async () => {
+		const probe = probeFor({
+			repos: { [`${WORK}/project`]: { commit: "a".repeat(40) } },
+			staleMark: "2026-07-28T06:30:00.000Z\n",
+		});
+
+		const p = await read(config(), probe);
+
+		expect(p.stale).toBe(true);
+		expect(p.staleSince).toBe("2026-07-28T06:30:00.000Z");
+	});
+
+	/** The mark's presence is the signal; its contents are a courtesy. */
+	it("is still stale when the mark's body is empty or unparseable", async () => {
+		for (const body of ["", "   ", "not a date"]) {
+			const p = await read(
+				config(),
+				probeFor({ repos: {}, staleMark: body }),
+			);
+			expect(p.stale).toBe(true);
+			expect(p.staleSince).toBeUndefined();
+		}
+	});
+
+	it("is not stale when no mark is present", async () => {
+		const p = await read(config(), probeFor({ staleMark: false }));
+		expect(p.stale).toBe(false);
+	});
+
+	it("reports provenance without error for a habitat with no Mounted repos", async () => {
+		const probe = probeFor({
+			repos: { [`${WORK}/project`]: { commit: "a".repeat(40) } },
+		});
+
+		const p = await read(config({ agents: [] } as Partial<HabitatConfig>), probe);
+
+		expect(p.repos).toHaveLength(1);
+		expect(p.repos[0].role).toBe("owned");
+	});
+
+	it("reports a habitat with no repos at all rather than failing", async () => {
+		const p = await read(
+			config({ gitUrl: undefined } as Partial<HabitatConfig>),
+			probeFor({}),
+		);
+		expect(p.repos).toEqual([]);
+		expect(p.stale).toBe(false);
+	});
+
+	/**
+	 * A rollup that silently skips a repo it was told about is the exact
+	 * failure this ticket exists to prevent, so a declared-but-absent repo
+	 * is reported rather than omitted.
+	 */
+	it("reports a declared repo that is not checked out", async () => {
+		const cfg = config({
+			agents: [{ id: "api", gitRemote: "https://github.com/x/api.git", mode: "read" }],
+		} as Partial<HabitatConfig>);
+
+		const p = await read(cfg, probeFor({ repos: {} }));
+
+		expect(p.repos.map((r) => [r.id, r.present])).toEqual([
+			["owned", false],
+			["api", false],
+		]);
+	});
+
+	/** Credential-only agents (ADR 0006) have no checkout to date. */
+	it("ignores agents that declare no remote", async () => {
+		const cfg = config({
+			agents: [
+				{ id: "creds", kind: "credential-only" },
+				{ id: "api", gitRemote: "https://github.com/x/api.git", mode: "read" },
+			],
+		} as Partial<HabitatConfig>);
+
+		const p = await read(cfg, probeFor({ repos: {} }));
+
+		expect(p.repos.map((r) => r.id)).toEqual(["owned", "api"]);
+	});
+
+	it("never reaches the network — the probe is the only thing it can touch", async () => {
+		const probe = probeFor({ repos: { [`${WORK}/project`]: { commit: "a" } } });
+		await read(config(), probe);
+		// Every method used is a local read; there is no fetch seam to call.
+		expect(Object.keys(probe)).toEqual([
+			"exists",
+			"readFile",
+			"headCommit",
+			"headCommittedAt",
+			"lastFetchedAt",
+		]);
+	});
+
+	it("clamps a refresh time in the future to zero rather than going negative", async () => {
+		const probe = probeFor({
+			repos: {
+				[`${WORK}/project`]: { commit: "a", fetchedAt: "2026-07-28T13:00:00.000Z" },
+			},
+		});
+
+		const p = await read(config(), probe);
+
+		expect(p.repos[0].refreshedAgeSeconds).toBe(0);
+	});
+});
+
+describe("describeProvenance", () => {
+	const base: HabitatProvenance = {
+		capturedAt: NOW.toISOString(),
+		stale: false,
+		repos: [
+			{
+				id: "owned",
+				role: "owned",
+				present: true,
+				commit: "abcdef1234567890",
+				refreshedAgeSeconds: 7 * 86_400,
+			},
+		],
+	};
+
+	it("leads with the stale warning when a refresh is owed", () => {
+		const text = describeProvenance({
+			...base,
+			stale: true,
+			staleSince: "2026-07-28T06:30:00.000Z",
+		});
+		expect(text.split("\n")[0]).toContain("STALE");
+		expect(text).toContain("2026-07-28T06:30:00.000Z");
+	});
+
+	it("abbreviates the commit and the age", () => {
+		expect(describeProvenance(base)).toContain("abcdef12, refreshed 7d ago");
+	});
+
+	it("says a declared repo is not checked out", () => {
+		const text = describeProvenance({
+			...base,
+			repos: [{ id: "api", role: "mounted", present: false }],
+		});
+		expect(text).toContain("declared but not checked out");
+	});
+
+	it("handles a habitat with no repos", () => {
+		expect(describeProvenance({ ...base, repos: [] })).toContain(
+			"answers from no checkout",
+		);
+	});
+});
+
+describe("ProvenanceCache", () => {
+	const value = (n: number): HabitatProvenance => ({
+		capturedAt: `2026-07-28T12:00:0${n}.000Z`,
+		stale: false,
+		repos: [],
+	});
+
+	it("collapses repeated reads inside the TTL", async () => {
+		let n = 0;
+		const read = vi.fn(async () => value(n++));
+		let clock = 1_000;
+		const cache = new ProvenanceCache(read, 30_000, () => clock);
+
+		const a = await cache.get();
+		clock += 29_000;
+		const b = await cache.get();
+
+		expect(read).toHaveBeenCalledOnce();
+		expect(b).toBe(a);
+	});
+
+	it("reads again once the TTL has passed", async () => {
+		let n = 0;
+		const read = vi.fn(async () => value(n++));
+		let clock = 1_000;
+		const cache = new ProvenanceCache(read, 30_000, () => clock);
+
+		await cache.get();
+		clock += 30_001;
+		await cache.get();
+
+		expect(read).toHaveBeenCalledTimes(2);
+	});
+
+	/** After a refresh the old answer is a lie, so it must not be served. */
+	it("reads again after being invalidated", async () => {
+		let n = 0;
+		const read = vi.fn(async () => value(n++));
+		const cache = new ProvenanceCache(read, 30_000, () => 1_000);
+
+		await cache.get();
+		cache.invalidate();
+		await cache.get();
+
+		expect(read).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/habitat/src/provision/provenance.ts
+++ b/packages/habitat/src/provision/provenance.ts
@@ -1,0 +1,251 @@
+/**
+ * Where an answer came from (umwelten #277).
+ *
+ * Separating start from refresh (#276) means a habitat can legitimately
+ * answer from a checkout that is days old. That is usually fine and
+ * occasionally catastrophic: a changelog assembled across fifteen client
+ * habitats where three were quietly three weeks stale is confidently
+ * incorrect in a way nobody notices — the rollup reads as complete because
+ * every habitat answered.
+ *
+ * So every answer carries what it was computed from: the commit each repo is
+ * on, when that checkout was last brought up to date, and whether a refresh
+ * is already known to be owed. Consumers decide what to do with it. That is
+ * what gives the operations habitat grounds to refuse to publish a rollup at
+ * all (operations#3) and what the control plane surfaces (habitats#117).
+ *
+ * Two constraints shape the implementation:
+ *
+ *  - **No network.** Provenance is about what this checkout *is*, not how far
+ *    behind upstream it is. Asking GitHub would make every answer depend on
+ *    GitHub being up, and would turn a cheap fact into a rate-limited one.
+ *    Everything here reads the volume.
+ *
+ *  - **Machine-readable first.** Prose provenance gets summarised away by the
+ *    next model in the chain. The structured record is the contract;
+ *    `describeProvenance()` exists for humans reading a transcript, not for
+ *    callers deciding whether to trust an answer.
+ */
+
+import { join } from "node:path";
+import { normalizeAgents } from "./plan.js";
+import { staleMarkerPath } from "./stale.js";
+import type { HabitatConfig } from "../types.js";
+
+export type RepoRole = "owned" | "mounted";
+
+export interface RepoProvenance {
+	/** `owned` for the Owned repo, otherwise the agent id. */
+	id: string;
+	role: RepoRole;
+	/** False when the repo is declared but not on the volume yet. */
+	present: boolean;
+	gitRemote?: string;
+	branch?: string;
+	/** Full SHA of HEAD. */
+	commit?: string;
+	/** ISO commit date of HEAD — how old the *code* is. */
+	committedAt?: string;
+	/** ISO time this checkout was last brought up to date. */
+	refreshedAt?: string;
+	/** Seconds since `refreshedAt`, for callers that would rather not do date maths. */
+	refreshedAgeSeconds?: number;
+}
+
+export interface HabitatProvenance {
+	capturedAt: string;
+	/**
+	 * A refresh is known to be owed — #276 left a stale mark and the habitat
+	 * has not yet acted on it. Distinct from "old": a checkout can be weeks
+	 * old and perfectly current if nothing upstream moved.
+	 */
+	stale: boolean;
+	/** ISO time the stale mark was written, when it says. */
+	staleSince?: string;
+	repos: RepoProvenance[];
+}
+
+/** The seam: everything that touches the volume, injectable for tests. */
+export interface ProvenanceProbe {
+	exists(path: string): Promise<boolean>;
+	readFile(path: string): Promise<string | undefined>;
+	/** Full SHA of HEAD in `dir`, or undefined if it cannot be read. */
+	headCommit(dir: string): Promise<string | undefined>;
+	/** ISO commit date of HEAD in `dir`. */
+	headCommittedAt(dir: string): Promise<string | undefined>;
+	/** ISO time `dir` was last fetched into. */
+	lastFetchedAt(dir: string): Promise<string | undefined>;
+}
+
+export interface ReadProvenanceInput {
+	workDir: string;
+	config: HabitatConfig;
+	probe: ProvenanceProbe;
+	now?: () => Date;
+}
+
+async function readRepo(
+	probe: ProvenanceProbe,
+	now: Date,
+	base: Pick<RepoProvenance, "id" | "role" | "gitRemote" | "branch">,
+	dir: string,
+): Promise<RepoProvenance> {
+	if (!(await probe.exists(join(dir, ".git")))) {
+		// Declared but not cloned. Reported rather than omitted: a rollup
+		// that silently skips a repo it was told about is the failure mode
+		// this ticket exists to prevent.
+		return { ...base, present: false };
+	}
+
+	const [commit, committedAt, refreshedAt] = await Promise.all([
+		probe.headCommit(dir),
+		probe.headCommittedAt(dir),
+		probe.lastFetchedAt(dir),
+	]);
+
+	return {
+		...base,
+		present: true,
+		commit,
+		committedAt,
+		refreshedAt,
+		refreshedAgeSeconds: refreshedAt
+			? Math.max(0, Math.floor((now.getTime() - Date.parse(refreshedAt)) / 1000))
+			: undefined,
+	};
+}
+
+export async function readHabitatProvenance(
+	input: ReadProvenanceInput,
+): Promise<HabitatProvenance> {
+	const { workDir, config, probe } = input;
+	const now = input.now?.() ?? new Date();
+
+	const marker = staleMarkerPath(workDir);
+	const staleBody = (await probe.exists(marker))
+		? await probe.readFile(marker)
+		: undefined;
+	const stale = staleBody !== undefined;
+
+	const repos: RepoProvenance[] = [];
+
+	if (config.gitUrl) {
+		repos.push(
+			await readRepo(
+				probe,
+				now,
+				{
+					id: "owned",
+					role: "owned",
+					gitRemote: config.gitUrl,
+					branch: config.gitBranch,
+				},
+				join(workDir, config.projectDir ?? "project"),
+			),
+		);
+	}
+
+	// Mounted repos are the agents with a remote. An agent without one is a
+	// credential-only entry (ADR 0006) — there is no checkout to date.
+	const mounts = normalizeAgents(config.agents).filter((a) => a.gitRemote);
+	const mounted = await Promise.all(
+		mounts.map((agent) =>
+			readRepo(
+				probe,
+				now,
+				{
+					id: agent.id,
+					role: "mounted",
+					gitRemote: agent.gitRemote,
+					branch: agent.gitBranch,
+				},
+				join(workDir, "agents", agent.id, "repo"),
+			),
+		),
+	);
+	repos.push(...mounted);
+
+	return {
+		capturedAt: now.toISOString(),
+		stale,
+		// The mark's body is the ISO time it was written (#276). An empty or
+		// unparseable body still means stale — the mark's presence is the
+		// signal, its contents are a courtesy.
+		...(stale && staleBody?.trim() && !Number.isNaN(Date.parse(staleBody.trim()))
+			? { staleSince: new Date(staleBody.trim()).toISOString() }
+			: {}),
+		repos,
+	};
+}
+
+/** Human-readable summary, for transcripts. The structured record is the contract. */
+export function describeProvenance(p: HabitatProvenance): string {
+	const lines: string[] = [];
+	if (p.stale) {
+		lines.push(
+			p.staleSince
+				? `STALE: a refresh has been owed since ${p.staleSince} and has not run yet.`
+				: "STALE: a refresh is owed and has not run yet.",
+		);
+	}
+	if (p.repos.length === 0) {
+		lines.push("No repos declared — this habitat answers from no checkout.");
+		return lines.join("\n");
+	}
+	for (const r of p.repos) {
+		if (!r.present) {
+			lines.push(`${r.id} (${r.role}): declared but not checked out.`);
+			continue;
+		}
+		const short = r.commit?.slice(0, 8) ?? "unknown";
+		const age =
+			r.refreshedAgeSeconds === undefined
+				? "refresh time unknown"
+				: `refreshed ${formatAge(r.refreshedAgeSeconds)} ago`;
+		lines.push(`${r.id} (${r.role}): ${short}, ${age}.`);
+	}
+	return lines.join("\n");
+}
+
+function formatAge(seconds: number): string {
+	if (seconds < 90) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 90) return `${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 48) return `${hours}h`;
+	return `${Math.floor(hours / 24)}d`;
+}
+
+/**
+ * Provenance goes on every answer, and reading it shells out to git once per
+ * repo. For the cross-project rollup habitat — the one with the most mounts,
+ * and the one this ticket is really for — that is the difference between a
+ * fact and a cost. A short TTL keeps it a fact.
+ *
+ * The TTL is deliberately short: it exists to collapse the repos of a single
+ * burst of questions, not to let a refresh go unnoticed.
+ */
+export class ProvenanceCache {
+	private cached?: { at: number; value: HabitatProvenance };
+
+	constructor(
+		private readonly read: () => Promise<HabitatProvenance>,
+		private readonly ttlMs = 30_000,
+		private readonly clock: () => number = () => Date.now(),
+	) {}
+
+	async get(): Promise<HabitatProvenance> {
+		const now = this.clock();
+		if (this.cached && now - this.cached.at < this.ttlMs) {
+			return this.cached.value;
+		}
+		const value = await this.read();
+		this.cached = { at: now, value };
+		return value;
+	}
+
+	/** Drop the cache — call after a refresh, so the next answer tells the truth. */
+	invalidate(): void {
+		this.cached = undefined;
+	}
+}


### PR DESCRIPTION
Closes #277.

Separating start from refresh (#276) means a habitat can legitimately answer from a checkout that is days old. That is usually fine and occasionally catastrophic: **a changelog assembled across fifteen client habitats where three were quietly three weeks stale is confidently incorrect in a way nobody notices** — the rollup reads as complete, because every habitat answered.

Every answer now carries the commit each repo is on, when that checkout was last brought up to date, and whether a refresh is already owed.

## Two constraints that shaped it

**No network.** Provenance is about what this checkout *is*, not how far behind upstream it is. Asking GitHub would make every answer depend on GitHub being up and turn a cheap fact into a rate-limited one.

The refresh time comes from the mtime of `FETCH_HEAD`, which git touches on every fetch *whether or not anything came back* — "we checked and there was nothing" is exactly the case a rollup must distinguish from "we never checked". A repo cloned and never fetched has no `FETCH_HEAD` and falls back to the mtime of `.git`, its clone time.

**Machine-readable first.** Prose provenance gets summarised away by the next model in the chain, so the structured record rides the same message-metadata channel as per-run usage (#117). `describeProvenance()` exists for humans reading a transcript, not for callers deciding whether to trust an answer.

## Design points worth reviewing

**`stale` and *old* are separate fields, deliberately.** A checkout can be weeks old and perfectly current if nothing upstream moved; a stale mark means a refresh is owed and has not run. Conflating them would make the signal useless in both directions.

**A declared repo that is not checked out reports `present: false` rather than being omitted.** A rollup that silently skips a repo it was told about is the precise failure this ticket exists to prevent.

**30s TTL cache.** Reading provenance shells out to git once per repo and goes on every answer. For the cross-project rollup habitat — the one with the most mounts, and the one this is really for — that is the difference between a fact and a cost. The TTL is short on purpose: it collapses the repos of a single burst of questions, it does not let a refresh go unnoticed.

**Provenance never fails an answer.** A habitat that cannot describe its checkout still answers, with provenance absent — which is itself informative, and distinct from provenance claiming everything is current.

## Behaviour change

The final message's `metadata` is **no longer omitted** when a run reports no usage — it always carries `provenance`.

Two `a2a-handler` tests pinned the old "no usage → no metadata" shape. They now assert the usage fields are absent while provenance is present, which is what they were actually about. Flagging explicitly because "I changed the tests" deserves the scrutiny: they were pinning a shape this ticket changes by design, not catching a regression.

## Files

- `provision/provenance.ts` — the record, `readHabitatProvenance`, `describeProvenance`, `ProvenanceCache`. No I/O.
- `provision/provenance-probe.ts` — the only file that touches the volume. Git calls are read-only, local, and 5s-timeout-bounded.
- `a2a-handler.ts` — cache on the executor, provenance on the final message.
- `index.ts` — exported, because the consumers that need it (operations rollup, control-plane workstream habitats#117) are outside this package.

## Verification

18 new tests, including that a habitat with no mounts, no repos at all, or a declared-but-uncloned repo each report without error.

- `pnpm test:run` — 185 files, 2282 tests passing
- `tsc --noEmit` clean across every package

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_