### PR TITLE
Report what a declaration actually applied, not just its mounts

### DIFF
--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -498,6 +498,14 @@ export function createHabitatLifecycleTools(
 						.filter((a) => (a.kind ?? "repo") === "repo" && a.mode === "read")
 						.map((a) => a.id);
 
+					// Report what was applied, not just what was mounted. An
+					// omitted field reads to a model as an unset one: leaving
+					// provider/model/secrets unmentioned had Gaia conclude they
+					// were missing and go do remedial work that was not needed.
+					// A tool result's silence gets interpreted, so say it.
+					const cfg = result.entry.config;
+					const secrets = result.entry.secretBindings ?? [];
+
 					return [
 						`${result.action === "created" ? "Created" : "Updated"} habitat "${id}" from ${gitUrl}.`,
 						`Mounts: ${mounts.length ? mounts.join(", ") : "(none)"}`,
@@ -505,8 +513,14 @@ export function createHabitatLifecycleTools(
 						result.entry.github?.write?.length
 							? `Write scope (declared, never derived): ${result.entry.github.write.join(", ")}`
 							: "Write scope: (none declared)",
+						cfg.defaultProvider || cfg.defaultModel
+							? `Provider/model (from the declaration): ${cfg.defaultProvider ?? "(unset)"} / ${cfg.defaultModel ?? "(unset)"}`
+							: `Provider/model: not declared — inherits Gaia's defaults.`,
+						secrets.length
+							? `Secret bindings (from the declaration): ${secrets.join(", ")}`
+							: `Secret bindings: none declared.`,
 						result.action === "created"
-							? `Ask "${id}" anything to start it — no separate start step is needed.`
+							? `Nothing further is required. Asking "${id}" starts it, and starting seeds the volume with this config and these secrets — do not seed, grant or rebuild by hand first.`
 							: `Rebuild "${id}" if it is already running, so the new declaration reaches its container.`,
 					].join("\n");
 				} catch (err) {


### PR DESCRIPTION
Found by running the thing for real. First live use of `apply_habitat_declaration` — standing up the UpperHand client habitat.

The tool listed mounts and scopes and said **nothing** about provider, model or secret bindings — all three of which it does in fact apply (`declarationToCreateOptions` passes them straight through to `registry.create`).

Gaia read that silence as "not set", and reported back:

> No provider/model/secrets were set explicitly, so it'll inherit Gaia's defaults unless the declaration in the repo specifies otherwise […] the underlying GitHub App grant may still need `grant_github_access`

It then went looking for a GitHub grant that had already been derived, re-seeded a secret that was already bound, and rebuilt a container that had never started. None of it was harmful; all of it was unnecessary. It happened because a tool result omitted three fields and an agent filled the gap with a guess.

**A tool result's silence gets interpreted.** For a self-provisioning system that is a real failure mode, not a cosmetic one — the whole point of Gaia doing this is that a human isn't checking each step.

So the tool now states the provider, the model and the secret bindings it applied and where they came from, and on a create says outright that nothing further is needed, because starting seeds the volume and asking starts it (#279).

Reporting only — no behaviour change. The fields were being applied before; nobody could tell.

`pnpm test:run` — 193 files, 2393 tests passing. `tsc --noEmit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_