### PR TITLE
Supplier: `umwelten supplier` runs and publishes Offers

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,8 @@
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^15.0.0",
-    "ora": "^9.4.1"
+    "ora": "^9.4.1",
+    "@umwelten/supplier": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,6 +17,7 @@ import {
 import { registerSessionsHabitatCommands } from "@umwelten/habitat";
 import { habitatCommand } from "./habitat.js";
 import { mcpCommand } from "./mcp.js";
+import { supplierCommand } from "@umwelten/supplier";
 
 // Get the version from package.json. Try both the dist layout
 // (packages/cli/dist/cli.js → ../package.json) and the src layout
@@ -57,6 +58,7 @@ program.addCommand(sessionsCommand);
 registerSessionsHabitatCommands(sessionsCommand);
 program.addCommand(habitatCommand);
 program.addCommand(mcpCommand);
+program.addCommand(supplierCommand);
 program.addCommand(introspectCommand);
 program.addCommand(browseCommand);
 program.addCommand(searchCommand);

--- a/packages/supplier/package.json
+++ b/packages/supplier/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@umwelten/supplier",
+  "version": "0.1.0",
+  "description": "Turns a machine into a Supplier the Exchange can dispatch to",
+  "type": "module",
+  "exports": {
+    ".": { "types": "./src/index.ts", "import": "./src/index.ts" },
+    "./*.js": { "types": "./src/*.ts", "import": "./src/*.ts" }
+  },
+  "scripts": { "typecheck": "tsc --noEmit -p tsconfig.json" },
+  "dependencies": {
+    "@umwelten/core": "workspace:*",
+    "commander": "^15.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.10"
+  },
+  "license": "MIT"
+}

--- a/packages/supplier/src/command.ts
+++ b/packages/supplier/src/command.ts
@@ -1,0 +1,206 @@
+/**
+ * `umwelten supplier` — turn this machine into a Supplier.
+ *
+ * A CLI command rather than a separately installed binary: someone who already
+ * has umwelten runs a command they already have, which is the difference
+ * between onboarding hardware being a task and it being a decision.
+ *
+ * This package deliberately does **not** depend on `@umwelten/exchange`. It
+ * talks to a running Exchange over HTTP, which keeps a database driver out of
+ * every umwelten install for a command that never opens a database.
+ */
+
+import { Command } from "commander";
+import { discoverRuntimes } from "./discover.js";
+import { probeOffer } from "./probe.js";
+import { findDuplicateModels, probeTargets, toOfferDrafts } from "./offers.js";
+import { ExchangeClient } from "./exchange-client.js";
+import type { MachineState, ProbedOffer, ServingMode, SupplierConfig } from "./types.js";
+
+interface CliOptions {
+  exchange?: string;
+  credential?: string;
+  guarantees?: string;
+  mode?: string;
+  provider?: string;
+  model?: string;
+  concurrency?: string;
+  noHeadroom?: boolean;
+}
+
+function resolveConfig(opts: CliOptions): SupplierConfig {
+  const exchangeUrl = opts.exchange ?? process.env.EXCHANGE_URL;
+  const credential = opts.credential ?? process.env.SUPPLIER_CREDENTIAL;
+  if (!exchangeUrl) throw new Error("No Exchange URL. Pass --exchange or set EXCHANGE_URL.");
+  if (!credential) {
+    throw new Error("No credential. Pass --credential or set SUPPLIER_CREDENTIAL.");
+  }
+
+  const mode = (opts.mode ?? "adapted") as ServingMode;
+  if (mode !== "managed" && mode !== "adapted") {
+    throw new Error(`Unknown serving mode "${mode}". Expected managed or adapted.`);
+  }
+
+  return {
+    exchangeUrl,
+    credential,
+    guarantees: (opts.guarantees ?? "").split(",").map((g) => g.trim()).filter(Boolean),
+    servingMode: mode,
+    providers: opts.provider?.split(",").map((p) => p.trim()).filter(Boolean),
+    modelFilter: opts.model,
+  };
+}
+
+async function probeMachine(
+  config: SupplierConfig,
+  opts: CliOptions,
+  onProgress: (line: string) => void,
+): Promise<{ machine: MachineState; probed: ProbedOffer[] }> {
+  const runtimes = await discoverRuntimes(config.providers);
+  const machine: MachineState = { runtimes };
+
+  for (const runtime of runtimes) {
+    onProgress(
+      runtime.reachable
+        ? `✓ ${runtime.provider.padEnd(11)} ${runtime.models.length} model(s)`
+        : `✗ ${runtime.provider.padEnd(11)} unreachable — ${runtime.error}`,
+    );
+  }
+
+  const targets = probeTargets(machine, {
+    providers: config.providers,
+    modelFilter: config.modelFilter,
+  });
+  const concurrency = (opts.concurrency ?? "1")
+    .split(",")
+    .map((n) => Number(n.trim()))
+    .filter((n) => Number.isFinite(n) && n > 0);
+
+  const probed: ProbedOffer[] = [];
+  for (const [i, target] of targets.entries()) {
+    onProgress(`[${i + 1}/${targets.length}] ${target.provider}:${target.model} …`);
+    probed.push(
+      await probeOffer(target.provider, target.model, {
+        concurrency,
+        skipHeadroom: opts.noHeadroom,
+      }),
+    );
+  }
+
+  return { machine, probed };
+}
+
+export const supplierCommand = new Command("supplier")
+  .description("Turn this machine into a Supplier the Exchange can dispatch to")
+  .addHelpText(
+    "after",
+    `
+Serving modes:
+  managed   The agent owns the runtime, pinning context size and quantization.
+            Only managed Offers can commit to resource properties, which is why
+            it is the default posture (ADR 0010).
+  adapted   Resell a runtime already running on this machine. Costs the owner
+            nothing to join, and carries no resource commitments — a lesser
+            tier, priced as one.
+
+Examples:
+  umwelten supplier probe --no-headroom
+  umwelten supplier publish --exchange https://exchange.example --credential $KEY
+`,
+  );
+
+supplierCommand
+  .command("probe")
+  .description("Show what this machine can do, without publishing anything")
+  .option("--provider <names>", "Restrict to these runtimes (comma-separated)")
+  .option("--model <substring>", "Restrict to Models matching this")
+  .option("--concurrency <levels>", "Headroom sample levels, e.g. 1,4", "1")
+  .option("--no-headroom", "Capabilities only — much faster")
+  .option("--mode <mode>", "managed or adapted", "adapted")
+  .action(async (opts: CliOptions) => {
+    // A dry run needs no Exchange: an operator inspecting a new machine should
+    // not have to register it first.
+    const config: SupplierConfig = {
+      exchangeUrl: "",
+      credential: "",
+      guarantees: [],
+      servingMode: (opts.mode ?? "adapted") as ServingMode,
+      providers: opts.provider?.split(",").map((p) => p.trim()).filter(Boolean),
+      modelFilter: opts.model,
+    };
+
+    const { probed } = await probeMachine(config, opts, (line) => console.log(line));
+    const drafts = toOfferDrafts(probed, { servingMode: config.servingMode });
+
+    console.log(`\nWould publish ${drafts.length} offer(s):`);
+    for (const draft of drafts) {
+      console.log(`  ${draft.model.padEnd(46)} ${draft.capabilities.join(", ") || "none"}`);
+    }
+
+    const failed = probed.filter((p) => p.failed);
+    if (failed.length) {
+      // A failed probe produces no Offer rather than an Offer with a hole in
+      // it, so an operator has to be told which Models fell out and why.
+      console.log(`\n${failed.length} model(s) produced no offer:`);
+      for (const f of failed) console.log(`  ${f.model} — ${f.failed}`);
+    }
+
+    const duplicates = findDuplicateModels(drafts);
+    if (duplicates.length) {
+      console.log(
+        `\n⚠ Published twice, and the Exchange keys on (Supplier, Model) — ` +
+          `one will overwrite the other: ${duplicates.join(", ")}`,
+      );
+    }
+  });
+
+supplierCommand
+  .command("publish")
+  .description("Probe this machine and publish its Offers to the Exchange")
+  .option("--exchange <url>", "Exchange base URL (or EXCHANGE_URL)")
+  .option("--credential <token>", "Supplier credential (or SUPPLIER_CREDENTIAL)")
+  .option("--guarantees <names>", "Guarantees to claim, comma-separated")
+  .option("--mode <mode>", "managed or adapted", "adapted")
+  .option("--provider <names>", "Restrict to these runtimes")
+  .option("--model <substring>", "Restrict to Models matching this")
+  .option("--concurrency <levels>", "Headroom sample levels", "1")
+  .option("--no-headroom", "Capabilities only")
+  .action(async (opts: CliOptions) => {
+    const config = resolveConfig(opts);
+    const { probed } = await probeMachine(config, opts, (line) => console.log(line));
+    const drafts = toOfferDrafts(probed, { servingMode: config.servingMode });
+
+    const client = new ExchangeClient({
+      exchangeUrl: config.exchangeUrl,
+      credential: config.credential,
+    });
+    const result = await client.publish(drafts, config.guarantees);
+
+    if (result.ok) {
+      console.log(`\nPublished ${result.offers} offer(s).`);
+      console.log(`Offered under: ${(result.guarantees ?? []).join(", ") || "no guarantees"}`);
+      return;
+    }
+
+    // Surfaced, never swallowed. A Supplier that believes it is on-premise and
+    // is not needs to hear about it.
+    console.error(`\nPublish failed (${result.status}): ${result.error ?? "unknown"}`);
+    if (result.message) console.error(`  ${result.message}`);
+    process.exitCode = 1;
+  });
+
+supplierCommand
+  .command("withdraw")
+  .description("Remove this machine's Offers from the Exchange")
+  .option("--exchange <url>", "Exchange base URL (or EXCHANGE_URL)")
+  .option("--credential <token>", "Supplier credential (or SUPPLIER_CREDENTIAL)")
+  .action(async (opts: CliOptions) => {
+    const config = resolveConfig({ ...opts, mode: "adapted" });
+    const client = new ExchangeClient({
+      exchangeUrl: config.exchangeUrl,
+      credential: config.credential,
+    });
+    const result = await client.withdraw();
+    console.log(result.ok ? "Withdrawn." : `Withdraw failed (${result.status}).`);
+    if (!result.ok) process.exitCode = 1;
+  });

