### PR TITLE
Stop telling operators to rebuild a habitat that was just created

### DIFF
--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -464,7 +464,7 @@ export function createHabitatLifecycleTools(
 
 		apply_habitat_declaration: tool({
 			description:
-				"Stand a habitat up from the habitat.json in its own repo (ADR 0006), creating it if it does not exist and updating it if it does. This is the sanctioned way to provision a repo-backed habitat — it reads the declaration and derives the GitHub read scope from the mounts it declares, so mounts and scopes cannot drift. Rebuild the habitat afterwards for the changes to reach a running container.",
+				"Stand a habitat up from the habitat.json in its own repo (ADR 0006), creating it if it does not exist and updating it if it does. This is the sanctioned way to provision a repo-backed habitat — it reads the declaration and derives the GitHub read scope from the mounts it declares, so mounts and scopes cannot drift. A habitat that was not running needs no further step: asking it starts it (#279). A habitat that is already running needs a rebuild for the new declaration to reach its container.",
 			inputSchema: z.object({
 				id: z.string().describe("Habitat id to create or update"),
 				gitUrl: z
@@ -505,7 +505,9 @@ export function createHabitatLifecycleTools(
 						result.entry.github?.write?.length
 							? `Write scope (declared, never derived): ${result.entry.github.write.join(", ")}`
 							: "Write scope: (none declared)",
-						`Rebuild "${id}" for this to reach a running container.`,
+						result.action === "created"
+							? `Ask "${id}" anything to start it — no separate start step is needed.`
+							: `Rebuild "${id}" if it is already running, so the new declaration reaches its container.`,
 					].join("\n");
 				} catch (err) {
 					// Nothing was registered — apply validates before it writes.


### PR DESCRIPTION
`apply_habitat_declaration` told every caller to rebuild afterwards.

For a habitat that already exists and is running, that is right — the container holds the old declaration and only a rebuild replaces it.

For one that was just created there is nothing to rebuild, and since #279 there is nothing to *start* either: asking it wakes it. Saying "rebuild" there sends the operator looking for a step that does not apply, which is exactly the kind of thing that makes a self-provisioning path feel like it still needs a human with a runbook.

The tool now says which case it is in, and the description mentions wake-on-ask so a model reading it does not invent a start step.

No behaviour change — output text only. `pnpm test:run` 185 files / 2282 tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_