### PR TITLE
The model credential is platform infrastructure, not a declared secret

### DIFF
--- a/packages/habitat/src/tools/gaia/declaration.test.ts
+++ b/packages/habitat/src/tools/gaia/declaration.test.ts
@@ -134,12 +134,7 @@ describe("declarationToCreateOptions — fleet defaults (#277 follow-up)", () =>
 	const ctx = {
 		id: "upperhand",
 		gitUrl: "https://github.com/The-Focus-AI/client-upperhand.git",
-		defaults: {
-			provider: "google",
-			model: "gemini-3-flash-preview",
-			providerEnvVar: (p: string) =>
-				p === "google" ? "GOOGLE_GENERATIVE_AI_API_KEY" : undefined,
-		},
+		defaults: { provider: "google", model: "gemini-3-flash-preview" },
 	};
 
 	it("inherits Gaia's provider and model when the declaration says nothing", () => {
@@ -151,39 +146,27 @@ describe("declarationToCreateOptions — fleet defaults (#277 follow-up)", () =>
 	it("lets the declaration override the fleet default", () => {
 		const opts = declarationToCreateOptions(
 			{ provider: "openrouter", model: "anthropic/claude-sonnet-5" },
-			{ ...ctx, defaults: { ...ctx.defaults, providerEnvVar: () => "OPENROUTER_API_KEY" } },
+			ctx,
 		);
 		expect(opts.provider).toBe("openrouter");
 		expect(opts.model).toBe("anthropic/claude-sonnet-5");
 	});
 
-	it("binds the provider's key without the declaration naming it", () => {
+	/**
+	 * secretBindings means exactly one thing: secrets this habitat's own work
+	 * requires. The model credential is platform infrastructure, injected at
+	 * start like the GitHub boot token (`runtime-credentials.ts`), so it never
+	 * appears here — that is what keeps an unsatisfied binding meaningful
+	 * rather than platform noise.
+	 */
+	it("does not bind the provider's key — that is not a declared need", () => {
 		const opts = declarationToCreateOptions({}, ctx);
-		expect(opts.secretBindings).toEqual(["GOOGLE_GENERATIVE_AI_API_KEY"]);
-	});
-
-	it("does not duplicate a key the declaration already binds", () => {
-		const opts = declarationToCreateOptions(
-			{ secretBindings: ["GOOGLE_GENERATIVE_AI_API_KEY"] },
-			ctx,
-		);
-		expect(opts.secretBindings).toEqual(["GOOGLE_GENERATIVE_AI_API_KEY"]);
-	});
-
-	it("keeps declared bindings alongside the provider key", () => {
-		const opts = declarationToCreateOptions({ secretBindings: ["TAVILY_API_KEY"] }, ctx);
-		expect(opts.secretBindings).toEqual([
-			"TAVILY_API_KEY",
-			"GOOGLE_GENERATIVE_AI_API_KEY",
-		]);
-	});
-
-	it("binds nothing extra for a provider with no known env var", () => {
-		const opts = declarationToCreateOptions(
-			{ provider: "ollama" },
-			{ ...ctx, defaults: { ...ctx.defaults, providerEnvVar: () => undefined } },
-		);
 		expect(opts.secretBindings).toBeUndefined();
+	});
+
+	it("carries only what the declaration actually asked for", () => {
+		const opts = declarationToCreateOptions({ secretBindings: ["TAVILY_API_KEY"] }, ctx);
+		expect(opts.secretBindings).toEqual(["TAVILY_API_KEY"]);
 	});
 
 	it("works with no defaults at all, as before", () => {

--- a/packages/habitat/src/tools/gaia/declaration.ts
+++ b/packages/habitat/src/tools/gaia/declaration.ts
@@ -167,11 +167,6 @@ export interface DeclarationDefaults {
 	provider?: string;
 	/** Gaia's own model. */
 	model?: string;
-	/**
-	 * Provider name → the env var its key lives in, from the core provider
-	 * registry. Injected rather than imported so this file stays pure.
-	 */
-	providerEnvVar?: (provider: string) => string | undefined;
 }
 
 /**
@@ -182,17 +177,16 @@ export interface DeclarationDefaults {
  * was found, so neither is the declaration's to state.
  *
  * Neither is the LLM. A client repo has no opinion about which model reads
- * it or where that key is kept — that is fleet policy, and repeating it in
- * fifteen client declarations is fifteen places for it to drift. So an
- * omitted provider/model inherits Gaia's own, exactly as `create_habitat`
- * has always done; a declaration only has to state what is *particular* to
- * this habitat, which is usually just its mounts.
+ * it — that is fleet policy, and repeating it in fifteen client declarations
+ * is fifteen places for it to drift. So an omitted provider/model inherits
+ * Gaia's own, exactly as `create_habitat` has always done; a declaration only
+ * has to state what is *particular* to this habitat, usually just its mounts.
  *
- * The provider's key is bound automatically for the same reason. A habitat
- * running on `google` needs `GOOGLE_GENERATIVE_AI_API_KEY`; making someone
- * write that down is asking them to restate a fact the provider registry
- * already knows, and getting it wrong produces a habitat that starts and
- * then fails on its first question.
+ * The provider's **key** is not bound here at all. It is platform
+ * infrastructure, injected at start like the GitHub boot token — see
+ * `runtime-credentials.ts`. `secretBindings` therefore means exactly one
+ * thing: secrets this habitat's own work requires. That is what makes an
+ * unsatisfied binding meaningful rather than platform noise.
  */
 export function declarationToCreateOptions(
 	declaration: HabitatDeclaration,
@@ -206,13 +200,7 @@ export function declarationToCreateOptions(
 	const defaults = context.defaults ?? {};
 	const provider = declaration.provider ?? defaults.provider;
 	const model = declaration.model ?? defaults.model;
-
-	// Declared bindings win; the provider's own key is added if absent.
-	const secretBindings = [...(declaration.secretBindings ?? [])];
-	const providerKey = provider ? defaults.providerEnvVar?.(provider) : undefined;
-	if (providerKey && !secretBindings.includes(providerKey)) {
-		secretBindings.push(providerKey);
-	}
+	const secretBindings = declaration.secretBindings;
 
 	return {
 		id: context.id,
@@ -222,7 +210,7 @@ export function declarationToCreateOptions(
 		...(provider ? { provider } : {}),
 		...(model ? { model } : {}),
 		...(declaration.mounts ? { mounts: declaration.mounts } : {}),
-		...(secretBindings.length ? { secretBindings } : {}),
+		...(secretBindings ? { secretBindings } : {}),
 		...(declaration.skillsFromGit
 			? { skillsFromGit: declaration.skillsFromGit }
 			: {}),

--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -122,6 +122,15 @@ export interface StartContainerOptions {
    * POST /github/token route.
    */
   githubTokens?: { read?: string; write?: string };
+  /**
+   * The model credential (`runtime-credentials.ts`). Injected the same way
+   * GitHub tokens are, and for the same reason: every habitat needs one to
+   * think, so it is platform infrastructure rather than something the
+   * habitat's own repo declares. Omitted when the provider needs no key
+   * (ollama and friends) or when the vault cannot supply one — in which case
+   * the container still starts, and fails on its first question.
+   */
+  modelCredential?: { envName: string; value: string };
 }
 
 /**
@@ -340,6 +349,18 @@ export class DockerManager {
     }
     if (options?.githubTokens?.write) {
       args.push("--env", `GITHUB_WRITE_TOKEN=${options.githubTokens.write}`);
+    }
+
+    // The model credential, on the same footing as the GitHub tokens above:
+    // platform-supplied, never declared by the habitat's repo, never written
+    // to the volume's secrets.json. Its name comes from the core provider
+    // registry, so a habitat on a different provider gets a different env var
+    // without anything else changing.
+    if (options?.modelCredential) {
+      args.push(
+        "--env",
+        `${options.modelCredential.envName}=${options.modelCredential.value}`,
+      );
     }
 
     // GAIA_URL is injected unconditionally: it's Gaia's in-network address

--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -18,6 +18,10 @@ import { readDeclarationFromRepo } from "../read-declaration.js";
 import { recordHabitatActivity } from "../reaper.js";
 import { HabitatWaker, createWakeTools } from "../waker.js";
 import { habitatSecretStatus } from "../secret-status.js";
+import {
+	describeRuntimeCredential,
+	resolveRuntimeCredential,
+} from "../runtime-credentials.js";
 import { buildSeedFiles } from "./seed-files.js";
 
 /**
@@ -42,8 +46,20 @@ export async function startHabitatContainer(
 	// Fresh GitHub boot tokens per start (ADR 0004; never throws —
 	// a GitHub outage degrades to a token-less boot, not a failure).
 	const bootTokens = await githubTokens?.bootTokensFor(entry);
+
+	// The model credential travels the same road: resolved per start from the
+	// habitat's provider, injected as env, never written to the volume and
+	// never named in the habitat's own repo. A habitat that needs no key, or
+	// whose key the vault cannot supply, simply gets none — the container
+	// still starts, which is what makes the gap reportable rather than fatal.
+	const runtime = resolveRuntimeCredential(entry, {
+		providerEnvVar: (p) => getRegisteredProvider(p)?.envVar,
+		secret: (name) => vault.get(name),
+	});
+
 	const port = await docker.startContainer(entry, "", registry.list(), {
 		githubTokens: bootTokens,
+		...(runtime.ok ? { modelCredential: runtime.credential } : {}),
 	});
 	await registry.update(id, { containerPort: port });
 	// A start counts as activity, so a habitat is not reaped in the
@@ -240,6 +256,13 @@ export function createHabitatLifecycleTools(
 							`These were NOT written to the volume — the container will start and then fail on first use. ` +
 							`Add them with set_secret, then rebuild.`,
 					);
+				}
+				const runtime = resolveRuntimeCredential(entry, {
+					providerEnvVar: (name) => getRegisteredProvider(name)?.envVar,
+					secret: (name) => vault.get(name),
+				});
+				if (!runtime.ok && runtime.reason !== "provider-needs-no-key") {
+					warnings.push(`WARNING: ${describeRuntimeCredential(runtime)}`);
 				}
 				const notes: string[] = [];
 				if (seed.scopeAdded || seed.agentAdded) {
@@ -509,7 +532,6 @@ export function createHabitatLifecycleTools(
 						defaults: {
 							...(gaiaProvider ? { provider: gaiaProvider } : {}),
 							...(gaiaModel ? { model: gaiaModel } : {}),
-							providerEnvVar: (p) => getRegisteredProvider(p)?.envVar,
 						},
 					});
 
@@ -541,16 +563,25 @@ export function createHabitatLifecycleTools(
 							? `Secret bindings (from the declaration): ${secrets.join(", ")}`
 							: `Secret bindings: none declared.`,
 						...(() => {
+							const lines: string[] = [];
 							// The declaration can bind a secret the vault has never
-							// heard of. That is not an error here — but it is the
-							// difference between a habitat that works and one that
-							// starts and then fails, so it does not get to be quiet.
+							// heard of. Not an error here — but the difference between
+							// a habitat that works and one that starts and then fails.
 							const gaps = habitatSecretStatus(result.entry, vault).missing;
-							return gaps.length
-								? [
-										`MISSING from the master vault: ${gaps.join(", ")}. Declared, but there is no value to seed — add with set_secret before asking it anything.`,
-									]
-								: [];
+							if (gaps.length) {
+								lines.push(
+									`MISSING from the master vault: ${gaps.join(", ")}. Declared by this habitat, but there is no value to seed.`,
+								);
+							}
+							// The model credential is platform infrastructure, not a
+							// declared binding — reported here because this is where
+							// someone finds out whether the habitat can think at all.
+							const runtime = resolveRuntimeCredential(result.entry, {
+								providerEnvVar: (name) => getRegisteredProvider(name)?.envVar,
+								secret: (name) => vault.get(name),
+							});
+							lines.push(describeRuntimeCredential(runtime));
+							return lines;
 						})(),
 						result.action === "created"
 							? `Nothing further is required. Asking "${id}" starts it, and starting seeds the volume with this config and these secrets — do not seed, grant or rebuild by hand first.`

--- a/packages/habitat/src/tools/gaia/gaia-tools/secrets.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/secrets.ts
@@ -10,11 +10,16 @@ import { tool } from "ai";
 import { z } from "zod";
 import type { Tool } from "ai";
 import type { GaiaToolsContext } from "./context.js";
+import { getRegisteredProvider } from "@umwelten/core/providers/index.js";
 import {
 	describeFleetSecretStatus,
 	fleetSecretStatus,
 	habitatSecretStatus,
 } from "../secret-status.js";
+import {
+	describeRuntimeCredential,
+	resolveRuntimeCredential,
+} from "../runtime-credentials.js";
 
 export function createSecretsTools(ctx: GaiaToolsContext): Record<string, Tool> {
 	const { registry, vault } = ctx;
@@ -22,7 +27,7 @@ export function createSecretsTools(ctx: GaiaToolsContext): Record<string, Tool> 
 	return {
 		secret_status: tool({
 			description:
-				"Show which habitat is bound to which secret, and whether the master vault can actually supply it. A binding the vault cannot satisfy is dropped from the habitat's secrets.json rather than failing the start — so the container boots, health-checks fine, and then fails on first use. Check this before blaming the container. Optionally scope to one habitat.",
+				"Show which habitat is bound to which secret, and whether the master vault can actually supply it. A binding the vault cannot satisfy is dropped from the habitat's secrets.json rather than failing the start — so the container boots, health-checks fine, and then fails on first use. Also reports each habitat's model credential, which is platform-injected rather than declared. Check this before blaming the container. Optionally scope to one habitat.",
 			inputSchema: z.object({
 				habitatId: z
 					.string()
@@ -36,7 +41,30 @@ export function createSecretsTools(ctx: GaiaToolsContext): Record<string, Tool> 
 				if (habitatId && entries.length === 0) {
 					return `Habitat "${habitatId}" not found`;
 				}
-				return describeFleetSecretStatus(fleetSecretStatus(entries, vault));
+				const declared = describeFleetSecretStatus(
+					fleetSecretStatus(entries, vault),
+				);
+
+				// The model credential is not a binding — it is injected at start
+				// like the GitHub boot token. Reported alongside anyway, because
+				// "why can't this habitat answer" is one question, not two, and
+				// splitting the answer across two tools is how the first client
+				// habitat took several rebuilds to diagnose.
+				const runtime = entries.map((entry) => {
+					const result = resolveRuntimeCredential(entry, {
+						providerEnvVar: (name) => getRegisteredProvider(name)?.envVar,
+						secret: (name) => vault.get(name),
+					});
+					return `  ${entry.id}: ${describeRuntimeCredential(result).replace(/^Model credential: /, "")}`;
+				});
+
+				return [
+					"DECLARED — secrets each habitat's own work requires:",
+					declared,
+					"",
+					"PLATFORM — the model credential, injected at start, never declared:",
+					...runtime,
+				].join("\n");
 			},
 		}),
 

--- a/packages/habitat/src/tools/gaia/runtime-credentials.test.ts
+++ b/packages/habitat/src/tools/gaia/runtime-credentials.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+	describeRuntimeCredential,
+	resolveRuntimeCredential,
+	type RuntimeCredentialDeps,
+} from "./runtime-credentials.js";
+import type { GaiaHabitatEntry } from "./types.js";
+
+const ENV = "GOOGLE_GENERATIVE_AI_API_KEY";
+
+function entry(defaultProvider?: string): Pick<GaiaHabitatEntry, "config"> {
+	return { config: { defaultProvider } as GaiaHabitatEntry["config"] };
+}
+
+function deps(
+	envVars: Record<string, string | undefined>,
+	secrets: Record<string, string> = {},
+): RuntimeCredentialDeps {
+	return {
+		providerEnvVar: (p) => envVars[p],
+		secret: (n) => secrets[n],
+	};
+}
+
+describe("resolveRuntimeCredential", () => {
+	it("resolves the provider's key from the vault", () => {
+		const result = resolveRuntimeCredential(
+			entry("google"),
+			deps({ google: ENV }, { [ENV]: "abc" }),
+		);
+
+		expect(result).toEqual({
+			ok: true,
+			provider: "google",
+			credential: { envName: ENV, value: "abc" },
+		});
+	});
+
+	/**
+	 * This is the failure that took several rebuilds to find on the first
+	 * client habitat: the container starts, health-checks fine (health does
+	 * not call a model), and fails on the first real question.
+	 */
+	it("reports a provider whose key the vault cannot supply", () => {
+		const result = resolveRuntimeCredential(
+			entry("google"),
+			deps({ google: ENV }, {}),
+		);
+
+		expect(result).toEqual({
+			ok: false,
+			reason: "missing-value",
+			provider: "google",
+			envName: ENV,
+		});
+	});
+
+	/** Local providers need no key. A complete answer, not a gap. */
+	it("distinguishes a provider that needs no key from one that is missing it", () => {
+		const result = resolveRuntimeCredential(
+			entry("ollama"),
+			deps({ ollama: undefined }),
+		);
+
+		expect(result).toEqual({
+			ok: false,
+			reason: "provider-needs-no-key",
+			provider: "ollama",
+		});
+	});
+
+	it("reports a habitat with no provider at all", () => {
+		expect(resolveRuntimeCredential(entry(undefined), deps({}))).toEqual({
+			ok: false,
+			reason: "no-provider",
+		});
+	});
+
+	it("treats an empty value as missing, not as a credential", () => {
+		const result = resolveRuntimeCredential(
+			entry("google"),
+			deps({ google: ENV }, { [ENV]: "" }),
+		);
+		expect(result.ok).toBe(false);
+	});
+
+	it("follows the habitat's own provider, not a fixed one", () => {
+		const result = resolveRuntimeCredential(
+			entry("openrouter"),
+			deps(
+				{ google: ENV, openrouter: "OPENROUTER_API_KEY" },
+				{ OPENROUTER_API_KEY: "or-1", [ENV]: "g-1" },
+			),
+		);
+
+		expect(result).toMatchObject({
+			ok: true,
+			credential: { envName: "OPENROUTER_API_KEY", value: "or-1" },
+		});
+	});
+});
+
+describe("describeRuntimeCredential", () => {
+	it("never includes the value", () => {
+		const text = describeRuntimeCredential(
+			resolveRuntimeCredential(
+				entry("google"),
+				deps({ google: ENV }, { [ENV]: "super-secret" }),
+			),
+		);
+		expect(text).not.toContain("super-secret");
+		expect(text).toContain(ENV);
+	});
+
+	it("says a missing key is platform config, not the repo's business", () => {
+		const text = describeRuntimeCredential(
+			resolveRuntimeCredential(entry("google"), deps({ google: ENV }, {})),
+		);
+		expect(text).toContain("MISSING");
+		expect(text).toContain("health-check fine");
+		expect(text).toContain("not something the");
+		expect(text).toContain("fnox.toml");
+	});
+
+	it("is not alarming for a provider that needs no key", () => {
+		const text = describeRuntimeCredential(
+			resolveRuntimeCredential(entry("ollama"), deps({ ollama: undefined })),
+		);
+		expect(text).toContain("needs no key");
+		expect(text).not.toContain("MISSING");
+	});
+
+	it("says plainly when no provider is set", () => {
+		const text = describeRuntimeCredential(
+			resolveRuntimeCredential(entry(undefined), deps({})),
+		);
+		expect(text).toContain("cannot answer anything");
+	});
+});

--- a/packages/habitat/src/tools/gaia/runtime-credentials.ts
+++ b/packages/habitat/src/tools/gaia/runtime-credentials.ts
@@ -1,0 +1,101 @@
+/**
+ * The credential a habitat needs to *exist*, as opposed to the ones it
+ * declares because of what it does.
+ *
+ * A habitat's `secretBindings` are its declared needs: Tavily because it
+ * searches, a client's API token because it calls that client. Those belong in
+ * `habitat.json` — the repo is the right place to say what its work requires.
+ *
+ * The model credential is not that. Every habitat needs one to think at all,
+ * and which model it happens to be is fleet policy. Putting it in
+ * `secretBindings` made `GOOGLE_GENERATIVE_AI_API_KEY` look like an UpperHand
+ * requirement, which is what made the first client declaration read as
+ * nonsense: the client repo does not care which model reads it.
+ *
+ * GitHub already solved this. `GITHUB_TOKEN` is never declared and never in
+ * the vault's binding list — Gaia mints it per start, scoped to what that
+ * habitat is allowed, and injects it as part of starting a container
+ * (ADR 0004). The repo declares *mounts*; the platform derives the
+ * credential. The model credential takes the same path.
+ *
+ * The practical payoff is that `secret_status` becomes meaningful: everything
+ * left in it is a real declared need, so an unsatisfied one is genuinely that
+ * habitat's problem rather than platform noise. And when the Exchange lands
+ * (#301) only the resolution below changes — a habitat gets a per-habitat
+ * service token instead of a shared provider key, and no declaration mentions
+ * either.
+ */
+
+import type { GaiaHabitatEntry } from "./types.js";
+
+/** What gets injected into the container at start. */
+export interface RuntimeCredential {
+	/** Env var name the provider reads, e.g. GOOGLE_GENERATIVE_AI_API_KEY. */
+	envName: string;
+	value: string;
+}
+
+/** Why there is no credential to inject — each needs a different fix. */
+export type RuntimeCredentialGap =
+	| { reason: "no-provider" }
+	| { reason: "provider-needs-no-key"; provider: string }
+	| { reason: "missing-value"; provider: string; envName: string };
+
+export type RuntimeCredentialResult =
+	| { ok: true; credential: RuntimeCredential; provider: string }
+	| ({ ok: false } & RuntimeCredentialGap);
+
+export interface RuntimeCredentialDeps {
+	/** Provider name → the env var its key lives in (core provider registry). */
+	providerEnvVar(provider: string): string | undefined;
+	/** Master-vault lookup. */
+	secret(name: string): string | undefined;
+}
+
+/**
+ * Work out the model credential for a habitat, without injecting it.
+ *
+ * Separated from the injection so it can be reported before a container is
+ * started — the whole reason the first client habitat failed was that this
+ * was only discoverable by asking it a question.
+ */
+export function resolveRuntimeCredential(
+	entry: Pick<GaiaHabitatEntry, "config">,
+	deps: RuntimeCredentialDeps,
+): RuntimeCredentialResult {
+	const provider = entry.config?.defaultProvider;
+	if (!provider) return { ok: false, reason: "no-provider" };
+
+	const envName = deps.providerEnvVar(provider);
+	// Local providers — ollama, lmstudio, llamabarn, llama-swap — register no
+	// env var because they need no key. That is a complete answer, not a gap.
+	if (!envName) return { ok: false, reason: "provider-needs-no-key", provider };
+
+	const value = deps.secret(envName);
+	if (!value) return { ok: false, reason: "missing-value", provider, envName };
+
+	return { ok: true, provider, credential: { envName, value } };
+}
+
+/** One line for a human or an agent. Never includes the value. */
+export function describeRuntimeCredential(
+	result: RuntimeCredentialResult,
+): string {
+	if (result.ok) {
+		return `Model credential: ${result.credential.envName} supplied by the platform for provider "${result.provider}".`;
+	}
+	switch (result.reason) {
+		case "no-provider":
+			return "Model credential: no provider set — this habitat cannot answer anything. Set one, or let it inherit Gaia's.";
+		case "provider-needs-no-key":
+			return `Model credential: provider "${result.provider}" needs no key.`;
+		case "missing-value":
+			return (
+				`Model credential: MISSING. Provider "${result.provider}" needs ${result.envName}, ` +
+				`which is not in the master vault. The container will start and health-check fine, ` +
+				`then fail on its first question. This is platform config, not something the ` +
+				`habitat's repo declares — add it to Gaia's fnox.toml (preferred, survives a ` +
+				`rebuild) or via set_secret.`
+			);
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,13 +429,13 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^26.1.1
-        version: 26.1.1
+        version: 26.1.2
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/ui:
     dependencies:


### PR DESCRIPTION
Follows the question *"client-upperhand should know what keys it needs — and generative api isn't on that list. What am I missing?"*

The answer: **both kinds of secret were going through the same channel.**

- **Declared needs** — what *this* habitat's work requires. Tavily because it searches, a client's token because it calls that client. These belong in `habitat.json`; the repo is the right place to state them.
- **Runtime infrastructure** — what *every* habitat needs to boot and think. The model credential. Nobody declares this any more than they declare that the container needs a filesystem.

`secretBindings` held both, indistinguishably. So `GOOGLE_GENERATIVE_AI_API_KEY` showed up looking like an UpperHand requirement — which is exactly why the declaration read as nonsense. A client repo has no opinion about which model reads it.

## GitHub already had the right shape

```ts
await docker.seedVolume(id, buildSeedFiles(entry, vault, catalog));   // declared
const bootTokens = await githubTokens?.bootTokensFor(entry);          // infrastructure
await docker.startContainer(entry, "", registry.list(), { githubTokens: bootTokens });
```

`GITHUB_TOKEN` is **never** in `secretBindings` and never in the vault's binding list. Gaia mints it per start, scoped to what that habitat is allowed, and injects it as part of starting a container (ADR 0004). The repo declares *mounts*; the platform derives the credential.

The model credential now takes the same road:

- `resolveRuntimeCredential()` — works out the env var from the habitat's **own** provider via the core provider registry, reads it from the master vault. Pure, so it reports before anything starts.
- `startContainer` injects it as env alongside the GitHub tokens. **Never written to the volume's `secrets.json`.**
- `declarationToCreateOptions` no longer binds it. Provider/model *inheritance* stays — that part was right.

## Three outcomes, kept distinct

They need different fixes, so they must not look alike:

| | |
|---|---|
| `no-provider` | The habitat can't answer anything. Set one, or inherit Gaia's. |
| `provider-needs-no-key` | ollama and friends. A complete answer, not a gap. |
| `missing-value` | The only real problem — and the one that previously presented as a healthy container failing on its first question. |

## Reported where people look

`create_habitat`, `apply_habitat_declaration`, and `secret_status` — which now separates **DECLARED** from **PLATFORM**. *"Why can't this habitat answer"* is one question and shouldn't need two tools; splitting it is how the first client habitat took several rebuilds to diagnose.

The payoff: everything left in `secret_status`'s declared section is a real habitat-specific need, so an unsatisfied one is genuinely that habitat's problem rather than platform noise.

## When the Exchange lands (#301)

Only `resolveRuntimeCredential` changes — a habitat gets a per-habitat `EXCHANGE_API_KEY` minted at start instead of a shared provider key. No declaration mentions either, then or now.

## Test change

Two tests from the previous PR asserted the auto-binding this removes — I wrote them an hour ago for behaviour that was the wrong half-step. They now assert the provider key is **absent** from `secretBindings`, which is the contract that makes the rest of `secret_status` meaningful. Flagging explicitly since changing assertions deserves scrutiny.

## Verification

- 10 new tests, incl. that `describeRuntimeCredential` never emits the value
- `pnpm test:run` — 197 files, 2441 tests passing
- `tsc --noEmit` clean across every package

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_