### PR TITLE
Make secret bindings legible, and stop declarations restating the fleet's LLM

### DIFF
--- a/packages/habitat/src/provision/execute.test.ts
+++ b/packages/habitat/src/provision/execute.test.ts
@@ -253,7 +253,14 @@ describe("executeProvisionPlan", () => {
 
     expect(result.aborted).toBeUndefined();
     expect(result.warned.map((s) => s.kind)).toEqual(["clone-agent-repo"]);
-    expect(rec.logs).toContain("[entrypoint] Clone failed for agent web (continuing).");
+    // The warning names the likely cause, not just the fact of failure —
+    // git reports a repo outside the App installation as "could not read
+    // Username", which sends people looking at credentials rather than at
+    // the App's repo list.
+    const warning = rec.logs.find((l) => l.includes("Clone failed for agent web"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("GitHub App is probably not installed");
+    expect(warning).toContain("separate grants");
     expect(rec.markers).toContain("/data/agents/web/.provisioned");
     // Skills still get installed after the failure.
     expect(rec.commands.at(-1)?.command).toContain("npx skills@latest add");

--- a/packages/habitat/src/provision/plan.ts
+++ b/packages/habitat/src/provision/plan.ts
@@ -243,7 +243,17 @@ export function planProvision(input: PlanProvisionInput): ProvisionPlan {
         envNames: agent.envNames,
         announce: `${LOG} Cloning agent ${agent.id} (kind=${agent.kind}, mode=${agent.mode}) from ${agent.gitRemote}...`,
         onFailure: "warn",
-        warning: `${LOG} Clone failed for agent ${agent.id} (continuing).`,
+        // Name the likely cause. Under an installation token git reports a
+        // repo outside the installation as `could not read Username for
+        // 'https://github.com'` — which reads like a missing prompt, not a
+        // missing grant, and sends people looking at credentials instead of
+        // at the App's repo list. Declaring read scope in Gaia does not
+        // install the App; those are two separate grants and only one of
+        // them is ours.
+        warning:
+          `${LOG} Clone failed for agent ${agent.id} from ${agent.gitRemote} (continuing without it).\n` +
+          `${LOG}   If git said "could not read Username", the @habitats GitHub App is probably not installed on that repo.\n` +
+          `${LOG}   Gaia's read scope and the App's installation are separate grants — declaring the scope does not add the repo to the App.`,
       });
     } else {
       steps.push({

--- a/packages/habitat/src/tools/gaia/apply-declaration.ts
+++ b/packages/habitat/src/tools/gaia/apply-declaration.ts
@@ -22,6 +22,7 @@ import {
 	HabitatDeclarationError,
 	declarationToCreateOptions,
 	parseHabitatDeclaration,
+	type DeclarationDefaults,
 	type HabitatDeclaration,
 } from "./declaration.js";
 import { mountsToAgentEntries } from "./mounts.js";
@@ -54,6 +55,12 @@ export interface ApplyDeclarationOptions {
 		gitUrl: string,
 		gitBranch?: string,
 	) => Promise<string | undefined>;
+	/**
+	 * Fleet policy the declaration inherits when it says nothing: Gaia's own
+	 * provider and model, and how to find a provider's key. A client repo
+	 * has no opinion about which model reads it.
+	 */
+	defaults?: DeclarationDefaults;
 }
 
 export interface ApplyResult {
@@ -89,6 +96,7 @@ export async function applyHabitatDeclaration(
 		id: options.id,
 		gitUrl: options.gitUrl,
 		...(options.gitBranch ? { gitBranch: options.gitBranch } : {}),
+		...(options.defaults ? { defaults: options.defaults } : {}),
 	});
 
 	const existing = registry.get(options.id);
@@ -123,8 +131,12 @@ export async function applyHabitatDeclaration(
 	const entry = await registry.update(options.id, {
 		name: createOptions.name,
 		config,
-		...(declaration.secretBindings
-			? { secretBindings: declaration.secretBindings }
+		// Use the resolved bindings, not the raw declaration: they include the
+		// provider's own key, which the declaration is not required to state.
+		// Taking the raw list here would strip that key on every re-apply and
+		// silently break a habitat that was working.
+		...(createOptions.secretBindings
+			? { secretBindings: createOptions.secretBindings }
 			: {}),
 		// Read is re-derived from what the declaration says to mount, so removing
 		// a mount in the repo actually narrows the scope. Write comes only from

--- a/packages/habitat/src/tools/gaia/declaration.test.ts
+++ b/packages/habitat/src/tools/gaia/declaration.test.ts
@@ -122,3 +122,76 @@ describe("declarationToCreateOptions", () => {
 		).toBe("main");
 	});
 });
+
+/**
+ * A client repo has no opinion about which model reads it, or where that
+ * model's key is kept. Making fifteen client declarations restate the same
+ * provider, model and key name is fifteen places for it to drift — and the
+ * first one that got it wrong produced a habitat that started and then
+ * failed on its first question.
+ */
+describe("declarationToCreateOptions — fleet defaults (#277 follow-up)", () => {
+	const ctx = {
+		id: "upperhand",
+		gitUrl: "https://github.com/The-Focus-AI/client-upperhand.git",
+		defaults: {
+			provider: "google",
+			model: "gemini-3-flash-preview",
+			providerEnvVar: (p: string) =>
+				p === "google" ? "GOOGLE_GENERATIVE_AI_API_KEY" : undefined,
+		},
+	};
+
+	it("inherits Gaia's provider and model when the declaration says nothing", () => {
+		const opts = declarationToCreateOptions({}, ctx);
+		expect(opts.provider).toBe("google");
+		expect(opts.model).toBe("gemini-3-flash-preview");
+	});
+
+	it("lets the declaration override the fleet default", () => {
+		const opts = declarationToCreateOptions(
+			{ provider: "openrouter", model: "anthropic/claude-sonnet-5" },
+			{ ...ctx, defaults: { ...ctx.defaults, providerEnvVar: () => "OPENROUTER_API_KEY" } },
+		);
+		expect(opts.provider).toBe("openrouter");
+		expect(opts.model).toBe("anthropic/claude-sonnet-5");
+	});
+
+	it("binds the provider's key without the declaration naming it", () => {
+		const opts = declarationToCreateOptions({}, ctx);
+		expect(opts.secretBindings).toEqual(["GOOGLE_GENERATIVE_AI_API_KEY"]);
+	});
+
+	it("does not duplicate a key the declaration already binds", () => {
+		const opts = declarationToCreateOptions(
+			{ secretBindings: ["GOOGLE_GENERATIVE_AI_API_KEY"] },
+			ctx,
+		);
+		expect(opts.secretBindings).toEqual(["GOOGLE_GENERATIVE_AI_API_KEY"]);
+	});
+
+	it("keeps declared bindings alongside the provider key", () => {
+		const opts = declarationToCreateOptions({ secretBindings: ["TAVILY_API_KEY"] }, ctx);
+		expect(opts.secretBindings).toEqual([
+			"TAVILY_API_KEY",
+			"GOOGLE_GENERATIVE_AI_API_KEY",
+		]);
+	});
+
+	it("binds nothing extra for a provider with no known env var", () => {
+		const opts = declarationToCreateOptions(
+			{ provider: "ollama" },
+			{ ...ctx, defaults: { ...ctx.defaults, providerEnvVar: () => undefined } },
+		);
+		expect(opts.secretBindings).toBeUndefined();
+	});
+
+	it("works with no defaults at all, as before", () => {
+		const opts = declarationToCreateOptions(
+			{ provider: "google", secretBindings: ["K"] },
+			{ id: "x", gitUrl: "https://example.com/r.git" },
+		);
+		expect(opts.provider).toBe("google");
+		expect(opts.secretBindings).toEqual(["K"]);
+	});
+});

--- a/packages/habitat/src/tools/gaia/declaration.ts
+++ b/packages/habitat/src/tools/gaia/declaration.ts
@@ -161,28 +161,68 @@ export function parseHabitatDeclaration(source: string): HabitatDeclaration {
 	};
 }
 
+/** Fleet-level defaults a declaration inherits when it says nothing. */
+export interface DeclarationDefaults {
+	/** Gaia's own provider. */
+	provider?: string;
+	/** Gaia's own model. */
+	model?: string;
+	/**
+	 * Provider name → the env var its key lives in, from the core provider
+	 * registry. Injected rather than imported so this file stays pure.
+	 */
+	providerEnvVar?: (provider: string) => string | undefined;
+}
+
 /**
  * Turn a declaration into creation options.
  *
  * `id` and `gitUrl` come from outside the declaration — the id is how the
  * fleet addresses this habitat and the Owned repo is where the declaration
  * was found, so neither is the declaration's to state.
+ *
+ * Neither is the LLM. A client repo has no opinion about which model reads
+ * it or where that key is kept — that is fleet policy, and repeating it in
+ * fifteen client declarations is fifteen places for it to drift. So an
+ * omitted provider/model inherits Gaia's own, exactly as `create_habitat`
+ * has always done; a declaration only has to state what is *particular* to
+ * this habitat, which is usually just its mounts.
+ *
+ * The provider's key is bound automatically for the same reason. A habitat
+ * running on `google` needs `GOOGLE_GENERATIVE_AI_API_KEY`; making someone
+ * write that down is asking them to restate a fact the provider registry
+ * already knows, and getting it wrong produces a habitat that starts and
+ * then fails on its first question.
  */
 export function declarationToCreateOptions(
 	declaration: HabitatDeclaration,
-	context: { id: string; gitUrl: string; gitBranch?: string },
+	context: {
+		id: string;
+		gitUrl: string;
+		gitBranch?: string;
+		defaults?: DeclarationDefaults;
+	},
 ): CreateHabitatOptions {
+	const defaults = context.defaults ?? {};
+	const provider = declaration.provider ?? defaults.provider;
+	const model = declaration.model ?? defaults.model;
+
+	// Declared bindings win; the provider's own key is added if absent.
+	const secretBindings = [...(declaration.secretBindings ?? [])];
+	const providerKey = provider ? defaults.providerEnvVar?.(provider) : undefined;
+	if (providerKey && !secretBindings.includes(providerKey)) {
+		secretBindings.push(providerKey);
+	}
+
 	return {
 		id: context.id,
 		name: declaration.name ?? context.id,
 		gitUrl: context.gitUrl,
 		...(context.gitBranch ? { gitBranch: context.gitBranch } : {}),
-		...(declaration.provider ? { provider: declaration.provider } : {}),
-		...(declaration.model ? { model: declaration.model } : {}),
+		...(provider ? { provider } : {}),
+		...(model ? { model } : {}),
 		...(declaration.mounts ? { mounts: declaration.mounts } : {}),
-		...(declaration.secretBindings
-			? { secretBindings: declaration.secretBindings }
-			: {}),
+		...(secretBindings.length ? { secretBindings } : {}),
 		...(declaration.skillsFromGit
 			? { skillsFromGit: declaration.skillsFromGit }
 			: {}),

--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -9,6 +9,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import type { Tool } from "ai";
 import { sendA2AMessage } from "@umwelten/protocols";
+import { getRegisteredProvider } from "@umwelten/core/providers/index.js";
 import { CapabilityResolver } from "../capability-resolver.js";
 import { seedOrgReadonly, seedStandardsAgent } from "../gaia-seed.js";
 import { type GaiaToolsContext, entryToEndpoint, discoverHabitats, entryOpenUrl } from "./context.js";
@@ -503,6 +504,13 @@ export function createHabitatLifecycleTools(
 						...(gitBranch ? { gitBranch } : {}),
 						readDeclaration: (url, ref) =>
 							readDeclarationFromRepo(url, ref, { token: ambient?.token }),
+						// Fleet policy the repo does not have to restate: Gaia's own
+						// provider and model, and where a provider keeps its key.
+						defaults: {
+							...(gaiaProvider ? { provider: gaiaProvider } : {}),
+							...(gaiaModel ? { model: gaiaModel } : {}),
+							providerEnvVar: (p) => getRegisteredProvider(p)?.envVar,
+						},
 					});
 
 					const read = result.entry.github?.read;

--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -16,6 +16,7 @@ import { applyHabitatDeclaration } from "../apply-declaration.js";
 import { readDeclarationFromRepo } from "../read-declaration.js";
 import { recordHabitatActivity } from "../reaper.js";
 import { HabitatWaker, createWakeTools } from "../waker.js";
+import { habitatSecretStatus } from "../secret-status.js";
 import { buildSeedFiles } from "./seed-files.js";
 
 /**
@@ -225,6 +226,18 @@ export function createHabitatLifecycleTools(
 				if (entry.secretBindings.length === 0) {
 					warnings.push(
 						"WARNING: No secrets bound — the habitat has no API keys. Use bind_secret to add them.",
+					);
+				}
+				// A binding the vault cannot satisfy is dropped from the seeded
+				// secrets.json rather than failing, so the habitat boots and
+				// health-checks fine and fails on first use. Say it here, where
+				// the person who declared the binding is still looking.
+				const gaps = habitatSecretStatus(entry, vault).missing;
+				if (gaps.length) {
+					warnings.push(
+						`WARNING: bound but missing from the master vault: ${gaps.join(", ")}. ` +
+							`These were NOT written to the volume — the container will start and then fail on first use. ` +
+							`Add them with set_secret, then rebuild.`,
 					);
 				}
 				const notes: string[] = [];
@@ -519,6 +532,18 @@ export function createHabitatLifecycleTools(
 						secrets.length
 							? `Secret bindings (from the declaration): ${secrets.join(", ")}`
 							: `Secret bindings: none declared.`,
+						...(() => {
+							// The declaration can bind a secret the vault has never
+							// heard of. That is not an error here — but it is the
+							// difference between a habitat that works and one that
+							// starts and then fails, so it does not get to be quiet.
+							const gaps = habitatSecretStatus(result.entry, vault).missing;
+							return gaps.length
+								? [
+										`MISSING from the master vault: ${gaps.join(", ")}. Declared, but there is no value to seed — add with set_secret before asking it anything.`,
+									]
+								: [];
+						})(),
 						result.action === "created"
 							? `Nothing further is required. Asking "${id}" starts it, and starting seeds the volume with this config and these secrets — do not seed, grant or rebuild by hand first.`
 							: `Rebuild "${id}" if it is already running, so the new declaration reaches its container.`,

--- a/packages/habitat/src/tools/gaia/gaia-tools/secrets.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/secrets.ts
@@ -10,11 +10,36 @@ import { tool } from "ai";
 import { z } from "zod";
 import type { Tool } from "ai";
 import type { GaiaToolsContext } from "./context.js";
+import {
+	describeFleetSecretStatus,
+	fleetSecretStatus,
+	habitatSecretStatus,
+} from "../secret-status.js";
 
 export function createSecretsTools(ctx: GaiaToolsContext): Record<string, Tool> {
 	const { registry, vault } = ctx;
 
 	return {
+		secret_status: tool({
+			description:
+				"Show which habitat is bound to which secret, and whether the master vault can actually supply it. A binding the vault cannot satisfy is dropped from the habitat's secrets.json rather than failing the start — so the container boots, health-checks fine, and then fails on first use. Check this before blaming the container. Optionally scope to one habitat.",
+			inputSchema: z.object({
+				habitatId: z
+					.string()
+					.optional()
+					.describe("Limit to one habitat; omit for the whole fleet"),
+			}),
+			execute: async ({ habitatId }) => {
+				const entries = habitatId
+					? registry.list().filter((h) => h.id === habitatId)
+					: registry.list();
+				if (habitatId && entries.length === 0) {
+					return `Habitat "${habitatId}" not found`;
+				}
+				return describeFleetSecretStatus(fleetSecretStatus(entries, vault));
+			},
+		}),
+
 		set_secret: tool({
 			description: "Add or update a secret in the master vault.",
 			inputSchema: z.object({
@@ -56,7 +81,14 @@ export function createSecretsTools(ctx: GaiaToolsContext): Record<string, Tool> 
 						secretBindings: entry.secretBindings,
 					});
 				}
-				return `Secret "${secretName}" bound to habitat "${habitatId}"`;
+				// Report the whole picture, not just this one binding. A habitat
+				// with one good binding and one unsatisfiable one still starts
+				// and still fails, and this is the moment someone is looking.
+				const status = habitatSecretStatus(entry, vault);
+				const gap = status.missing.length
+					? `\nStill unsatisfiable for "${habitatId}": ${status.missing.join(", ")} — bound, but the vault has no value, so they will be missing from the container.`
+					: "";
+				return `Secret "${secretName}" bound to habitat "${habitatId}". Rebuild for it to reach a running container.${gap}`;
 			},
 		}),
 	};

--- a/packages/habitat/src/tools/gaia/secret-status.test.ts
+++ b/packages/habitat/src/tools/gaia/secret-status.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+	describeFleetSecretStatus,
+	fleetSecretStatus,
+	habitatSecretStatus,
+	type SecretPresence,
+} from "./secret-status.js";
+import type { GaiaHabitatEntry } from "./types.js";
+
+function vaultOf(secrets: Record<string, string>): SecretPresence {
+	return {
+		listNames: () => Object.keys(secrets),
+		get: (name) => secrets[name],
+	};
+}
+
+function entry(
+	id: string,
+	secretBindings: string[] = [],
+): GaiaHabitatEntry {
+	return {
+		id,
+		name: id,
+		config: {} as GaiaHabitatEntry["config"],
+		secretBindings,
+		createdAt: "2026-07-01T00:00:00.000Z",
+	} as GaiaHabitatEntry;
+}
+
+const KEY = "GOOGLE_GENERATIVE_AI_API_KEY";
+
+describe("habitatSecretStatus", () => {
+	it("separates bindings the vault can supply from ones it cannot", () => {
+		const status = habitatSecretStatus(
+			entry("upperhand", [KEY, "TAVILY_API_KEY"]),
+			vaultOf({ [KEY]: "abc" }),
+		);
+
+		expect(status.satisfied).toEqual([KEY]);
+		expect(status.missing).toEqual(["TAVILY_API_KEY"]);
+	});
+
+	/**
+	 * The live failure this exists to catch: the habitat bound the key, the
+	 * vault did not have it, the seeded secrets.json was empty, the container
+	 * booted and health-checked fine, and the first real question failed.
+	 */
+	it("reports a binding the vault has never heard of", () => {
+		const status = habitatSecretStatus(entry("upperhand", [KEY]), vaultOf({}));
+
+		expect(status.satisfied).toEqual([]);
+		expect(status.missing).toEqual([KEY]);
+	});
+
+	/** An empty string is not a usable credential — treating it as present
+	 * would reproduce the same failure one layer down. */
+	it("treats an empty value as missing, not satisfied", () => {
+		const status = habitatSecretStatus(
+			entry("upperhand", [KEY]),
+			vaultOf({ [KEY]: "" }),
+		);
+
+		expect(status.missing).toEqual([KEY]);
+	});
+
+	it("handles a habitat that binds nothing", () => {
+		const status = habitatSecretStatus(entry("bare"), vaultOf({ [KEY]: "x" }));
+		expect(status).toMatchObject({ satisfied: [], missing: [] });
+	});
+});
+
+describe("fleetSecretStatus", () => {
+	it("flags gaps anywhere in the fleet", () => {
+		const status = fleetSecretStatus(
+			[entry("a", [KEY]), entry("b", ["MISSING_KEY"])],
+			vaultOf({ [KEY]: "x" }),
+		);
+
+		expect(status.hasGaps).toBe(true);
+		expect(status.habitats.find((h) => h.id === "b")?.missing).toEqual([
+			"MISSING_KEY",
+		]);
+	});
+
+	it("reports no gaps when every binding resolves", () => {
+		const status = fleetSecretStatus(
+			[entry("a", [KEY]), entry("b", [KEY])],
+			vaultOf({ [KEY]: "x" }),
+		);
+		expect(status.hasGaps).toBe(false);
+	});
+
+	it("lists vault secrets no habitat binds", () => {
+		const status = fleetSecretStatus(
+			[entry("a", [KEY])],
+			vaultOf({ [KEY]: "x", ORPHAN: "y" }),
+		);
+		expect(status.unbound).toEqual(["ORPHAN"]);
+	});
+
+	/**
+	 * The flat master vault means one value per name for the whole fleet
+	 * (ADR 0009 / #283). Two habitats binding the same name is therefore
+	 * normal today, and must not read as a conflict.
+	 */
+	it("does not treat two habitats sharing a secret name as a problem", () => {
+		const status = fleetSecretStatus(
+			[entry("a", [KEY]), entry("b", [KEY])],
+			vaultOf({ [KEY]: "x" }),
+		);
+		expect(status.unbound).toEqual([]);
+		expect(status.hasGaps).toBe(false);
+	});
+
+	it("handles an empty fleet", () => {
+		const status = fleetSecretStatus([], vaultOf({ [KEY]: "x" }));
+		expect(status.habitats).toEqual([]);
+		expect(status.unbound).toEqual([KEY]);
+	});
+});
+
+describe("describeFleetSecretStatus", () => {
+	it("leads with the gaps and explains why the container looks healthy", () => {
+		const text = describeFleetSecretStatus(
+			fleetSecretStatus([entry("upperhand", [KEY])], vaultOf({})),
+		);
+
+		expect(text.split("\n")[0]).toContain("MISSING");
+		expect(text).toContain("upperhand");
+		expect(text).toContain(KEY);
+		expect(text).toContain("health-checks fine");
+		expect(text).toContain("set_secret");
+	});
+
+	it("says nothing alarming when everything resolves", () => {
+		const text = describeFleetSecretStatus(
+			fleetSecretStatus([entry("upperhand", [KEY])], vaultOf({ [KEY]: "x" })),
+		);
+
+		expect(text).not.toContain("MISSING");
+		expect(text).toContain(`OK upperhand: ${KEY}`);
+	});
+
+	it("is explicit about a habitat with no bindings at all", () => {
+		const text = describeFleetSecretStatus(
+			fleetSecretStatus([entry("bare")], vaultOf({})),
+		);
+		expect(text).toContain("(no secrets bound)");
+	});
+
+	it("handles an empty fleet", () => {
+		expect(
+			describeFleetSecretStatus(fleetSecretStatus([], vaultOf({}))),
+		).toBe("No habitats registered.");
+	});
+});

--- a/packages/habitat/src/tools/gaia/secret-status.ts
+++ b/packages/habitat/src/tools/gaia/secret-status.ts
@@ -1,0 +1,117 @@
+/**
+ * Who needs which secret, and can the vault actually supply it.
+ *
+ * Gaia already tracks which habitat gets which secret — that is what
+ * `entry.secretBindings` is, and `buildSeedFiles` writes only the bound names
+ * into a habitat's volume. What was missing is any way to see whether a
+ * binding can be *satisfied*.
+ *
+ * `buildSeedFiles` drops a bound name the vault has no value for, silently and
+ * by design — there is nothing to write. The cost of that silence, found while
+ * standing up the first client habitat: a habitat bound
+ * `GOOGLE_GENERATIVE_AI_API_KEY`, the vault did not have it, the volume was
+ * seeded with an empty secrets file, the container booted, and the health check
+ * passed — because health does not call a model. The first real question failed
+ * with `GOOGLE_GENERATIVE_AI_API_KEY environment variable is required`, three
+ * rebuilds away from the cause.
+ *
+ * A missing binding is knowable before the container starts. This makes it
+ * knowable, and the check is deliberately pure so it can run at bind time, at
+ * start time, and on demand without a Docker daemon anywhere near it.
+ */
+
+import type { GaiaHabitatEntry } from "./types.js";
+
+/** The vault surface this needs — names and presence, never values. */
+export interface SecretPresence {
+	listNames(): string[];
+	get(name: string): string | undefined;
+}
+
+export interface HabitatSecretStatus {
+	id: string;
+	name: string;
+	/** Bound names the vault can supply. */
+	satisfied: string[];
+	/**
+	 * Bound names the vault has no value for. These are silently absent from
+	 * the container's secrets.json, so the habitat starts and then fails on
+	 * first use of whatever needed them.
+	 */
+	missing: string[];
+}
+
+export interface FleetSecretStatus {
+	habitats: HabitatSecretStatus[];
+	/** Vault secrets no habitat binds. Not a problem — but worth seeing. */
+	unbound: string[];
+	/** True when at least one habitat has an unsatisfiable binding. */
+	hasGaps: boolean;
+}
+
+export function habitatSecretStatus(
+	entry: GaiaHabitatEntry,
+	vault: SecretPresence,
+): HabitatSecretStatus {
+	const satisfied: string[] = [];
+	const missing: string[] = [];
+	for (const name of entry.secretBindings ?? []) {
+		// An empty string is not a usable credential. Treating it as satisfied
+		// would reproduce the failure this exists to catch, one layer down.
+		if (vault.get(name)) satisfied.push(name);
+		else missing.push(name);
+	}
+	return { id: entry.id, name: entry.name, satisfied, missing };
+}
+
+export function fleetSecretStatus(
+	entries: GaiaHabitatEntry[],
+	vault: SecretPresence,
+): FleetSecretStatus {
+	const habitats = entries.map((e) => habitatSecretStatus(e, vault));
+	const boundAnywhere = new Set(
+		entries.flatMap((e) => e.secretBindings ?? []),
+	);
+	return {
+		habitats,
+		unbound: vault.listNames().filter((n) => !boundAnywhere.has(n)),
+		hasGaps: habitats.some((h) => h.missing.length > 0),
+	};
+}
+
+/** One line per habitat, gaps first — the answer to "who gets what". */
+export function describeFleetSecretStatus(status: FleetSecretStatus): string {
+	if (status.habitats.length === 0) return "No habitats registered.";
+
+	const lines: string[] = [];
+	const gaps = status.habitats.filter((h) => h.missing.length > 0);
+	const ok = status.habitats.filter((h) => h.missing.length === 0);
+
+	if (gaps.length) {
+		lines.push("MISSING — bound but the master vault has no value:");
+		for (const h of gaps) {
+			lines.push(
+				`  ${h.id}: ${h.missing.join(", ")}` +
+					(h.satisfied.length ? `  (has: ${h.satisfied.join(", ")})` : ""),
+			);
+		}
+		lines.push(
+			"  These are dropped from the habitat's secrets.json rather than failing the start,",
+			"  so the container boots and health-checks fine and then fails on first use.",
+			"  Fix with set_secret (adds the value to the master vault), then rebuild.",
+			"",
+		);
+	}
+
+	for (const h of ok) {
+		lines.push(
+			`OK ${h.id}: ${h.satisfied.length ? h.satisfied.join(", ") : "(no secrets bound)"}`,
+		);
+	}
+
+	if (status.unbound.length) {
+		lines.push("", `In the vault, bound to nothing: ${status.unbound.join(", ")}`);
+	}
+
+	return lines.join("\n");
+}

--- a/packages/habitat/src/tools/gaia/secrets.ts
+++ b/packages/habitat/src/tools/gaia/secrets.ts
@@ -74,25 +74,21 @@ export class GaiaSecretVault {
     return true;
   }
 
-  /**
-   * Write filtered secrets for a specific habitat container.
-   * Only secrets listed in `entry.secretBindings` are included.
-   */
-  async writeFilteredSecrets(entry: GaiaHabitatEntry, habitatDataDir: string): Promise<void> {
-    this.ensureLoaded();
-
-    const filtered: Record<string, string> = {};
-    for (const name of entry.secretBindings) {
-      if (name in this.secrets) {
-        filtered[name] = this.secrets[name];
-      }
-    }
-
-    await mkdir(habitatDataDir, { recursive: true });
-    await writeFile(
-      join(habitatDataDir, SECRETS_FILE),
-      JSON.stringify(filtered, null, 2) + "\n",
-      { mode: 0o600 },
-    );
-  }
 }
+
+/*
+ * `writeFilteredSecrets` used to live here: it filtered the vault by a
+ * habitat's bindings and wrote the result to that habitat's data dir. It had
+ * no callers — every seeding path goes through `buildSeedFiles`, which does
+ * the same filtering and hands the files to `docker.seedVolume`.
+ *
+ * Removed rather than left in place because it was a trap. It silently
+ * dropped a bound name the vault had no value for, which is the bug that
+ * cost three rebuilds on the first client habitat, and anyone finding it
+ * would reasonably assume it was the live path and fix it here instead of in
+ * `buildSeedFiles`. Two implementations of one rule, one of them dead, is
+ * worse than one.
+ *
+ * See `secret-status.ts` for how a binding the vault cannot satisfy is
+ * surfaced now.
+ */


### PR DESCRIPTION
Three findings from standing up the first client habitat. The original scope of this PR (the clone diagnostic) is item 3.

## 1. An unsatisfiable secret binding was invisible until it was an outage

Gaia already tracks who gets what — `entry.secretBindings` holds the names, `buildSeedFiles` writes only those into the volume, the master vault holds the values. **The tracking was never the problem.**

The problem is `seed-files.ts:35`:

```ts
const val = vault.get(name);
if (val) filtered[name] = val;   // no value → silently skipped
```

`upperhand` bound `GOOGLE_GENERATIVE_AI_API_KEY`, the vault didn't have it, the volume was seeded with an empty secrets file, the container started, and **the health check passed — because health doesn't call a model.** The first real question failed with `GOOGLE_GENERATIVE_AI_API_KEY environment variable is required`, several rebuilds from the cause.

All of that was knowable before the container started:

- `secret-status.ts` — who needs what, and can the vault supply it. Pure, so it runs at bind time, start time and on demand with no Docker anywhere near it.
- **`secret_status` tool** — fleet or single habitat, gaps first. This is the thing that was missing: `list_secrets` showed vault names, the registry held bindings, and *nothing showed the join*.
- `bind_secret` reports what is still unsatisfiable after the bind — that is when someone is looking.
- `create_habitat` and `apply_habitat_declaration` warn when a declared binding has no value behind it, and say what that means: it starts, then fails.

An empty string counts as missing; treating it as present reproduces the failure one layer down.

Also removed `GaiaSecretVault.writeFilteredSecrets` — **zero callers**, and it carried the same silent-drop behaviour, so whoever found it would reasonably have fixed the dead copy.

## 2. Declarations shouldn't restate the fleet's LLM

*"Why does this particular repo need that secret?"* It doesn't. A client repo has no opinion about which model reads it or where that key is kept. Both are fleet policy, and restating them in fifteen client declarations is fifteen places to drift.

Two creation paths had also quietly diverged: `create_habitat` defaults an omitted provider/model to Gaia's own, while `apply_habitat_declaration` called `registry.create` directly and defaulted **nothing** — so the repo-backed path, the one meant to be sanctioned, was the stricter of the two.

Now an omitted provider/model inherits Gaia's, and the provider's key is bound automatically via the core provider registry's `envVar`. A declaration that names them still wins — this is a default, not a policy.

The update path uses the **resolved** bindings rather than the raw declaration; taking the raw list would strip the inherited provider key on every re-apply and silently break a working habitat.

`client-upperhand`'s declaration is now just a name and four mounts.

## 3. A failed mount clone now names its cause

`Clone failed for agent X (continuing)` plus git's `could not read Username` reads like a credentials problem. Under an installation token it means the repo is **outside the App installation**. Gaia's read scope and the App's repo allowlist are separate grants and only one of them is ours; the warning now says so.

`execute.test.ts` asserted the old string verbatim and now asserts the cause is named — flagging since changing an assertion deserves scrutiny. The behaviour under test (warn, continue, still mark attempted) is unchanged.

## Verification

- `pnpm test:run` — 194 files, 2413 tests passing
- `tsc --noEmit` clean across every package