--- a/packages/supplier/src/discover.ts
+++ b/packages/supplier/src/discover.ts
@@ -1,0 +1,75 @@
+/**
+ * Stage 2 of the supplier agent: discover.
+ *
+ * Stage 1 (estimate) is `whichllm` or equivalent — it reads your hardware and
+ * predicts which models *should* fit, from VRAM math plus published
+ * leaderboards. It never executes a model, so it cannot tell you what this box
+ * actually does. That is stage 3's job (`probe.ts`).
+ *
+ * This stage sits between them and answers a narrower question: which local
+ * runtimes are up right now, and what do they say they are serving? We ask the
+ * runtimes rather than the disk, because in adapt-mode the box's existing
+ * Ollama/LM Studio config is the thing we are reselling.
+ *
+ * `findLlamaSwapModels()` in core scans GGUF caches on disk instead — use that
+ * when the agent owns the serving layer and needs to generate a llama-swap
+ * config, rather than adapting to what is already running.
+ */
+
+import { createOllamaProvider } from "@umwelten/core/providers/ollama.js";
+import { createLMStudioProvider } from "@umwelten/core/providers/lmstudio.js";
+import { createLlamaBarnProvider } from "@umwelten/core/providers/llamabarn.js";
+import { createLlamaSwapProvider } from "@umwelten/core/providers/llamaswap.js";
+import type { BaseProvider } from "@umwelten/core/providers/base.js";
+import type { MachineState } from "./types.js";
+
+const RUNTIMES: { provider: string; create: () => BaseProvider }[] = [
+  { provider: "ollama", create: () => createOllamaProvider() },
+  { provider: "lmstudio", create: () => createLMStudioProvider() },
+  { provider: "llamabarn", create: () => createLlamaBarnProvider() },
+  { provider: "llamaswap", create: () => createLlamaSwapProvider() },
+];
+
+/**
+ * Knock on every local runtime we know about. Unreachable runtimes are
+ * reported rather than thrown — a box running only Ollama is the normal case,
+ * not an error.
+ */
+export async function discoverRuntimes(
+  only?: string[],
+): Promise<MachineState["runtimes"][number][]> {
+  const wanted = only?.length
+    ? RUNTIMES.filter((r) => only.includes(r.provider))
+    : RUNTIMES;
+
+  return Promise.all(
+    wanted.map(async ({ provider, create }): Promise<MachineState["runtimes"][number]> => {
+      try {
+        const models = await create().listModels();
+        return {
+          provider,
+          reachable: true,
+          models: models.map((m) => m.name).sort(),
+        };
+      } catch (error) {
+        return {
+          provider,
+          reachable: false,
+          models: [],
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  );
+}
+
+/** Flatten discovery into the (provider, model) pairs a probe run iterates. */
+export function toProbeTargets(
+  runtimes: MachineState["runtimes"][number][],
+  modelFilter?: string,
+): { provider: string; model: string }[] {
+  return runtimes
+    .filter((r) => r.reachable)
+    .flatMap((r) => r.models.map((model) => ({ provider: r.provider, model })))
+    .filter((t) => !modelFilter || t.model.includes(modelFilter));
+}

--- a/packages/supplier/src/exchange-client.test.ts
+++ b/packages/supplier/src/exchange-client.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The second seam: publishing behaviour, against a fake Exchange.
+ */
+
+import { describe, it, expect } from "vitest";
+import http from "node:http";
+import { ExchangeClient } from "./exchange-client.js";
+import type { OfferDraft } from "./types.js";
+
+const DRAFT: OfferDraft = {
+  model: "gemma-4-26b",
+  capabilities: ["chat"],
+  servingMode: "managed",
+  headroom: [],
+};
+
+async function fakeExchange(
+  respond: (body: Record<string, unknown>, res: http.ServerResponse) => void,
+): Promise<{ url: string; bodies: Record<string, unknown>[]; close: () => Promise<void> }> {
+  const bodies: Record<string, unknown>[] = [];
+  const server = http.createServer(async (req, res) => {
+    const raw = await new Promise<string>((resolve) => {
+      let acc = "";
+      req.on("data", (c) => (acc += c));
+      req.on("end", () => resolve(acc));
+    });
+    const body = JSON.parse(raw || "{}");
+    bodies.push(body);
+    respond(body, res);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    bodies,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+}
+
+function ok(guarantees: string[] = []) {
+  return (body: Record<string, unknown>, res: http.ServerResponse) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        supplierId: "office-spark",
+        offers: (body.offers as unknown[]).length,
+        guarantees,
+      }),
+    );
+  };
+}
+
+describe("ExchangeClient", () => {
+  it("publishes offers with the credential", async () => {
+    const exchange = await fakeExchange(ok(["on-premise"]));
+    const client = new ExchangeClient({
+      exchangeUrl: exchange.url,
+      credential: "secret",
+    });
+
+    const result = await client.publish([DRAFT], ["on-premise"]);
+    expect(result.ok).toBe(true);
+    expect(result.offers).toBe(1);
+    expect(exchange.bodies[0].guarantees).toEqual(["on-premise"]);
+    await exchange.close();
+  });
+
+  it("reports back what the operator actually granted", async () => {
+    // So an agent can confirm what it is offered under rather than assume its
+    // own config was honored.
+    const exchange = await fakeExchange(ok(["no-training"]));
+    const client = new ExchangeClient({ exchangeUrl: exchange.url, credential: "s" });
+
+    const result = await client.publish([DRAFT], ["no-training"]);
+    expect(result.guarantees).toEqual(["no-training"]);
+    await exchange.close();
+  });
+
+  it("surfaces a rejected guarantee rather than swallowing it", async () => {
+    // A Supplier that believes it is on-premise and is not needs to hear.
+    const exchange = await fakeExchange((_body, res) => {
+      res.writeHead(403, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: "guarantee_not_granted",
+          guarantee: "fips-140",
+          message: "Supplier is not granted the guarantee \"fips-140\".",
+        }),
+      );
+    });
+    const client = new ExchangeClient({ exchangeUrl: exchange.url, credential: "s" });
+
+    const result = await client.publish([DRAFT], ["fips-140"]);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(403);
+    expect(result.error).toBe("guarantee_not_granted");
+    expect(result.message).toContain("fips-140");
+    await exchange.close();
+  });
+
+  it("reports an unreachable Exchange without throwing", async () => {
+    // A machine whose Exchange is down should keep running and retry, not die.
+    const client = new ExchangeClient({
+      exchangeUrl: "http://127.0.0.1:1",
+      credential: "s",
+    });
+
+    const result = await client.publish([DRAFT], []);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("unreachable");
+    await client.withdraw();
+  });
+
+  it("withdraws by publishing an empty set", async () => {
+    // Publishing is total, so an empty set removes everything. A clean
+    // shutdown says so immediately rather than leaving the Exchange to notice
+    // a machine has gone quiet.
+    const exchange = await fakeExchange(ok());
+    const client = new ExchangeClient({ exchangeUrl: exchange.url, credential: "s" });
+
+    await client.publish([DRAFT], []);
+    await client.withdraw();
+
+    expect(exchange.bodies).toHaveLength(2);
+    expect(exchange.bodies[1].offers).toEqual([]);
+    await exchange.close();
+  });
+
+  it("republishing sends the whole set, not a delta", async () => {
+    const exchange = await fakeExchange(ok());
+    const client = new ExchangeClient({ exchangeUrl: exchange.url, credential: "s" });
+
+    await client.publish([DRAFT, { ...DRAFT, model: "other" }], []);
+    await client.publish([DRAFT], []);
+
+    expect((exchange.bodies[0].offers as unknown[]).length).toBe(2);
+    expect((exchange.bodies[1].offers as unknown[]).length).toBe(1);
+    await exchange.close();
+  });
+
+  it("tolerates a trailing slash on the Exchange URL", async () => {
+    const exchange = await fakeExchange(ok());
+    const client = new ExchangeClient({ exchangeUrl: `${exchange.url}/`, credential: "s" });
+
+    const result = await client.publish([DRAFT], []);
+    expect(result.ok).toBe(true);
+    await exchange.close();
+  });
+});

--- a/packages/supplier/src/exchange-client.ts
+++ b/packages/supplier/src/exchange-client.ts
@@ -1,0 +1,85 @@
+/**
+ * Talking to the Exchange.
+ *
+ * Publishing is total: what we send replaces this Supplier's entire Offer set,
+ * so a Model the machine stopped serving stops being advertised without anyone
+ * deleting anything. An empty publish is therefore a clean withdrawal, which is
+ * what shutdown uses.
+ */
+
+import type { OfferDraft } from "./types.js";
+
+export interface PublishResult {
+  ok: boolean;
+  status: number;
+  /** What the Exchange says this Supplier is actually granted. */
+  guarantees?: string[];
+  offers?: number;
+  error?: string;
+  message?: string;
+}
+
+export interface ExchangeClientOptions {
+  exchangeUrl: string;
+  credential: string;
+  fetchImpl?: typeof fetch;
+}
+
+export class ExchangeClient {
+  private readonly doFetch: typeof fetch;
+
+  constructor(private readonly opts: ExchangeClientOptions) {
+    this.doFetch = opts.fetchImpl ?? fetch;
+  }
+
+  private get base(): string {
+    return this.opts.exchangeUrl.replace(/\/$/, "");
+  }
+
+  /**
+   * Send the Offer set. Guarantees are echoed for confirmation — the Exchange's
+   * grant decides, and a claim beyond it is rejected rather than downgraded
+   * (ADR 0006), which is why the rejection is surfaced rather than swallowed.
+   */
+  async publish(offers: OfferDraft[], guarantees: string[]): Promise<PublishResult> {
+    let response: Response;
+    try {
+      response = await this.doFetch(`${this.base}/suppliers/offers`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${this.opts.credential}`,
+        },
+        body: JSON.stringify({ offers, guarantees }),
+      });
+    } catch (error) {
+      return {
+        ok: false,
+        status: 0,
+        error: "unreachable",
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+
+    const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+    return {
+      ok: response.ok,
+      status: response.status,
+      guarantees: body.guarantees as string[] | undefined,
+      offers: body.offers as number | undefined,
+      error: body.error as string | undefined,
+      message: body.message as string | undefined,
+    };
+  }
+
+  /**
+   * Publish an empty set.
+   *
+   * Because publishing is total this removes everything, and it is why a clean
+   * shutdown says so immediately rather than leaving the Exchange to notice a
+   * machine has gone quiet.
+   */
+  withdraw(): Promise<PublishResult> {
+    return this.publish([], []);
+  }
+}

--- a/packages/supplier/src/index.ts
+++ b/packages/supplier/src/index.ts
@@ -1,0 +1,17 @@
+export type {
+  CapabilityName,
+  CapabilityProbe,
+  HeadroomSample,
+  MachineState,
+  OfferDraft,
+  ProbedOffer,
+  ServingMode,
+  SupplierConfig,
+} from "./types.js";
+
+export { discoverRuntimes } from "./discover.js";
+export { probeOffer } from "./probe.js";
+export { findDuplicateModels, probeTargets, toOfferDrafts } from "./offers.js";
+export { ExchangeClient } from "./exchange-client.js";
+export type { ExchangeClientOptions, PublishResult } from "./exchange-client.js";
+export { supplierCommand } from "./command.js";

--- a/packages/supplier/src/offers.test.ts
+++ b/packages/supplier/src/offers.test.ts
@@ -1,0 +1,139 @@
+/**
+ * The seam: what the agent decides to publish, given a described machine.
+ *
+ * No GPU, no network, and no assertions about how it got there. Everything
+ * decision-shaped is testable here; only measurement needs metal.
+ */
+
+import { describe, it, expect } from "vitest";
+import { findDuplicateModels, probeTargets, toOfferDrafts } from "./offers.js";
+import type { MachineState, ProbedOffer } from "./types.js";
+
+const machine = (overrides: Partial<MachineState> = {}): MachineState => ({
+  runtimes: [
+    { provider: "ollama", reachable: true, models: ["gemma4:26b", "gemma4:e2b"] },
+    { provider: "lmstudio", reachable: false, models: [], error: "fetch failed" },
+    { provider: "llamaswap", reachable: true, models: ["ggml-org/gemma-4-26B:Q4_K_M"] },
+  ],
+  ...overrides,
+});
+
+const probed = (overrides: Partial<ProbedOffer> = {}): ProbedOffer => ({
+  provider: "ollama",
+  model: "gemma4:26b",
+  probedAt: "2026-07-28T00:00:00Z",
+  capabilities: [
+    { name: "chat", supported: true, evidence: "ok", elapsedMs: 1 },
+    { name: "streaming", supported: true, evidence: "ok", elapsedMs: 1 },
+    { name: "tool-calling", supported: false, evidence: "no tool call", elapsedMs: 1 },
+  ],
+  headroom: [
+    { concurrency: 1, ttftMs: 300, tokensPerSecond: 94, decodeTokensPerSecond: 114, errors: 0 },
+  ],
+  ...overrides,
+});
+
+describe("probeTargets", () => {
+  it("skips unreachable runtimes rather than failing", () => {
+    // A box running only one runtime is the normal case, not an error.
+    const targets = probeTargets(machine());
+    expect(targets.map((t) => t.provider)).not.toContain("lmstudio");
+    expect(targets).toHaveLength(3);
+  });
+
+  it("honours an explicit runtime list", () => {
+    const targets = probeTargets(machine(), { providers: ["ollama"] });
+    expect(targets.every((t) => t.provider === "ollama")).toBe(true);
+  });
+
+  it("honours a model filter", () => {
+    const targets = probeTargets(machine(), { modelFilter: "e2b" });
+    expect(targets).toEqual([{ provider: "ollama", model: "gemma4:e2b" }]);
+  });
+
+  it("returns nothing when no runtime answers", () => {
+    const targets = probeTargets({
+      runtimes: [{ provider: "ollama", reachable: false, models: [], error: "down" }],
+    });
+    expect(targets).toEqual([]);
+  });
+});
+
+describe("toOfferDrafts", () => {
+  it("carries probed capabilities through verbatim", () => {
+    // Nothing inferred, defaulted, or added. An Offer's capability set is
+    // evidence (ADR 0009), and the moment something is added it stops being.
+    const [draft] = toOfferDrafts([probed()], { servingMode: "managed" });
+    expect(draft.capabilities).toEqual(["chat", "streaming"]);
+  });
+
+  it("produces no Offer for a failed probe, rather than one with a hole in it", () => {
+    // "We did not establish this" is not "this machine cannot do it", and
+    // publishing the second when we only know the first has Dispatch route
+    // around a Model that works.
+    const drafts = toOfferDrafts(
+      [probed({ failed: "chat probe failed: timed out" })],
+      { servingMode: "managed" },
+    );
+    expect(drafts).toEqual([]);
+  });
+
+  it("marks the serving mode it was told to", () => {
+    expect(toOfferDrafts([probed()], { servingMode: "adapted" })[0].servingMode).toBe("adapted");
+    expect(toOfferDrafts([probed()], { servingMode: "managed" })[0].servingMode).toBe("managed");
+  });
+
+  it("carries Headroom samples through as measured", () => {
+    const [draft] = toOfferDrafts([probed()], { servingMode: "managed" });
+    expect(draft.headroom).toHaveLength(1);
+    expect(draft.headroom[0].tokensPerSecond).toBe(94);
+  });
+
+  it("publishes no price", () => {
+    // The Exchange sets Cost and Charge. A Supplier that prices itself takes
+    // away the routing lever (ADR 0007).
+    const [draft] = toOfferDrafts([probed()], { servingMode: "managed" });
+    expect(JSON.stringify(draft)).not.toMatch(/price|retail|wholesale|cost|charge/i);
+  });
+
+  it("publishes no guarantee on the Offer itself", () => {
+    // Guarantees are the operator's, granted at the Supplier level.
+    const [draft] = toOfferDrafts([probed()], { servingMode: "managed" });
+    expect(JSON.stringify(draft)).not.toMatch(/guarantee/i);
+  });
+
+  it("keeps an Offer whose capabilities all probed false", () => {
+    // Different from a failed probe: we established that it does nothing
+    // useful, which is a fact the Exchange can filter on.
+    const drafts = toOfferDrafts(
+      [
+        probed({
+          capabilities: [{ name: "chat", supported: false, evidence: "no", elapsedMs: 1 }],
+        }),
+      ],
+      { servingMode: "managed" },
+    );
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].capabilities).toEqual([]);
+  });
+});
+
+describe("findDuplicateModels", () => {
+  it("flags the same Model published from two runtimes", () => {
+    // The Exchange keys an Offer on (Supplier, Model), so the second would
+    // silently overwrite the first. Better to say so than lose one at random.
+    const drafts = toOfferDrafts(
+      [probed({ provider: "ollama" }), probed({ provider: "llamaswap" })],
+      { servingMode: "managed" },
+    );
+    expect(findDuplicateModels(drafts)).toEqual(["gemma4:26b"]);
+  });
+
+  it("is quiet when every Model is distinct", () => {
+    const drafts = toOfferDrafts(
+      [probed({ model: "a" }), probed({ model: "b" })],
+      { servingMode: "managed" },
+    );
+    expect(findDuplicateModels(drafts)).toEqual([]);
+  });
+});

--- a/packages/supplier/src/offers.ts
+++ b/packages/supplier/src/offers.ts
@@ -1,0 +1,67 @@
+/**
+ * Turning probe results into the Offers we publish.
+ *
+ * This is the seam. Feed it a described machine state and assert what comes
+ * out — no GPU, no network, and no assertions about *how* the agent got there.
+ * Everything decision-shaped lives here; only measurement needs metal.
+ */
+
+import type { CapabilityName, MachineState, OfferDraft, ProbedOffer } from "./types.js";
+
+/** Every (runtime, model) pair worth probing, from a described machine. */
+export function probeTargets(
+  machine: MachineState,
+  opts: { providers?: string[]; modelFilter?: string } = {},
+): { provider: string; model: string }[] {
+  return machine.runtimes
+    .filter((r) => r.reachable)
+    .filter((r) => !opts.providers?.length || opts.providers.includes(r.provider))
+    .flatMap((r) => r.models.map((model) => ({ provider: r.provider, model })))
+    .filter((t) => !opts.modelFilter || t.model.includes(opts.modelFilter));
+}
+
+/**
+ * Probe results → Offers.
+ *
+ * A failed probe produces **no Offer**, rather than an Offer with a missing
+ * Capability. Those are different claims: "we did not establish this" is not
+ * "this machine cannot do it", and publishing the second when we only know the
+ * first would have Dispatch route around a Model that works.
+ *
+ * Capabilities are carried through verbatim. Nothing is inferred, defaulted, or
+ * added — an Offer's capability set is evidence (ADR 0009), and the moment
+ * something is added here it stops being evidence.
+ */
+export function toOfferDrafts(
+  probed: ProbedOffer[],
+  opts: { servingMode: ProbedOffer extends never ? never : OfferDraft["servingMode"] },
+): OfferDraft[] {
+  return probed
+    .filter((p) => !p.failed)
+    .map((p) => ({
+      model: p.model,
+      capabilities: p.capabilities
+        .filter((c) => c.supported)
+        .map((c) => c.name as CapabilityName),
+      servingMode: opts.servingMode,
+      headroom: p.headroom,
+      contextTokens: p.contextTokens,
+    }));
+}
+
+/**
+ * Models the same weights served two ways would collide on.
+ *
+ * The Exchange keys an Offer on (Supplier, Model), so one agent publishing the
+ * same Model from two runtimes would have the second silently overwrite the
+ * first. Surfacing it lets the operator pick rather than lose one at random.
+ */
+export function findDuplicateModels(drafts: OfferDraft[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const draft of drafts) {
+    if (seen.has(draft.model)) duplicates.add(draft.model);
+    seen.add(draft.model);
+  }
+  return [...duplicates].sort();
+}

--- a/packages/supplier/src/probe.ts
+++ b/packages/supplier/src/probe.ts
@@ -1,0 +1,424 @@
+/**
+ * Stage 3 of the supplier agent: probe.
+ *
+ * This is the only stage that produces facts. `whichllm` estimates from VRAM
+ * math and other people's leaderboard scores; Ollama reports context windows
+ * from a hardcoded lookup table (`providers/ollama.ts`). Neither knows what
+ * *this* box does with *this* build of *this* quantization — which is exactly
+ * the thing an Offer's Capabilities are supposed to record.
+ *
+ * So we run the model and watch what happens.
+ *
+ * On token limits: the binary capability probes set `maxTokens` on their own
+ * Stimulus, which is the sanctioned per-task escape hatch in CLAUDE.md's HARD
+ * RULES — we are testing whether a tool call happens, not how long a model can
+ * talk. The headroom probe deliberately sets **no** cap; it uses a
+ * self-terminating prompt so the measurement window is bounded by the task
+ * rather than by a truncation that would distort tokens/sec.
+ */
+
+import { z } from "zod";
+import { tool } from "ai";
+import { Stimulus } from "@umwelten/core/stimulus/stimulus.js";
+import { Interaction } from "@umwelten/core/interaction/core/interaction.js";
+import type { ModelDetails } from "@umwelten/core/cognition/types.js";
+import { runWithWatchdog } from "./watchdog.js";
+import type { CapabilityProbe, HeadroomSample, ProbedOffer } from "./types.js";
+
+/** Binary probes are short by construction; 3 minutes is already generous. */
+const CAPABILITY_TIMEOUT_MS = 3 * 60_000;
+/** Throughput generates ~200 lines, and a cold model load can be slow. */
+const THROUGHPUT_TIMEOUT_MS = 10 * 60_000;
+
+function elapsedSince(start: number): number {
+  return Date.now() - start;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+// ── Individual capability probes ─────────────────────────────────────────────
+
+/** Does it answer at all, and does it follow a trivial instruction? */
+async function probeChat(model: ModelDetails): Promise<CapabilityProbe> {
+  const start = Date.now();
+  const outcome = await runWithWatchdog({
+    timeoutMs: CAPABILITY_TIMEOUT_MS,
+    task: async (signal) => {
+      const interaction = new Interaction(
+        model,
+        new Stimulus({
+          role: "a terse assistant",
+          instructions: ["Answer with the single requested word and nothing else."],
+          maxTokens: 32,
+        }),
+      );
+      interaction.addMessage({
+        role: "user",
+        content: 'Reply with exactly the word: READY',
+      });
+      return interaction.generateText(signal);
+    },
+  });
+
+  if (!outcome.ok) {
+    return {
+      name: "chat",
+      supported: false,
+      evidence: outcome.reason === "timeout" ? "timed out" : String(outcome.error),
+      elapsedMs: elapsedSince(start),
+    };
+  }
+
+  const said = outcome.value.content.trim().toUpperCase().includes("READY");
+  return {
+    name: "chat",
+    supported: said,
+    evidence: said
+      ? "responded with the requested token"
+      : `unexpected response: ${outcome.value.content.slice(0, 120)}`,
+    elapsedMs: elapsedSince(start),
+  };
+}
+
+/** Do deltas actually arrive incrementally, or does it buffer and dump? */
+async function probeStreaming(model: ModelDetails): Promise<CapabilityProbe> {
+  const start = Date.now();
+  let deltas = 0;
+
+  const outcome = await runWithWatchdog({
+    timeoutMs: CAPABILITY_TIMEOUT_MS,
+    task: async (signal) => {
+      const interaction = new Interaction(
+        model,
+        new Stimulus({ role: "a helpful assistant", maxTokens: 128 }),
+      );
+      interaction.addMessage({
+        role: "user",
+        content: "Count from one to twenty, in words, separated by commas.",
+      });
+      return interaction.streamText(signal, {
+        onTextDelta: () => {
+          deltas += 1;
+        },
+      });
+    },
+  });
+
+  if (!outcome.ok) {
+    return {
+      name: "streaming",
+      supported: false,
+      evidence: outcome.reason === "timeout" ? "timed out" : String(outcome.error),
+      elapsedMs: elapsedSince(start),
+    };
+  }
+
+  // A single delta means the runtime buffered the whole completion and handed
+  // it over at the end. That is not streaming, whatever the API shape claims.
+  return {
+    name: "streaming",
+    supported: deltas > 1,
+    evidence: `${deltas} text delta(s) observed`,
+    elapsedMs: elapsedSince(start),
+  };
+}
+
+/**
+ * Will it call a tool? This is the capability most likely to differ between
+ * two runtimes serving the same weights — chat template and grammar support
+ * decide it, not the model.
+ */
+async function probeToolCalling(model: ModelDetails): Promise<CapabilityProbe> {
+  const start = Date.now();
+  let called = false;
+
+  const outcome = await runWithWatchdog({
+    timeoutMs: CAPABILITY_TIMEOUT_MS,
+    task: async (signal) => {
+      const interaction = new Interaction(
+        model,
+        new Stimulus({
+          role: "an assistant that uses tools",
+          instructions: ["Use the provided tool to answer. Do not compute it yourself."],
+          maxToolSteps: 3,
+          maxTokens: 256,
+          tools: {
+            multiply: tool({
+              description: "Multiply two integers. The only way to get a correct product.",
+              inputSchema: z.object({ a: z.number(), b: z.number() }),
+              execute: async ({ a, b }: { a: number; b: number }) => {
+                called = true;
+                return { product: a * b };
+              },
+            }),
+          },
+        }),
+      );
+      interaction.addMessage({
+        role: "user",
+        content: "What is 3737 multiplied by 1319? Use the tool.",
+      });
+      return interaction.streamText(signal);
+    },
+  });
+
+  if (!outcome.ok) {
+    return {
+      name: "tool-calling",
+      supported: false,
+      evidence: outcome.reason === "timeout" ? "timed out" : String(outcome.error),
+      elapsedMs: elapsedSince(start),
+    };
+  }
+
+  return {
+    name: "tool-calling",
+    supported: called,
+    evidence: called
+      ? "tool handler executed"
+      : `no tool call; model answered directly: ${outcome.value.content.slice(0, 120)}`,
+    elapsedMs: elapsedSince(start),
+  };
+}
+
+/** Can it produce output that validates against a schema? */
+async function probeStructuredOutput(model: ModelDetails): Promise<CapabilityProbe> {
+  const start = Date.now();
+  const schema = z.object({
+    city: z.string(),
+    countryCode: z.string().length(2),
+    populationMillions: z.number(),
+  });
+
+  const outcome = await runWithWatchdog({
+    timeoutMs: CAPABILITY_TIMEOUT_MS,
+    task: async (signal) => {
+      const interaction = new Interaction(
+        model,
+        new Stimulus({ role: "a precise data extractor", maxTokens: 256 }),
+      );
+      interaction.addMessage({
+        role: "user",
+        content: "Give me structured data about the capital city of Japan.",
+      });
+      return interaction.generateObject(schema, signal);
+    },
+  });
+
+  if (!outcome.ok) {
+    return {
+      name: "structured-output",
+      supported: false,
+      evidence: outcome.reason === "timeout" ? "timed out" : String(outcome.error),
+      elapsedMs: elapsedSince(start),
+    };
+  }
+
+  // The runner stringifies generateObject's result into `content`, so this
+  // parses in practice — but a probe that crashes the whole run because one
+  // model returned something odd is worse than a probe that records a failure.
+  let parsedOk = false;
+  let detail = "";
+  try {
+    const parsed = schema.safeParse(JSON.parse(outcome.value.content || "{}"));
+    parsedOk = parsed.success;
+    if (!parsed.success) detail = `schema mismatch: ${outcome.value.content.slice(0, 120)}`;
+  } catch {
+    detail = `unparseable output: ${outcome.value.content.slice(0, 120)}`;
+  }
+
+  return {
+    name: "structured-output",
+    supported: parsedOk,
+    evidence: parsedOk ? "returned schema-valid JSON" : detail,
+    elapsedMs: elapsedSince(start),
+  };
+}
+
+/**
+ * Can this Offer surface reasoning tokens separately from the answer?
+ *
+ * Note the question: *can it*, not *does it by default*. Those differ, and the
+ * difference was worth a bug — llama-server splits thinking into its own
+ * channel unprompted, while Ollama only does so when asked via `think: true`.
+ * Probing without asking measured a default, not a capability, and reported
+ * that four models had no reasoning when they had it all along.
+ *
+ * So we ask, by setting `reasoningEffort`. Providers that ignore it are
+ * unaffected; providers that honor it now answer the question we meant.
+ */
+async function probeReasoning(model: ModelDetails): Promise<CapabilityProbe> {
+  const start = Date.now();
+  const asking: ModelDetails = { ...model, reasoningEffort: "medium" };
+  const outcome = await runWithWatchdog({
+    timeoutMs: CAPABILITY_TIMEOUT_MS,
+    task: async (signal) => {
+      const interaction = new Interaction(
+        asking,
+        new Stimulus({ role: "a careful reasoner", maxTokens: 1024 }),
+      );
+      interaction.addMessage({
+        role: "user",
+        content:
+          "A bat and a ball cost $1.10 together. The bat costs $1.00 more than the ball. How much does the ball cost?",
+      });
+      return interaction.generateText(signal);
+    },
+  });
+
+  if (!outcome.ok) {
+    return {
+      name: "reasoning",
+      supported: false,
+      evidence: outcome.reason === "timeout" ? "timed out" : String(outcome.error),
+      elapsedMs: elapsedSince(start),
+    };
+  }
+
+  const hasReasoning = Boolean(outcome.value.reasoning?.trim());
+  return {
+    name: "reasoning",
+    supported: hasReasoning,
+    // Deliberately not scored for correctness — that is an eval's job, not a
+    // capability probe's. We only record whether the channel exists.
+    evidence: hasReasoning
+      ? `${outcome.value.reasoning!.length} chars of reasoning surfaced`
+      : "no separate reasoning channel",
+    elapsedMs: elapsedSince(start),
+  };
+}
+
+// ── Throughput ───────────────────────────────────────────────────────────────
+
+/**
+ * Measure TTFT and tokens/sec at a given concurrency. Run at 1 to get the
+ * single-stream number a buyer experiences, and at N to find where the box
+ * stops scaling — that inflection is the Headroom the exchange needs.
+ *
+ * No `maxTokens` here on purpose: the prompt self-terminates, so the window is
+ * defined by the task. Capping would truncate mid-generation and inflate the
+ * rate.
+ */
+async function measureThroughput(
+  model: ModelDetails,
+  concurrency: number,
+): Promise<HeadroomSample> {
+  const ttfts: number[] = [];
+  const decodeRates: number[] = [];
+  let completionTokens = 0;
+  let errors = 0;
+
+  const wallStart = Date.now();
+
+  await Promise.all(
+    Array.from({ length: concurrency }, async () => {
+      const started = Date.now();
+      let firstTokenAt: number | undefined;
+
+      const outcome = await runWithWatchdog({
+        timeoutMs: THROUGHPUT_TIMEOUT_MS,
+        task: async (signal) => {
+          const interaction = new Interaction(
+            model,
+            new Stimulus({
+              role: "a counting machine",
+              instructions: ["Output only the numbers. No commentary."],
+            }),
+          );
+          interaction.addMessage({
+            role: "user",
+            content: "Count from 1 to 200. One number per line.",
+          });
+          return interaction.streamText(signal, {
+            onTextDelta: () => {
+              firstTokenAt ??= Date.now();
+            },
+          });
+        },
+      });
+
+      if (!outcome.ok) {
+        errors += 1;
+        return;
+      }
+
+      const tokens = outcome.value.metadata.tokenUsage.completionTokens ?? 0;
+      completionTokens += tokens;
+
+      if (firstTokenAt) {
+        ttfts.push(firstTokenAt - started);
+        // Decode rate excludes the wait before generation began, so it isolates
+        // how fast the box emits tokens from how long it made you queue.
+        const decodeSeconds = (Date.now() - firstTokenAt) / 1000;
+        if (decodeSeconds > 0 && tokens > 0) decodeRates.push(tokens / decodeSeconds);
+      }
+    }),
+  );
+
+  const wallSeconds = (Date.now() - wallStart) / 1000;
+  return {
+    concurrency,
+    ttftMs: Math.round(median(ttfts)),
+    tokensPerSecond: wallSeconds > 0 ? Number((completionTokens / wallSeconds).toFixed(1)) : 0,
+    decodeTokensPerSecond: Number(median(decodeRates).toFixed(1)),
+    errors,
+  };
+}
+
+// ── Orchestration ────────────────────────────────────────────────────────────
+
+export interface ProbeOptions {
+  /** Concurrency levels to sample. Default [1]. Try [1, 4] to find the knee. */
+  concurrency?: number[];
+  /** Skip the headroom stage — capabilities only, much faster. */
+  skipHeadroom?: boolean;
+}
+
+/**
+ * Probe one (runtime, model) pair. Capability probes run in sequence rather
+ * than in parallel: on a single-GPU box, concurrent probes would contend and
+ * the headroom numbers would measure our own interference.
+ */
+export async function probeOffer(
+  provider: string,
+  model: string,
+  opts: ProbeOptions = {},
+): Promise<ProbedOffer> {
+  const details: ModelDetails = { name: model, provider };
+  const probedAt = new Date().toISOString();
+
+  const chat = await probeChat(details);
+  if (!chat.supported) {
+    // Nothing downstream is meaningful if it cannot hold a conversation.
+    return {
+      provider,
+      model,
+      probedAt,
+      capabilities: [chat],
+      headroom: [],
+      failed: `chat probe failed: ${chat.evidence}`,
+    };
+  }
+
+  const capabilities: CapabilityProbe[] = [chat];
+  capabilities.push(await probeStreaming(details));
+  capabilities.push(await probeToolCalling(details));
+  capabilities.push(await probeStructuredOutput(details));
+  capabilities.push(await probeReasoning(details));
+
+  const headroom: HeadroomSample[] = [];
+  if (!opts.skipHeadroom) {
+    for (const level of opts.concurrency ?? [1]) {
+      headroom.push(await measureThroughput(details, level));
+    }
+  }
+
+  return { provider, model, probedAt, capabilities, headroom };
+}

--- a/packages/supplier/src/types.ts
+++ b/packages/supplier/src/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Supplier-agent domain types.
+ *
+ * Vocabulary follows `packages/exchange/CONTEXT.md` — the agent and the
+ * Exchange share a bounded context even though they are different deployables.
+ * Two rules from the ADRs are structural here:
+ *
+ *   - **Capabilities are probed, never declared** (ADR 0009). Nothing in this
+ *     file lets an operator assert what a Model can do.
+ *   - **Headroom is measured, never declared.** Same reason, and it is why
+ *     there is no way to hand-write a throughput number.
+ *
+ * Note what is absent: prices. The agent publishes evidence about what a
+ * machine can do; the Exchange decides what to pay and what to charge, because
+ * a Supplier that prices itself takes away the routing lever (ADR 0007).
+ */
+
+export type CapabilityName =
+  | "chat"
+  | "streaming"
+  | "tool-calling"
+  | "structured-output"
+  | "reasoning";
+
+/**
+ * Whether the agent controls the runtime behind an Offer or is reselling one it
+ * does not control. Managed is the default (ADR 0010); adapted is the zero-cost
+ * onboarding path and a lesser tier.
+ */
+export type ServingMode = "managed" | "adapted";
+
+export interface CapabilityProbe {
+  name: CapabilityName;
+  supported: boolean;
+  /** Why we concluded that. Kept so a human can audit a surprising result. */
+  evidence: string;
+  elapsedMs: number;
+}
+
+/**
+ * One throughput measurement.
+ *
+ * Three numbers because they move in different directions and only together
+ * locate saturation: aggregate rises with concurrency until the box saturates,
+ * per-stream decode falls as concurrency climbs, and time-to-first-token rises
+ * under queueing. A flat aggregate with rising TTFT means queueing; a falling
+ * aggregate means real contention.
+ */
+export interface HeadroomSample {
+  concurrency: number;
+  ttftMs: number;
+  tokensPerSecond: number;
+  decodeTokensPerSecond: number;
+  errors: number;
+}
+
+/** A machine state the agent reasons about. Fabricated in tests, real at runtime. */
+export interface MachineState {
+  /** Runtimes that answered, and what each says it serves. */
+  runtimes: { provider: string; reachable: boolean; models: string[]; error?: string }[];
+}
+
+/** What a probe run learned about one (runtime, model) pair. */
+export interface ProbedOffer {
+  provider: string;
+  model: string;
+  probedAt: string;
+  capabilities: CapabilityProbe[];
+  headroom: HeadroomSample[];
+  contextTokens?: number;
+  /** Set when the Model could not be probed at all. No Offer is published. */
+  failed?: string;
+}
+
+/** What the agent sends to the Exchange. */
+export interface OfferDraft {
+  model: string;
+  capabilities: CapabilityName[];
+  servingMode: ServingMode;
+  headroom: HeadroomSample[];
+  contextTokens?: number;
+}
+
+export interface SupplierConfig {
+  /** Where the Exchange lives. */
+  exchangeUrl: string;
+  /** The credential the operator issued when registering this Supplier. */
+  credential: string;
+  /**
+   * Guarantees the operator says this machine is offered under. Echoed to the
+   * Exchange for confirmation only — the Exchange's grant decides, and a claim
+   * beyond it is rejected (ADR 0006).
+   */
+  guarantees: string[];
+  servingMode: ServingMode;
+  /** Restrict probing to these runtimes. Empty means all reachable ones. */
+  providers?: string[];
+  /** Restrict probing to Models whose name contains this. */
+  modelFilter?: string;
+}

--- a/packages/supplier/src/watchdog.ts
+++ b/packages/supplier/src/watchdog.ts
@@ -1,0 +1,85 @@
+/**
+ * Run a task with a hard deadline.
+ *
+ * Promoted from `examples/local-providers/harness/cancellation.ts`, where it was
+ * written for benchmark runs. A probe that hangs must not hang the agent — a
+ * machine with one wedged Model should still publish the rest.
+ */
+
+export interface WatchdogResult<T> {
+  ok: true;
+  value: T;
+  elapsedMs: number;
+}
+
+export interface WatchdogTimeout {
+  ok: false;
+  reason: 'timeout';
+  elapsedMs: number;
+}
+
+export interface WatchdogError {
+  ok: false;
+  reason: 'error';
+  error: unknown;
+  elapsedMs: number;
+}
+
+export type WatchdogOutcome<T> = WatchdogResult<T> | WatchdogTimeout | WatchdogError;
+
+/**
+ * Run `task(signal)` with a watchdog timer. If the timer fires before
+ * the task settles, `controller.abort()` is called and the outcome is
+ * `{ ok: false, reason: 'timeout' }`.
+ *
+ * The task is responsible for honoring the signal (passing it to the
+ * SDK call). If it doesn't, the watchdog timer still resolves the
+ * outer promise — but the underlying work will keep going in the
+ * background, which is exactly the bug this design is meant to expose.
+ */
+export async function runWithWatchdog<T>(opts: {
+  /** Hard ceiling. Default 10 minutes. */
+  timeoutMs?: number;
+  /** Optional caller-supplied signal we should also honor. */
+  parentSignal?: AbortSignal;
+  task: (signal: AbortSignal) => Promise<T>;
+}): Promise<WatchdogOutcome<T>> {
+  const { timeoutMs = 10 * 60_000, parentSignal, task } = opts;
+  const start = Date.now();
+  const controller = new AbortController();
+
+  // Forward the parent signal if one is provided.
+  if (parentSignal) {
+    if (parentSignal.aborted) controller.abort(parentSignal.reason);
+    else parentSignal.addEventListener('abort', () => controller.abort(parentSignal.reason), {
+      once: true,
+    });
+  }
+
+  let timer: NodeJS.Timeout | null = null;
+  const timerPromise = new Promise<WatchdogTimeout>((resolve) => {
+    timer = setTimeout(() => {
+      controller.abort(new Error(`watchdog timeout after ${timeoutMs}ms`));
+      resolve({ ok: false, reason: 'timeout', elapsedMs: Date.now() - start });
+    }, timeoutMs);
+    if (typeof timer.unref === 'function') timer.unref();
+  });
+
+  try {
+    const value = await Promise.race([
+      task(controller.signal).then(
+        (v): WatchdogResult<T> => ({ ok: true, value: v, elapsedMs: Date.now() - start }),
+        (error): WatchdogError => ({
+          ok: false,
+          reason: 'error',
+          error,
+          elapsedMs: Date.now() - start,
+        }),
+      ),
+      timerPromise,
+    ]);
+    return value;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/supplier/tsconfig.json
+++ b/packages/supplier/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "rootDir": "src",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@umwelten/sessions':
         specifier: workspace:*
         version: link:../sessions
+      '@umwelten/supplier':
+        specifier: workspace:*
+        version: link:../supplier
       '@umwelten/ui':
         specifier: workspace:*
         version: link:../ui
@@ -401,6 +404,25 @@ importers:
       cli-table3:
         specifier: ^0.6.5
         version: 0.6.5
+      commander:
+        specifier: ^15.0.0
+        version: 15.0.0
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/supplier:
+    dependencies:
+      '@umwelten/core':
+        specifier: workspace:*
+        version: link:../core
       commander:
         specifier: ^15.0.0
         version: 15.0.0


### PR DESCRIPTION
Closes #305. The prototype becomes `packages/supplier` with a real CLI command — `probe`, `publish`, `withdraw`.

Unblocks #306 (managed mode), #307 (Headroom), and everything downstream on the supply side.

```
$ umwelten supplier --help
Turn this machine into a Supplier the Exchange can dispatch to

Commands:
  probe      Show what this machine can do, without publishing anything
  publish    Probe this machine and publish its Offers to the Exchange
  withdraw   Remove this machine's Offers from the Exchange
```

## Packaging

Its own package, not inside `packages/exchange`. They share a bounded context and both read the exchange glossary, but folding the agent in beside the server would drag a **Postgres driver into every umwelten install** for a command that never opens a database. `packages/supplier` depends on `@umwelten/core` and `commander`, and nothing else in the workspace.

## Decisions

**A failed probe produces no Offer**, rather than an Offer with a missing capability. Those are different claims — *"we did not establish this"* is not *"this machine cannot do it"* — and publishing the second when we only know the first would have Dispatch route around a Model that works.

The mirror case is also tested: an Offer whose capabilities **all** probed false is kept, because that's an established fact the Exchange can filter on.

**Capabilities carry through verbatim.** Two tests assert the published draft contains no price and no guarantee anywhere in it — an Offer's capability set is evidence (ADR 0009), and the moment something is added it stops being evidence; prices are the Exchange's routing lever (ADR 0007).

**Duplicate Models are flagged.** The Exchange keys an Offer on `(Supplier, Model)`, so the same Model published from two runtimes means the second silently overwrites the first. Better to say so than lose one at random.

**A rejected guarantee is surfaced, not swallowed** — a Supplier that believes it's on-premise and isn't needs to hear about it. An unreachable Exchange is *reported* rather than thrown, so a machine keeps running and retries instead of dying.

## Testing

The seam is the Offer set it decides to publish, given a described machine state. No GPU, no network, and no assertions about how the agent got there — 20 tests, all in `pnpm test:run`.

## Verification

- `umwelten supplier --help` and `umwelten supplier probe` both run from the CLI entry point; the latter degrades correctly with no runtimes up
- `pnpm test:run` — 2413 tests passing (20 new)
- `pnpm typecheck` and `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG)_