### PR TITLE
Agent-browser menagerie: Hearthstone, Meteora, and Atlas demo agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -619,6 +619,9 @@ All umwelten services use the 74xx port range to avoid conflicts with common dev
 | Context explorer        | **7432**      | `examples/context-explorer` — turn fan-out |
 | Agent browser           | **7433**      | `examples/agent-browser` — MCP/A2A discovery + chat |
 | Agent browser demo      | **7434**      | `examples/agent-browser/demo-endpoint.ts`  |
+| House demo (Hearthstone)| **7435**      | `examples/agent-browser/demo-house.ts`     |
+| Weather demo (Meteora)  | **7436**      | `examples/agent-browser/demo-weather.ts`   |
+| Atlas demo (routes)     | **7437**      | `examples/agent-browser/demo-atlas.ts`     |
 | Managed containers      | **7440–7499** | Gaia assigns sequentially from this range  |
 | Internal container port | **8080**      | Inside Docker only, never exposed directly |
 

--- a/examples/agent-browser/README.md
+++ b/examples/agent-browser/README.md
@@ -32,6 +32,24 @@ The demo endpoint's `roll_dice` tool returns an mcp-ui-style HTML resource
 alongside its JSON — the chat renders it as an interactive sandboxed dice
 widget, so the UI-resource flow is testable without any real habitat.
 
+## More demo agents
+
+Three richer demo servers, each answering as both protocols (MCP at `/mcp`,
+A2A card + `message/send`) and returning a self-contained HTML widget with
+every tool result:
+
+| Server | Port | What it is |
+| --- | --- | --- |
+| `demo-house.ts` | 7435 | **Hearthstone** — a smart-house controller with real in-process state: lights, furnace, and a lazily drifting indoor temperature, reflected in a glowing house dashboard |
+| `demo-weather.ts` | 7436 | **Meteora** — a long-range forecaster with deterministic pseudo-forecasts: 14-day hi/lo band charts and monthly climate outlooks |
+| `demo-atlas.ts` | 7437 | **Atlas** — a route planner over fake-but-coherent geography: place names hash to stable map coordinates, routes animate across a terrain chart |
+
+```bash
+pnpm tsx examples/agent-browser/demo-house.ts     # http://localhost:7435
+pnpm tsx examples/agent-browser/demo-weather.ts   # http://localhost:7436
+pnpm tsx examples/agent-browser/demo-atlas.ts     # http://localhost:7437
+```
+
 Things to point it at:
 
 ```bash

--- a/examples/agent-browser/TESTING.md
+++ b/examples/agent-browser/TESTING.md
@@ -100,6 +100,31 @@ dotenvx run -- pnpm run cli habitat serve     # then paste http://localhost:7430
 # local browser (works because the agent browser runs on your machine).
 ```
 
+## 6. Optional: attach the menagerie
+
+Three richer demo agents ship alongside the dice endpoint — each answers as
+both protocols and returns a dashboard/chart/map widget with every tool call:
+
+```bash
+pnpm tsx examples/agent-browser/demo-house.ts     # Hearthstone · http://localhost:7435
+pnpm tsx examples/agent-browser/demo-weather.ts   # Meteora     · http://localhost:7436
+pnpm tsx examples/agent-browser/demo-atlas.ts     # Atlas       · http://localhost:7437
+```
+
+Add `http://localhost:7435/mcp`, `http://localhost:7436/mcp`, and
+`http://localhost:7437/mcp` to the chat (or the bare origins for their A2A
+faces), then try:
+
+- `Turn on the porch light and set the furnace to 72` — the house dashboard
+  should show the porch glowing amber and the furnace flame lit, with the
+  indoor temperature drifting toward target on later calls.
+- `What's the 14-day outlook for Chicago?` — a hi/lo temperature band chart
+  with precipitation bars and per-day glyph cards. Ask again: forecasts are
+  deterministic per location + day, so the numbers agree.
+- `Plan a bike route from Harbor Point to the Observatory via the Old Mill` —
+  an animated dashed route across Atlas's terrain chart, with numbered stops
+  and a per-leg distance/ETA legend. `What landmarks do you know?` pins them.
+
 ## Troubleshooting
 
 - **`Unknown command: "tsx"`** — you typed `npm`; use `pnpm`.

--- a/examples/agent-browser/demo-atlas.ts
+++ b/examples/agent-browser/demo-atlas.ts
@@ -1,0 +1,446 @@
+/**
+ * Atlas — a route/map planning demo endpoint for the agent browser. One
+ * process that answers as BOTH protocols. Geography is fake but coherent:
+ * every place name hashes to a stable coordinate on a 1000×620 chart, so
+ * "Harbor Point" is always in the same spot, and a fixed decorative
+ * terrain (lakes, a river, contour hills) sits behind every map.
+ *
+ *   - MCP server at        http://localhost:7437/mcp
+ *       tools: plan_route (from/to/waypoints/mode), list_landmarks
+ *   - A2A agent card at    http://localhost:7437/.well-known/agent-card.json
+ *   - A2A message/send at  http://localhost:7437/a2a  ("from X to Y" itinerary)
+ *
+ *   pnpm tsx examples/agent-browser/demo-atlas.ts
+ *
+ * Point the agent browser at http://localhost:7437/mcp for the MCP face,
+ * or http://localhost:7437 for the A2A face. Every tool returns a one-line
+ * JSON text block first plus a self-contained mcp-ui SVG map widget
+ * (animated dashed route stroke, numbered markers, leg legend) designed
+ * for the browser's 560×320 sandboxed iframe. Route colors (drive
+ * #3987e5 / bike #d95926 / walk #199e70) were validated all-pairs with
+ * the dataviz palette checker against the chart surface (#0e1a20).
+ */
+
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+const port = Number(process.env.PORT ?? 7437);
+
+// ── fake but coherent geography ─────────────────────────────────────────────
+
+const CANVAS_W = 1000;
+const CANVAS_H = 620;
+
+function hash32(s: string): number {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Every place name lands on a stable chart coordinate. */
+function placeCoord(name: string): { x: number; y: number } {
+  const rng = mulberry32(hash32(name.trim().toLowerCase().replace(/\s+/g, " ")));
+  return {
+    x: Math.round(70 + rng() * (CANVAS_W - 140)),
+    y: Math.round(60 + rng() * (CANVAS_H - 120)),
+  };
+}
+
+type Mode = "drive" | "bike" | "walk";
+
+const MODES: Record<Mode, { color: string; fudge: number; kmh: number; label: string }> = {
+  drive: { color: "#3987e5", fudge: 1.35, kmh: 64, label: "driving" },
+  bike: { color: "#d95926", fudge: 1.18, kmh: 16.5, label: "cycling" },
+  walk: { color: "#199e70", fudge: 1.02, kmh: 4.8, label: "walking" },
+};
+
+const KM_PER_PX = 0.32;
+
+interface Leg {
+  from: string;
+  to: string;
+  km: number;
+  minutes: number;
+}
+
+interface RoutePlan {
+  mode: Mode;
+  stops: string[];
+  legs: Leg[];
+  totalKm: number;
+  totalMinutes: number;
+}
+
+function planRoute(stops: string[], mode: Mode): RoutePlan {
+  const m = MODES[mode];
+  const legs: Leg[] = [];
+  for (let i = 0; i < stops.length - 1; i++) {
+    const a = placeCoord(stops[i]);
+    const b = placeCoord(stops[i + 1]);
+    const px = Math.hypot(b.x - a.x, b.y - a.y) * 1.04; // curved path
+    const km = Math.round(px * KM_PER_PX * m.fudge * 10) / 10;
+    legs.push({
+      from: stops[i],
+      to: stops[i + 1],
+      km,
+      minutes: Math.max(1, Math.round((km / m.kmh) * 60)),
+    });
+  }
+  const totalKm = Math.round(legs.reduce((s, l) => s + l.km, 0) * 10) / 10;
+  const totalMinutes = legs.reduce((s, l) => s + l.minutes, 0);
+  return { mode, stops, legs, totalKm, totalMinutes };
+}
+
+function fmtMin(min: number): string {
+  return min >= 60 ? `${Math.floor(min / 60)} h ${min % 60} min` : `${min} min`;
+}
+
+const LANDMARKS: Array<{ name: string; tag: string }> = [
+  { name: "Harbor Point", tag: "lighthouse quay" },
+  { name: "Old Mill", tag: "riverside ruin" },
+  { name: "Observatory", tag: "hilltop dome" },
+  { name: "Fern Hollow", tag: "shaded valley" },
+  { name: "Saltmarsh Landing", tag: "tidal flats" },
+  { name: "Kestrel Ridge", tag: "high moor" },
+  { name: "Larkspur Crossing", tag: "market bridge" },
+];
+
+// ── widget ──────────────────────────────────────────────────────────────────
+
+function esc(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] as string,
+  );
+}
+
+/** Fixed decorative terrain in chart coordinates: graticule, contour hills, two lakes, a river. */
+function terrainSvg(): string {
+  let grat = "";
+  for (let x = 125; x < CANVAS_W; x += 125)
+    grat += `<line x1="${x}" y1="0" x2="${x}" y2="${CANVAS_H}"/>`;
+  for (let y = 125; y < CANVAS_H; y += 125)
+    grat += `<line x1="0" y1="${y}" x2="${CANVAS_W}" y2="${y}"/>`;
+  const contours = (cx: number, cy: number) =>
+    [46, 84, 126, 172]
+      .map(
+        (r, i) =>
+          `<ellipse cx="${cx}" cy="${cy}" rx="${r}" ry="${Math.round(r * 0.72)}" transform="rotate(${i % 2 ? -8 : 6} ${cx} ${cy})"/>`,
+      )
+      .join("");
+  return (
+    `<g stroke="#13232c" stroke-width="2">${grat}</g>` +
+    `<g fill="none" stroke="#1a303b" stroke-width="3">${contours(790, 140)}${contours(215, 480)}</g>` +
+    `<path d="M100,140 C110,90 220,95 245,150 C262,195 190,228 140,212 C95,198 92,172 100,140 Z" fill="#123039" stroke="#1f4a58" stroke-width="3"/>` +
+    `<path d="M755,470 C772,418 882,424 902,470 C918,510 862,547 800,536 C752,527 744,504 755,470 Z" fill="#123039" stroke="#1f4a58" stroke-width="3"/>` +
+    `<path d="M430,0 C400,90 500,130 480,210 C460,290 380,330 418,410 C452,480 560,520 545,620" fill="none" stroke="#1f4a58" stroke-width="8" stroke-linecap="round" opacity=".9"/>` +
+    // compass rose, top-left
+    `<g transform="translate(58,66)" stroke="#3a5563" fill="none" stroke-width="3">` +
+    `<circle r="30"/><circle r="5" fill="#3a5563" stroke="none"/>` +
+    `<path d="M0,-30 L7,0 L0,30 L-7,0 Z" fill="#3a5563" stroke="none" opacity=".85"/>` +
+    `<text y="-38" text-anchor="middle" font-size="24" fill="#5d7887" stroke="none">N</text></g>`
+  );
+}
+
+/** Route polyline through the stops: gently curved quadratic legs. */
+function routePathD(pts: Array<{ x: number; y: number }>): string {
+  let d = `M${pts[0].x},${pts[0].y}`;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const a = pts[i];
+    const b = pts[i + 1];
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const dist = Math.hypot(dx, dy) || 1;
+    const bend = Math.min(80, dist * 0.18) * (i % 2 === 0 ? 1 : -1);
+    const cx = (a.x + b.x) / 2 - (dy / dist) * bend;
+    const cy = (a.y + b.y) / 2 + (dx / dist) * bend;
+    d += ` Q${cx.toFixed(0)},${cy.toFixed(0)} ${b.x},${b.y}`;
+  }
+  return d;
+}
+
+function markerSvg(
+  pt: { x: number; y: number },
+  label: string,
+  fill: string,
+  n?: number,
+): string {
+  const halo = `paint-order="stroke" stroke="#0e1a20" stroke-width="8"`;
+  const labelY = pt.y > CANVAS_H - 90 ? pt.y - 40 : pt.y + 58;
+  return (
+    `<circle cx="${pt.x}" cy="${pt.y}" r="26" fill="${fill}" stroke="#0e1a20" stroke-width="6"/>` +
+    (n !== undefined
+      ? `<text x="${pt.x}" y="${pt.y + 9}" text-anchor="middle" font-size="27" font-weight="700" fill="#0e1a20">${n}</text>`
+      : `<circle cx="${pt.x}" cy="${pt.y}" r="9" fill="#0e1a20"/>`) +
+    `<text x="${pt.x}" y="${labelY}" text-anchor="middle" font-size="29" font-weight="600" fill="#cfe0ea" ${halo}>${esc(label)}</text>`
+  );
+}
+
+const WIDGET_CSS = `
+  * { box-sizing:border-box; }
+  body { margin:0; width:560px; height:320px; overflow:hidden; padding:10px 12px;
+         background:#0b141a; color:#dfe9ef;
+         font:12px/1.35 system-ui,-apple-system,"Segoe UI",sans-serif; }
+  #title { font-size:11px; font-weight:700; letter-spacing:.14em; color:#d6b36a;
+           margin-bottom:7px; }
+  #title span { color:#7e929f; font-weight:500; letter-spacing:.05em; }
+  #layout { display:flex; gap:10px; }
+  #map { width:316px; height:196px; border-radius:10px; border:1px solid #1d3340;
+         background:#0e1a20; flex:none; }
+  #panel { flex:1; min-width:0; background:#111e26; border:1px solid #1d3340;
+           border-radius:10px; padding:8px 10px; display:flex; flex-direction:column; }
+  #panel h3 { margin:0 0 6px; font-size:10px; text-transform:uppercase;
+              letter-spacing:.09em; color:#7e929f; font-weight:700;
+              display:flex; align-items:center; gap:5px; }
+  #panel h3 i { width:9px; height:9px; border-radius:50%; display:inline-block; }
+  .rows { flex:1; overflow:hidden; }
+  .leg { display:flex; gap:6px; margin-bottom:5px; font-size:10px; }
+  .leg .n { color:#7e929f; font-weight:700; flex:none; width:26px; }
+  .leg .names { color:#dfe9ef; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .leg .stats { color:#93a8b4; }
+  .total { border-top:1px solid #1d3340; margin-top:2px; padding-top:5px;
+           font-size:10.5px; font-weight:700; display:flex; justify-content:space-between; }
+  #note { margin-top:6px; font-size:9.5px; color:#5f7280; }
+  @keyframes dash { to { stroke-dashoffset:-46; } }
+  .route { stroke-dasharray:26 20; animation:dash 1.15s linear infinite; }
+`;
+
+function routeWidgetHtml(plan: RoutePlan): string {
+  const m = MODES[plan.mode];
+  const pts = plan.stops.map(placeCoord);
+  const markers = plan.stops
+    .map((name, i) => markerSvg(pts[i], name, m.color, i + 1))
+    .join("");
+  const legRows = plan.legs
+    .map(
+      (l, i) => `<div class="leg"><span class="n">${i + 1}→${i + 2}</span>
+        <div style="min-width:0"><div class="names">${esc(l.from)} → ${esc(l.to)}</div>
+        <div class="stats">${l.km} km · ${fmtMin(l.minutes)}</div></div></div>`,
+    )
+    .join("");
+  return `<!doctype html><html><head><meta charset="utf-8"><style>${WIDGET_CSS}</style></head><body>
+  <div id="title">ATLAS <span>· route plan — ${esc(m.label)}</span></div>
+  <div id="layout">
+    <svg id="map" viewBox="0 0 ${CANVAS_W} ${CANVAS_H}" preserveAspectRatio="xMidYMid meet">
+      ${terrainSvg()}
+      <path class="route" d="${routePathD(pts)}" fill="none" stroke="${m.color}" stroke-width="9" stroke-linecap="round"/>
+      ${markers}
+    </svg>
+    <div id="panel">
+      <h3><i style="background:${m.color}"></i>${plan.stops.length} stops · ${esc(m.label)}</h3>
+      <div class="rows">${legRows}</div>
+      <div class="total"><span>Total</span><span>${plan.totalKm} km · ${fmtMin(plan.totalMinutes)}</span></div>
+    </div>
+  </div>
+  <div id="note">Fictional cartography — every place name maps to a stable spot on Atlas's own chart.</div>
+  </body></html>`;
+}
+
+function landmarksWidgetHtml(): string {
+  const pins = LANDMARKS.map((l) => {
+    const p = placeCoord(l.name);
+    return markerSvg(p, l.name, "#3987e5");
+  }).join("");
+  const rows = LANDMARKS.map(
+    (l) => `<div class="leg"><span class="n">◆</span>
+      <div style="min-width:0"><div class="names">${esc(l.name)}</div>
+      <div class="stats">${esc(l.tag)}</div></div></div>`,
+  ).join("");
+  return `<!doctype html><html><head><meta charset="utf-8"><style>${WIDGET_CSS}</style></head><body>
+  <div id="title">ATLAS <span>· charted landmarks</span></div>
+  <div id="layout">
+    <svg id="map" viewBox="0 0 ${CANVAS_W} ${CANVAS_H}" preserveAspectRatio="xMidYMid meet">
+      ${terrainSvg()}${pins}
+    </svg>
+    <div id="panel">
+      <h3><i style="background:#3987e5"></i>${LANDMARKS.length} landmarks</h3>
+      <div class="rows">${rows}</div>
+    </div>
+  </div>
+  <div id="note">Fictional cartography — ask Atlas to plan a route between any of these.</div>
+  </body></html>`;
+}
+
+// ── protocol plumbing ───────────────────────────────────────────────────────
+
+const agentCard = {
+  protocolVersion: "0.2.5",
+  name: "Atlas",
+  description: "A cartographic planner that turns place names into routes.",
+  version: "1.0.0",
+  url: `http://localhost:${port}/a2a`,
+  capabilities: { streaming: false, pushNotifications: false },
+  defaultInputModes: ["text/plain"],
+  defaultOutputModes: ["text/plain"],
+  skills: [
+    {
+      id: "route-planning",
+      name: "Route planning",
+      description: "Plans drive/bike/walk routes between named places, with waypoints.",
+      tags: ["demo", "maps"],
+    },
+  ],
+};
+
+function parseItinerary(text: string): { stops: string[]; mode: Mode } {
+  const mode: Mode = /\b(bike|bicycle|cycl)/i.test(text)
+    ? "bike"
+    : /\b(walk|foot|hik)/i.test(text)
+      ? "walk"
+      : "drive";
+  const m = text.match(/from\s+(.+?)\s+to\s+(.+?)(?:\s+via\s+(.+?))?\s*[?.!]*$/i);
+  if (!m) return { stops: ["Harbor Point", "Observatory"], mode };
+  const via = m[3] ? m[3].split(/\s*(?:,|and)\s+/).filter(Boolean) : [];
+  return { stops: [m[1].trim(), ...via.map((v) => v.trim()), m[2].trim()], mode };
+}
+
+function itineraryText(plan: RoutePlan): string {
+  const legs = plan.legs
+    .map((l, i) => `${i + 1}. ${l.from} → ${l.to} (${l.km} km, ${fmtMin(l.minutes)})`)
+    .join("; ");
+  return `Atlas ${MODES[plan.mode].label} route: ${legs}. Total ${plan.totalKm} km, about ${fmtMin(plan.totalMinutes)}.`;
+}
+
+function readBody(req: import("node:http").IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (c) => (data += c));
+    req.on("end", () => resolve(data));
+    req.on("error", reject);
+  });
+}
+
+const server = createServer((req, res) => {
+  void (async () => {
+    const path = new URL(req.url ?? "/", `http://localhost:${port}`).pathname;
+
+    if (req.method === "GET" && path === "/.well-known/agent-card.json") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(agentCard));
+      return;
+    }
+
+    if (req.method === "POST" && path === "/a2a") {
+      const rpc = JSON.parse(await readBody(req));
+      const parts: Array<{ kind?: string; text?: string }> =
+        rpc?.params?.message?.parts ?? [];
+      const asked = parts.filter((p) => p.kind === "text").map((p) => p.text).join(" ");
+      const { stops, mode } = parseItinerary(asked);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: rpc.id ?? null,
+          result: {
+            kind: "message",
+            messageId: randomUUID(),
+            role: "agent",
+            parts: [{ kind: "text", text: itineraryText(planRoute(stops, mode)) }],
+          },
+        }),
+      );
+      return;
+    }
+
+    if (path === "/mcp") {
+      const raw = await readBody(req);
+      let parsed: unknown;
+      try {
+        parsed = raw ? JSON.parse(raw) : undefined;
+      } catch {
+        res.writeHead(400).end();
+        return;
+      }
+      const mcp = new McpServer({ name: "atlas", version: "1.0.0" });
+      mcp.registerTool(
+        "plan_route",
+        {
+          description:
+            "Plan a route between named places (with up to 4 waypoints) by drive, bike, or walk. Returns JSON legs with distance and duration plus a stylized map widget the client may render.",
+          inputSchema: {
+            from: z.string().min(1),
+            to: z.string().min(1),
+            waypoints: z.array(z.string().min(1)).max(4).optional(),
+            mode: z.enum(["drive", "bike", "walk"]).optional(),
+          },
+        },
+        async ({ from, to, waypoints, mode }) => {
+          const plan = planRoute([from, ...(waypoints ?? []), to], mode ?? "drive");
+          return {
+            content: [
+              { type: "text", text: JSON.stringify(plan) },
+              {
+                type: "resource",
+                resource: {
+                  uri: `ui://atlas/route/${randomUUID()}`,
+                  mimeType: "text/html",
+                  text: routeWidgetHtml(plan),
+                },
+              },
+            ],
+          };
+        },
+      );
+      mcp.registerTool(
+        "list_landmarks",
+        {
+          description:
+            "List Atlas's charted landmarks (invented, but stable — routes to them always agree). Returns JSON plus a map widget pinning each one.",
+          inputSchema: {},
+        },
+        async () => ({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                landmarks: LANDMARKS.map((l) => ({ ...l, ...placeCoord(l.name) })),
+              }),
+            },
+            {
+              type: "resource",
+              resource: {
+                uri: `ui://atlas/landmarks/${randomUUID()}`,
+                mimeType: "text/html",
+                text: landmarksWidgetHtml(),
+              },
+            },
+          ],
+        }),
+      );
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      await mcp.connect(transport);
+      await transport.handleRequest(req, res, parsed);
+      await transport.close();
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("try /mcp, /a2a, or /.well-known/agent-card.json");
+  })().catch((err) => {
+    if (!res.headersSent) {
+      res.writeHead(500);
+      res.end(String(err));
+    }
+  });
+});
+
+server.listen(port, () => {
+  console.log(`atlas demo: http://localhost:${port}`);
+  console.log(`  MCP:      http://localhost:${port}/mcp`);
+  console.log(`  A2A card: http://localhost:${port}/.well-known/agent-card.json`);
+});

--- a/examples/agent-browser/demo-house.ts
+++ b/examples/agent-browser/demo-house.ts
@@ -1,0 +1,365 @@
+/**
+ * Hearthstone — a smart-house demo endpoint for the agent browser. One
+ * process that answers as BOTH protocols, with REAL in-process house state
+ * (lights + furnace + a lazily drifting indoor temperature) that every
+ * tool result's dashboard widget reflects:
+ *
+ *   - MCP server at        http://localhost:7435/mcp
+ *       tools: get_house_status, set_light, set_all_lights, set_furnace
+ *   - A2A agent card at    http://localhost:7435/.well-known/agent-card.json
+ *   - A2A message/send at  http://localhost:7435/a2a   (text status summary)
+ *
+ *   pnpm tsx examples/agent-browser/demo-house.ts
+ *
+ * Point the agent browser at http://localhost:7435/mcp for the MCP face,
+ * or http://localhost:7435 for the A2A face. Every tool returns a one-line
+ * JSON text block (for text-only clients) plus a self-contained mcp-ui HTML
+ * dashboard designed for the browser's 560×320 sandboxed iframe.
+ */
+
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+const port = Number(process.env.PORT ?? 7435);
+
+const ROOMS = ["living", "kitchen", "bedroom", "office", "porch"] as const;
+type Room = (typeof ROOMS)[number];
+
+/** The one true house. Temperature drift is advanced lazily per request. */
+const house = {
+  furnace: { on: false, targetF: 68 },
+  indoorF: 61,
+  rooms: Object.fromEntries(ROOMS.map((r) => [r, { light: false }])) as Record<
+    Room,
+    { light: boolean }
+  >,
+  lastTick: Date.now(),
+};
+
+const DRIFT_F_PER_MIN = 0.4;
+const COLD_FLOOR_F = 55;
+
+function advanceHouse(now = Date.now()): void {
+  const minutes = (now - house.lastTick) / 60_000;
+  house.lastTick = now;
+  if (minutes <= 0) return;
+  const target = house.furnace.on ? house.furnace.targetF : COLD_FLOOR_F;
+  const delta = target - house.indoorF;
+  const step = Math.sign(delta) * Math.min(Math.abs(delta), DRIFT_F_PER_MIN * minutes);
+  house.indoorF = Math.round((house.indoorF + step) * 10) / 10;
+}
+
+type Trend = "heating" | "cooling" | "holding";
+
+function trend(): Trend {
+  const target = house.furnace.on ? house.furnace.targetF : COLD_FLOOR_F;
+  if (Math.abs(target - house.indoorF) < 0.3) return "holding";
+  return target > house.indoorF ? "heating" : "cooling";
+}
+
+function snapshot() {
+  return {
+    indoorF: house.indoorF,
+    furnace: { ...house.furnace },
+    trend: trend(),
+    rooms: Object.fromEntries(ROOMS.map((r) => [r, house.rooms[r].light])),
+    litRooms: ROOMS.filter((r) => house.rooms[r].light),
+  };
+}
+
+function statusLine(): string {
+  const s = snapshot();
+  const lit = s.litRooms.length
+    ? `lights on in ${s.litRooms.join(", ")}`
+    : "all lights off";
+  const furnace = s.furnace.on
+    ? `furnace on (target ${s.furnace.targetF}°F)`
+    : "furnace off";
+  return `Indoors ${s.indoorF}°F and ${s.trend}; ${furnace}; ${lit}.`;
+}
+
+/**
+ * The dashboard: a CSS-grid cross-section of the house. Room cards glow
+ * warm amber when lit; the furnace panel burns an animated CSS flame when
+ * on. Cards and the furnace toggle are clickable but only update the
+ * widget's local view — the footer says so.
+ */
+function dashboardHtml(): string {
+  const s = snapshot();
+  return `<!doctype html><html><head><meta charset="utf-8"><style>
+  * { box-sizing:border-box; }
+  body { margin:0; width:560px; height:320px; overflow:hidden; padding:10px 12px;
+         background:#16110c; color:#efe6d8;
+         font:12px/1.35 system-ui,-apple-system,"Segoe UI",sans-serif; }
+  #title { font-size:11px; font-weight:700; letter-spacing:.14em; color:#f5a742;
+           margin-bottom:8px; }
+  #title span { color:#8f8271; font-weight:500; letter-spacing:.06em; }
+  #layout { display:flex; gap:10px; height:252px; }
+  #housegrid { flex:1; display:grid; gap:7px;
+    grid-template-columns:1fr 1fr; grid-template-rows:1fr 1fr 0.62fr;
+    grid-template-areas:"bedroom office" "living kitchen" "porch porch"; }
+  .room { border-radius:10px; padding:7px 9px; cursor:pointer; position:relative;
+          border:1px solid #253048; background:#141c2c;
+          transition:background .25s,border-color .25s,box-shadow .25s;
+          display:flex; flex-direction:column; justify-content:space-between; }
+  .room .name { font-size:10px; text-transform:uppercase; letter-spacing:.08em;
+                color:#8b95a8; }
+  .room.lit { background:radial-gradient(circle at 50% 35%,#4a3413 0%,#2c2010 70%);
+              border-color:#7a5a22; box-shadow:0 0 16px rgba(245,167,66,.22) inset,
+              0 0 10px rgba(245,167,66,.14); }
+  .room.lit .name { color:#e8c98a; }
+  .lamp { width:22px; height:22px; }
+  #right { width:186px; display:flex; flex-direction:column; gap:8px; }
+  #furnace { flex:1; border-radius:10px; border:1px solid #2a3a52; background:#131b29;
+             padding:8px 10px; text-align:center; cursor:pointer;
+             transition:background .25s,border-color .25s; position:relative; }
+  #furnace.on { background:#241609; border-color:#8a4a18;
+                box-shadow:0 0 18px rgba(226,87,30,.18) inset; }
+  #furnace .label { font-size:10px; text-transform:uppercase; letter-spacing:.1em;
+                    color:#8b95a8; }
+  #furnace.on .label { color:#f0a35e; }
+  .flame { position:relative; width:46px; height:54px; margin:8px auto 2px; }
+  .flame i { position:absolute; bottom:0; left:50%; display:block;
+             border-radius:50% 50% 50% 50%/62% 62% 38% 38%;
+             transform:translateX(-50%); }
+  #furnace.on .f1 { width:34px; height:50px; background:#e2571e;
+    box-shadow:0 0 22px rgba(255,140,40,.5); animation:flick .9s ease-in-out infinite alternate; }
+  #furnace.on .f2 { width:21px; height:33px; background:#ff9d2e;
+    animation:flick .66s ease-in-out infinite alternate-reverse; }
+  #furnace.on .f3 { width:11px; height:16px; background:#ffe08a;
+    animation:flick .5s ease-in-out infinite alternate; }
+  #furnace.off .f1 { width:34px; height:50px; background:none;
+    border:2px dashed #33475e; }
+  @keyframes flick {
+    from { transform:translateX(-50%) scale(1,1); }
+    to   { transform:translateX(-52%) scale(.9,1.07); } }
+  #furnace .state { font-size:11px; font-weight:700; margin-top:2px; }
+  #furnace.on .state { color:#ffb45e; } #furnace.off .state { color:#5c7595; }
+  #temp { border-radius:10px; border:1px solid #2a3a52; background:#131b29;
+          padding:8px 10px; display:flex; gap:9px; align-items:center; height:84px; }
+  #temp .big { font-size:19px; font-weight:700; color:#efe6d8; }
+  #temp .arrow { color:#8b95a8; font-size:12px; }
+  #temp .mode { font-size:10px; color:#8b95a8; margin-top:2px; }
+  #note { margin-top:7px; font-size:10px; color:#7d7466; }
+  #note.flash { color:#f5a742; }
+  </style></head><body>
+  <div id="title">HEARTHSTONE <span>· house controller</span></div>
+  <div id="layout">
+    <div id="housegrid"></div>
+    <div id="right">
+      <div id="furnace">
+        <div class="label">Furnace</div>
+        <div class="flame"><i class="f1"></i><i class="f2"></i><i class="f3"></i></div>
+        <div class="state"></div>
+      </div>
+      <div id="temp"></div>
+    </div>
+  </div>
+  <div id="note">Click rooms or the furnace for a local preview — ask the agent to actually switch anything.</div>
+  <script>
+  const ROOMS = ${JSON.stringify(ROOMS)};
+  let s = ${JSON.stringify(s)};
+  const lampSvg = (lit) => '<svg class="lamp" viewBox="0 0 24 24">' +
+    (lit ? '<ellipse cx="12" cy="12.5" rx="8" ry="4" fill="#f5a742" opacity=".28"/>' : '') +
+    '<path d="M8.2 4h7.6l3 7H5.2z" fill="' + (lit ? '#ffc266' : '#3a4658') + '"/>' +
+    '<rect x="11.2" y="11" width="1.6" height="7" fill="' + (lit ? '#c89454' : '#31405a') + '"/>' +
+    '<path d="M8.5 20h7" stroke="' + (lit ? '#c89454' : '#31405a') + '" stroke-width="2" stroke-linecap="round"/></svg>';
+  function render() {
+    document.getElementById("housegrid").innerHTML = ROOMS.map((r) =>
+      '<div class="room' + (s.rooms[r] ? ' lit' : '') + '" data-room="' + r +
+      '" style="grid-area:' + r + '">' + lampSvg(s.rooms[r]) +
+      '<div class="name">' + r + '</div></div>').join('');
+    const f = document.getElementById("furnace");
+    f.className = s.furnace.on ? 'on' : 'off';
+    f.querySelector(".state").textContent = s.furnace.on
+      ? 'ON · ' + s.furnace.targetF + '°F' : 'OFF';
+    const frac = Math.max(0, Math.min(1, (s.indoorF - 50) / 35));
+    const mercury = s.trend === 'cooling' ? '#6da7ec' : '#e2861e';
+    const modeText = s.trend === 'heating' ? 'heating\\u2026'
+      : s.trend === 'cooling' ? 'drifting down\\u2026' : 'holding steady';
+    document.getElementById("temp").innerHTML =
+      '<svg width="18" height="62" viewBox="0 0 18 62">' +
+      '<rect x="6.5" y="3" width="5" height="46" rx="2.5" fill="#0f1622" stroke="#33475e"/>' +
+      '<rect x="7.5" y="' + (47 - 42 * frac) + '" width="3" height="' + (42 * frac + 2) +
+      '" rx="1.5" fill="' + mercury + '"/>' +
+      '<circle cx="9" cy="53" r="6" fill="' + mercury + '"/></svg>' +
+      '<div><span class="big">' + s.indoorF + '°F</span> <span class="arrow">→ ' +
+      (s.furnace.on ? s.furnace.targetF : ${COLD_FLOOR_F}) + '°F</span>' +
+      '<div class="mode">' + modeText + '</div></div>';
+    for (const el of document.querySelectorAll(".room"))
+      el.onclick = () => { s.rooms[el.dataset.room] = !s.rooms[el.dataset.room]; poke(); };
+    f.onclick = () => { s.furnace.on = !s.furnace.on; retrend(); poke(); };
+  }
+  function retrend() {
+    const target = s.furnace.on ? s.furnace.targetF : ${COLD_FLOOR_F};
+    s.trend = Math.abs(target - s.indoorF) < .3 ? 'holding'
+      : target > s.indoorF ? 'heating' : 'cooling';
+  }
+  function poke() {
+    render();
+    const n = document.getElementById("note");
+    n.classList.add("flash");
+    n.textContent = "local preview — ask the agent to actually switch it";
+    setTimeout(() => n.classList.remove("flash"), 900);
+  }
+  render();
+  </script></body></html>`;
+}
+
+/** Standard tool payload: one-line JSON first, dashboard resource second. */
+function houseResult() {
+  return {
+    content: [
+      { type: "text" as const, text: JSON.stringify(snapshot()) },
+      {
+        type: "resource" as const,
+        resource: {
+          uri: `ui://hearthstone/dashboard/${randomUUID()}`,
+          mimeType: "text/html",
+          text: dashboardHtml(),
+        },
+      },
+    ],
+  };
+}
+
+const agentCard = {
+  protocolVersion: "0.2.5",
+  name: "Hearthstone",
+  description:
+    "A smart-house butler that reports and controls the lights and furnace.",
+  version: "1.0.0",
+  url: `http://localhost:${port}/a2a`,
+  capabilities: { streaming: false, pushNotifications: false },
+  defaultInputModes: ["text/plain"],
+  defaultOutputModes: ["text/plain"],
+  skills: [
+    {
+      id: "house-status",
+      name: "House status",
+      description: "Reports lights, furnace, and indoor temperature.",
+      tags: ["demo", "smart-home"],
+    },
+  ],
+};
+
+function readBody(req: import("node:http").IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (c) => (data += c));
+    req.on("end", () => resolve(data));
+    req.on("error", reject);
+  });
+}
+
+const server = createServer((req, res) => {
+  void (async () => {
+    const path = new URL(req.url ?? "/", `http://localhost:${port}`).pathname;
+    advanceHouse();
+
+    if (req.method === "GET" && path === "/.well-known/agent-card.json") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(agentCard));
+      return;
+    }
+
+    if (req.method === "POST" && path === "/a2a") {
+      const rpc = JSON.parse(await readBody(req));
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: rpc.id ?? null,
+          result: {
+            kind: "message",
+            messageId: randomUUID(),
+            role: "agent",
+            parts: [{ kind: "text", text: `Hearthstone reporting: ${statusLine()}` }],
+          },
+        }),
+      );
+      return;
+    }
+
+    if (path === "/mcp") {
+      const raw = await readBody(req);
+      let parsed: unknown;
+      try {
+        parsed = raw ? JSON.parse(raw) : undefined;
+      } catch {
+        res.writeHead(400).end();
+        return;
+      }
+      const mcp = new McpServer({ name: "hearthstone", version: "1.0.0" });
+      mcp.registerTool(
+        "get_house_status",
+        {
+          description:
+            "Report the current house state: indoor temperature, furnace, and which rooms are lit. Returns JSON plus a dashboard widget the client may render.",
+          inputSchema: {},
+        },
+        async () => houseResult(),
+      );
+      mcp.registerTool(
+        "set_light",
+        {
+          description: "Turn one room's light on or off.",
+          inputSchema: { room: z.enum(ROOMS), on: z.boolean() },
+        },
+        async ({ room, on }) => {
+          house.rooms[room].light = on;
+          return houseResult();
+        },
+      );
+      mcp.registerTool(
+        "set_all_lights",
+        {
+          description: "Turn every light in the house on or off at once.",
+          inputSchema: { on: z.boolean() },
+        },
+        async ({ on }) => {
+          for (const r of ROOMS) house.rooms[r].light = on;
+          return houseResult();
+        },
+      );
+      mcp.registerTool(
+        "set_furnace",
+        {
+          description:
+            "Turn the furnace on or off, optionally setting its target temperature (50–85°F). Indoor temperature drifts toward the target while on, and back toward 55°F while off.",
+          inputSchema: {
+            on: z.boolean(),
+            targetF: z.number().min(50).max(85).optional(),
+          },
+        },
+        async ({ on, targetF }) => {
+          house.furnace.on = on;
+          if (targetF !== undefined) house.furnace.targetF = Math.round(targetF);
+          return houseResult();
+        },
+      );
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      await mcp.connect(transport);
+      await transport.handleRequest(req, res, parsed);
+      await transport.close();
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("try /mcp, /a2a, or /.well-known/agent-card.json");
+  })().catch((err) => {
+    if (!res.headersSent) {
+      res.writeHead(500);
+      res.end(String(err));
+    }
+  });
+});
+
+server.listen(port, () => {
+  console.log(`hearthstone demo: http://localhost:${port}`);
+  console.log(`  MCP:      http://localhost:${port}/mcp`);
+  console.log(`  A2A card: http://localhost:${port}/.well-known/agent-card.json`);
+});

--- a/examples/agent-browser/demo-house.ts
+++ b/examples/agent-browser/demo-house.ts
@@ -268,6 +268,45 @@ const server = createServer((req, res) => {
 
     if (req.method === "POST" && path === "/a2a") {
       const rpc = JSON.parse(await readBody(req));
+      const asked: string = (rpc?.params?.message?.parts ?? [])
+        .filter((p: { kind?: string }) => p.kind === "text")
+        .map((p: { text?: string }) => p.text ?? "")
+        .join(" ")
+        .toLowerCase();
+
+      // The butler doesn't just report — simple spoken commands work too,
+      // so the A2A face lives up to its card. (The MCP face is still the
+      // one that returns the visual dashboard.)
+      const actions: string[] = [];
+      advanceHouse();
+      const wantsOff = /\b(off|out|kill|douse)\b/.test(asked);
+      const wantsOn = /\bon\b/.test(asked);
+      if (/light|lamp/.test(asked) && (wantsOn || wantsOff)) {
+        const named = ROOMS.filter((r) => asked.includes(r));
+        const targets = named.length ? named : [...ROOMS];
+        for (const r of targets) house.rooms[r].light = wantsOn && !wantsOff;
+        actions.push(
+          `${wantsOn && !wantsOff ? "lit" : "darkened"} ${named.length ? named.join(", ") : "every room"}`,
+        );
+      }
+      const tempMatch = asked.match(/\b(?:to|at)\s+(\d{2})\b/);
+      if (/furnace|heat|thermostat|warm/.test(asked)) {
+        if (tempMatch) {
+          house.furnace.targetF = Math.min(85, Math.max(50, Number(tempMatch[1])));
+          house.furnace.on = true;
+          actions.push(`set the furnace to ${house.furnace.targetF}°F`);
+        } else if (wantsOff) {
+          house.furnace.on = false;
+          actions.push("shut the furnace down");
+        } else if (wantsOn) {
+          house.furnace.on = true;
+          actions.push(`lit the furnace (target ${house.furnace.targetF}°F)`);
+        }
+      }
+
+      const preface = actions.length
+        ? `Very good — I have ${actions.join(" and ")}. `
+        : "";
       res.writeHead(200, { "content-type": "application/json" });
       res.end(
         JSON.stringify({
@@ -277,7 +316,12 @@ const server = createServer((req, res) => {
             kind: "message",
             messageId: randomUUID(),
             role: "agent",
-            parts: [{ kind: "text", text: `Hearthstone reporting: ${statusLine()}` }],
+            parts: [
+              {
+                kind: "text",
+                text: `${preface}Hearthstone reporting: ${statusLine()} (Attach my /mcp face to see the dashboard.)`,
+              },
+            ],
           },
         }),
       );

--- a/examples/agent-browser/demo-weather.ts
+++ b/examples/agent-browser/demo-weather.ts
@@ -1,0 +1,586 @@
+/**
+ * Meteora — a long-range weather forecasting demo endpoint for the agent
+ * browser. One process that answers as BOTH protocols. Forecasts are
+ * deterministic pseudo-data: a mulberry32 PRNG seeded from
+ * hash(location + ISO day), shaped by a seasonal sinusoid keyed to a
+ * pseudo-latitude hashed from the location — so repeated calls agree and
+ * different places/days differ plausibly.
+ *
+ *   - MCP server at        http://localhost:7436/mcp
+ *       tools: get_forecast (1–14 days), get_climate_outlook (1–12 months)
+ *   - A2A agent card at    http://localhost:7436/.well-known/agent-card.json
+ *   - A2A message/send at  http://localhost:7436/a2a  (text 7-day summary)
+ *
+ *   pnpm tsx examples/agent-browser/demo-weather.ts
+ *
+ * Point the agent browser at http://localhost:7436/mcp for the MCP face,
+ * or http://localhost:7436 for the A2A face. Every tool returns a one-line
+ * JSON text block first plus a self-contained mcp-ui SVG chart widget
+ * designed for the browser's 560×320 sandboxed iframe. Chart colors were
+ * validated with the dataviz palette checker against the widget's own dark
+ * surface (#101a24): high #d95926 / low #3987e5 pass all six checks.
+ */
+
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+const port = Number(process.env.PORT ?? 7436);
+const DEFAULT_LOCATION = "Beacon, NY";
+
+// ── deterministic pseudo-meteorology ────────────────────────────────────────
+
+function hash32(s: string): number {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function locKey(location: string): string {
+  return location.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+/** Stable per-location climate profile: pseudo-latitude and base wetness. */
+function profile(location: string) {
+  const h = hash32(locKey(location));
+  const lat = 25 + ((h % 1000) / 1000) * 30; // 25..55 "degrees"
+  const wet = 0.25 + (((h >>> 10) % 1000) / 1000) * 0.5; // 0.25..0.75
+  return { lat, wet };
+}
+
+function dayOfYear(d: Date): number {
+  return Math.floor(
+    (Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()) -
+      Date.UTC(d.getFullYear(), 0, 0)) /
+      86_400_000,
+  );
+}
+
+/** Climatological daily mean for this location at this day-of-year, °F. */
+function seasonalMeanF(location: string, doy: number): number {
+  const { lat } = profile(location);
+  const mean = 62 - (lat - 25) * 0.9;
+  const amp = 14 + (lat - 25) * 0.55;
+  return mean + amp * -Math.cos((2 * Math.PI * (doy - 14)) / 365);
+}
+
+type Condition = "sun" | "cloud" | "rain" | "storm" | "snow";
+
+interface DayForecast {
+  date: string; // ISO
+  weekday: string;
+  hi: number;
+  lo: number;
+  precip: number; // % probability
+  condition: Condition;
+}
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+function forecastDay(location: string, d: Date): DayForecast {
+  const iso = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  const rng = mulberry32(hash32(`${locKey(location)}|${iso}`));
+  const { wet } = profile(location);
+  const base = seasonalMeanF(location, dayOfYear(d));
+  const anomaly = (rng() - 0.5) * 14;
+  const spread = 7 + rng() * 7;
+  const hi = Math.round(base + anomaly + spread / 2);
+  const lo = Math.round(base + anomaly - spread / 2 - rng() * 3);
+  const precip = Math.round(
+    Math.max(0, Math.min(1, rng() * 0.75 + wet * 0.45 - 0.15)) * 100,
+  );
+  const condition: Condition =
+    precip >= 50 && hi <= 36 ? "snow"
+    : precip >= 75 && hi >= 68 ? "storm"
+    : precip >= 50 ? "rain"
+    : precip >= 28 ? "cloud"
+    : "sun";
+  return { date: iso, weekday: WEEKDAYS[d.getDay()], hi, lo, precip, condition };
+}
+
+function forecast(location: string, days: number): DayForecast[] {
+  const out: DayForecast[] = [];
+  const today = new Date();
+  for (let i = 0; i < days; i++) {
+    const d = new Date(today.getFullYear(), today.getMonth(), today.getDate() + i);
+    out.push(forecastDay(location, d));
+  }
+  return out;
+}
+
+type PrecipLean = "wetter" | "drier" | "normal";
+
+interface MonthOutlook {
+  month: string; // "2026-08"
+  label: string; // "Aug"
+  avgF: number;
+  normalF: number;
+  precip: PrecipLean;
+}
+
+function climateOutlook(location: string, months: number): MonthOutlook[] {
+  const out: MonthOutlook[] = [];
+  const now = new Date();
+  for (let i = 0; i < months; i++) {
+    const d = new Date(now.getFullYear(), now.getMonth() + i, 15);
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    const rng = mulberry32(hash32(`${locKey(location)}|${key}`));
+    const normalF = Math.round(seasonalMeanF(location, dayOfYear(d)) * 10) / 10;
+    const avgF = Math.round((normalF + (rng() - 0.5) * 8) * 10) / 10;
+    const lean = rng() - 0.5 + (profile(location).wet - 0.5) * 0.4;
+    const precip: PrecipLean = lean > 0.12 ? "wetter" : lean < -0.12 ? "drier" : "normal";
+    out.push({ month: key, label: MONTHS[d.getMonth()], avgF, normalF, precip });
+  }
+  return out;
+}
+
+function outlookSentence(location: string, rows: MonthOutlook[]): string {
+  const anom = rows.reduce((s, r) => s + (r.avgF - r.normalF), 0) / rows.length;
+  const wetter = rows.filter((r) => r.precip === "wetter").length;
+  const drier = rows.filter((r) => r.precip === "drier").length;
+  const tempPhrase =
+    anom > 1 ? "milder than normal" : anom < -1 ? "cooler than normal" : "near normal temperatures";
+  const wetPhrase =
+    wetter > drier ? "a wetter lean" : drier > wetter ? "a drier lean" : "typical precipitation";
+  const span = `${rows[0].label}–${rows[rows.length - 1].label}`;
+  return `${span} in ${location} runs ${tempPhrase} with ${wetPhrase} (${wetter} wetter, ${drier} drier month${drier === 1 ? "" : "s"}).`;
+}
+
+// ── widgets ─────────────────────────────────────────────────────────────────
+
+function esc(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] as string,
+  );
+}
+
+/** Catmull-Rom → cubic bezier path through points. */
+function smoothPath(pts: Array<[number, number]>): string {
+  if (pts.length === 0) return "";
+  let d = `M${pts[0][0].toFixed(1)},${pts[0][1].toFixed(1)}`;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[Math.max(0, i - 1)];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[Math.min(pts.length - 1, i + 2)];
+    d += `C${(p1[0] + (p2[0] - p0[0]) / 6).toFixed(1)},${(p1[1] + (p2[1] - p0[1]) / 6).toFixed(1)} ${(p2[0] - (p3[0] - p1[0]) / 6).toFixed(1)},${(p2[1] - (p3[1] - p1[1]) / 6).toFixed(1)} ${p2[0].toFixed(1)},${p2[1].toFixed(1)}`;
+  }
+  return d;
+}
+
+/** Inline SVG weather glyphs — no emoji, no external assets. */
+function glyph(kind: Condition, px: number): string {
+  const cloudLow = `<path d="M6.5 13h9.8a3.4 3.4 0 0 0 .6-6.76 4.9 4.9 0 0 0-9.5-1.1A3.6 3.6 0 0 0 6.5 13z" fill="#9fb0c0"/>`;
+  const bodies: Record<Condition, string> = {
+    sun:
+      `<g stroke="#e8b93c" stroke-width="1.7" stroke-linecap="round">` +
+      `<line x1="12" y1="2.6" x2="12" y2="5.4"/><line x1="12" y1="18.6" x2="12" y2="21.4"/>` +
+      `<line x1="2.6" y1="12" x2="5.4" y2="12"/><line x1="18.6" y1="12" x2="21.4" y2="12"/>` +
+      `<line x1="5.4" y1="5.4" x2="7.3" y2="7.3"/><line x1="16.7" y1="16.7" x2="18.6" y2="18.6"/>` +
+      `<line x1="16.7" y1="7.3" x2="18.6" y2="5.4"/><line x1="5.4" y1="18.6" x2="7.3" y2="16.7"/>` +
+      `</g><circle cx="12" cy="12" r="4.5" fill="#e8b93c"/>`,
+    cloud: `<path d="M6.3 17.5h10.2a3.9 3.9 0 0 0 .7-7.74 5.4 5.4 0 0 0-10.5-1.2A4.1 4.1 0 0 0 6.3 17.5z" fill="#9fb0c0"/>`,
+    rain:
+      cloudLow +
+      `<g stroke="#6da7ec" stroke-width="1.7" stroke-linecap="round">` +
+      `<line x1="8.4" y1="15.6" x2="7.2" y2="19.6"/><line x1="12.4" y1="15.6" x2="11.2" y2="19.6"/>` +
+      `<line x1="16.4" y1="15.6" x2="15.2" y2="19.6"/></g>`,
+    storm:
+      cloudLow +
+      `<polygon points="13.4,12.6 9.8,18.4 12.2,18.4 10.9,22.6 16.1,16.4 13.4,16.4 15.6,12.6" fill="#e8b93c"/>`,
+    snow:
+      cloudLow +
+      `<g fill="#e8f1fa"><circle cx="8.4" cy="16.8" r="1.35"/><circle cx="12.4" cy="19.6" r="1.35"/><circle cx="16.4" cy="16.8" r="1.35"/></g>`,
+  };
+  return `<svg width="${px}" height="${px}" viewBox="0 0 24 24" role="img" aria-label="${kind}">${bodies[kind]}</svg>`;
+}
+
+const WIDGET_CSS = `
+  * { box-sizing:border-box; }
+  body { margin:0; width:560px; height:320px; overflow:hidden; padding:10px 12px;
+         background:#101a24; color:#e7edf3;
+         font:12px/1.35 system-ui,-apple-system,"Segoe UI",sans-serif; }
+  #titlebar { display:flex; align-items:baseline; justify-content:space-between;
+              margin-bottom:6px; }
+  #title { font-size:11px; font-weight:700; letter-spacing:.13em; color:#8fc1f0; }
+  #title span { color:#7b8ea0; font-weight:500; letter-spacing:.05em; }
+  #legend { font-size:9.5px; color:#9db0c0; display:flex; gap:10px; }
+  #legend i { display:inline-block; width:8px; height:8px; border-radius:50%;
+              margin-right:4px; vertical-align:-1px; }
+  text { font-family:system-ui,-apple-system,"Segoe UI",sans-serif; }
+`;
+
+function dailyWidgetHtml(location: string, days: DayForecast[]): string {
+  const W = 536;
+  const plotX0 = 36;
+  const plotX1 = W - 8;
+  const tY0 = 8;
+  const tY1 = 108;
+  const pBase = 158;
+  const pMax = 32;
+  const n = days.length;
+  const step = (plotX1 - plotX0) / n;
+  const cx = (i: number) => plotX0 + (i + 0.5) * step;
+
+  const tMin = Math.min(...days.map((d) => d.lo)) - 4;
+  const tMax = Math.max(...days.map((d) => d.hi)) + 4;
+  const ty = (t: number) => tY1 - ((t - tMin) / (tMax - tMin)) * (tY1 - tY0);
+
+  // gridlines on a clean step
+  const range = tMax - tMin;
+  const tick = range > 45 ? 20 : range > 22 ? 10 : 5;
+  let grid = "";
+  for (let t = Math.ceil(tMin / tick) * tick; t <= tMax; t += tick) {
+    grid +=
+      `<line x1="${plotX0}" y1="${ty(t).toFixed(1)}" x2="${plotX1}" y2="${ty(t).toFixed(1)}" stroke="#223140" stroke-width="1"/>` +
+      `<text x="${plotX0 - 5}" y="${(ty(t) + 3).toFixed(1)}" text-anchor="end" font-size="8.5" fill="#7b8ea0">${t}°</text>`;
+  }
+
+  const hiPts = days.map((d, i) => [cx(i), ty(d.hi)] as [number, number]);
+  const loPts = days.map((d, i) => [cx(i), ty(d.lo)] as [number, number]);
+  const hiD = smoothPath(hiPts);
+  const loRev = [...loPts].reverse();
+  const band =
+    n > 1
+      ? `${hiD} L${loRev[0][0].toFixed(1)},${loRev[0][1].toFixed(1)} ${smoothPath(loRev).replace(/^M[^C]*/, "")} Z`
+      : "";
+
+  // selective direct labels: the warmest hi and the coldest lo
+  const hiMaxI = days.reduce((b, d, i) => (d.hi > days[b].hi ? i : b), 0);
+  const loMinI = days.reduce((b, d, i) => (d.lo < days[b].lo ? i : b), 0);
+  const halo = `paint-order="stroke" stroke="#101a24" stroke-width="3"`;
+  const labels =
+    `<text x="${hiPts[hiMaxI][0].toFixed(1)}" y="${(hiPts[hiMaxI][1] - 6).toFixed(1)}" text-anchor="middle" font-size="9" font-weight="700" fill="#e7edf3" ${halo}>${days[hiMaxI].hi}°</text>` +
+    `<text x="${loPts[loMinI][0].toFixed(1)}" y="${(loPts[loMinI][1] + 13).toFixed(1)}" text-anchor="middle" font-size="9" font-weight="700" fill="#e7edf3" ${halo}>${days[loMinI].lo}°</text>`;
+
+  // precipitation bars (2px surface gaps come from the bar width < step)
+  const barW = Math.min(24, step * 0.5);
+  let bars = "";
+  for (let i = 0; i < n; i++) {
+    const h = (days[i].precip / 100) * pMax;
+    bars +=
+      `<rect x="${(cx(i) - barW / 2).toFixed(1)}" y="${(pBase - h).toFixed(1)}" width="${barW.toFixed(1)}" height="${h.toFixed(1)}" rx="2" fill="#6da7ec"><title>${days[i].weekday} · ${days[i].precip}% precip</title></rect>` +
+      (days[i].precip >= 45
+        ? `<text x="${cx(i).toFixed(1)}" y="${(pBase - h - 3).toFixed(1)}" text-anchor="middle" font-size="7.5" fill="#9db0c0">${days[i].precip}</text>`
+        : "");
+  }
+
+  const todayLine = `<line x1="${cx(0).toFixed(1)}" y1="${tY0}" x2="${cx(0).toFixed(1)}" y2="${pBase}" stroke="#3a4d61" stroke-width="1" stroke-dasharray="3 3"/>`;
+
+  const cards = days
+    .map(
+      (d, i) => `<div class="day${i === 0 ? " today" : ""}">
+        <div class="wd">${i === 0 ? "Today" : d.weekday}</div>${glyph(d.condition, n > 10 ? 15 : 18)}
+        <div class="hi">${d.hi}°</div><div class="lo">${d.lo}°</div></div>`,
+    )
+    .join("");
+
+  return `<!doctype html><html><head><meta charset="utf-8"><style>${WIDGET_CSS}
+  #days { display:flex; gap:${n > 10 ? 2 : 4}px; margin-top:5px; }
+  .day { flex:1; min-width:0; background:#16222e; border:1px solid #223140;
+         border-radius:8px; padding:4px 1px 5px; text-align:center;
+         display:flex; flex-direction:column; align-items:center; gap:1px; }
+  .day.today { border-color:#3d566b; background:#1a2938; }
+  .day .wd { font-size:${n > 10 ? 8 : 9}px; color:#9db0c0; text-transform:uppercase;
+             letter-spacing:.04em; }
+  .day .hi { font-size:${n > 10 ? 9.5 : 11}px; font-weight:700; }
+  .day .lo { font-size:${n > 10 ? 8.5 : 9.5}px; color:#9db0c0; }
+  </style></head><body>
+  <div id="titlebar">
+    <div id="title">METEORA <span>· ${days.length}-day forecast — ${esc(location)}</span></div>
+    <div id="legend"><span><i style="background:#d95926"></i>high</span><span><i style="background:#3987e5"></i>low</span><span><i style="background:#6da7ec"></i>precip %</span></div>
+  </div>
+  <svg width="${W}" height="164" viewBox="0 0 ${W} 164">
+    <defs><linearGradient id="band" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#d95926" stop-opacity=".16"/>
+      <stop offset="1" stop-color="#3987e5" stop-opacity=".16"/>
+    </linearGradient></defs>
+    ${grid}${todayLine}
+    ${band ? `<path d="${band}" fill="url(#band)"/>` : ""}
+    <path d="${hiD}" fill="none" stroke="#d95926" stroke-width="2" stroke-linecap="round"/>
+    <path d="${smoothPath(loPts)}" fill="none" stroke="#3987e5" stroke-width="2" stroke-linecap="round"/>
+    ${n === 1 ? `<circle cx="${cx(0)}" cy="${ty(days[0].hi).toFixed(1)}" r="4" fill="#d95926"/><circle cx="${cx(0)}" cy="${ty(days[0].lo).toFixed(1)}" r="4" fill="#3987e5"/>` : ""}
+    ${labels}
+    <text x="2" y="146" font-size="8" fill="#7b8ea0">precip</text>
+    ${bars}
+    <line x1="${plotX0}" y1="${pBase}" x2="${plotX1}" y2="${pBase}" stroke="#31414f" stroke-width="1"/>
+  </svg>
+  <div id="days">${cards}</div>
+  </body></html>`;
+}
+
+function climateWidgetHtml(location: string, rows: MonthOutlook[]): string {
+  const W = 536;
+  const plotX0 = 36;
+  const plotX1 = W - 10;
+  const y0 = 8;
+  const y1 = 112;
+  const n = rows.length;
+  const step = (plotX1 - plotX0) / Math.max(1, n);
+  const cx = (i: number) => plotX0 + (i + 0.5) * step;
+
+  const bandHalf = 5;
+  const vMin = Math.min(...rows.map((r) => Math.min(r.avgF, r.normalF - bandHalf))) - 3;
+  const vMax = Math.max(...rows.map((r) => Math.max(r.avgF, r.normalF + bandHalf))) + 3;
+  const vy = (t: number) => y1 - ((t - vMin) / (vMax - vMin)) * (y1 - y0);
+
+  const range = vMax - vMin;
+  const tick = range > 45 ? 20 : range > 22 ? 10 : 5;
+  let grid = "";
+  for (let t = Math.ceil(vMin / tick) * tick; t <= vMax; t += tick) {
+    grid +=
+      `<line x1="${plotX0}" y1="${vy(t).toFixed(1)}" x2="${plotX1}" y2="${vy(t).toFixed(1)}" stroke="#223140" stroke-width="1"/>` +
+      `<text x="${plotX0 - 5}" y="${(vy(t) + 3).toFixed(1)}" text-anchor="end" font-size="8.5" fill="#7b8ea0">${t}°</text>`;
+  }
+
+  const upPts = rows.map((r, i) => [cx(i), vy(r.normalF + bandHalf)] as [number, number]);
+  const dnPts = rows.map((r, i) => [cx(i), vy(r.normalF - bandHalf)] as [number, number]);
+  const dnRev = [...dnPts].reverse();
+  const bandD =
+    n > 1
+      ? `${smoothPath(upPts)} L${dnRev[0][0].toFixed(1)},${dnRev[0][1].toFixed(1)} ${smoothPath(dnRev).replace(/^M[^C]*/, "")} Z`
+      : "";
+
+  const avgPts = rows.map((r, i) => [cx(i), vy(r.avgF)] as [number, number]);
+  const halo = `paint-order="stroke" stroke="#101a24" stroke-width="3"`;
+  const markers = rows
+    .map(
+      (r, i) =>
+        `<circle cx="${avgPts[i][0].toFixed(1)}" cy="${avgPts[i][1].toFixed(1)}" r="4" fill="#d95926" stroke="#101a24" stroke-width="2"><title>${r.label} · avg ${r.avgF}°F (normal ${r.normalF}°F)</title></circle>`,
+    )
+    .join("");
+  const endLabels =
+    `<text x="${avgPts[0][0].toFixed(1)}" y="${(avgPts[0][1] - 8).toFixed(1)}" text-anchor="middle" font-size="9" font-weight="700" fill="#e7edf3" ${halo}>${Math.round(rows[0].avgF)}°</text>` +
+    (n > 1
+      ? `<text x="${avgPts[n - 1][0].toFixed(1)}" y="${(avgPts[n - 1][1] - 8).toFixed(1)}" text-anchor="middle" font-size="9" font-weight="700" fill="#e7edf3" ${halo}>${Math.round(rows[n - 1].avgF)}°</text>`
+      : "");
+
+  const monthLabels = rows
+    .map(
+      (r, i) =>
+        `<text x="${cx(i).toFixed(1)}" y="128" text-anchor="middle" font-size="8.5" fill="#9db0c0">${r.label}</text>`,
+    )
+    .join("");
+
+  const drop = `<svg width="10" height="10" viewBox="0 0 24 24"><path d="M12 3c3 4.4 6 7.4 6 10.4a6 6 0 1 1-12 0C6 10.4 9 7.4 12 3z" fill="#6da7ec"/></svg>`;
+  const dry = `<svg width="10" height="10" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4.5" fill="#d95926"/><g stroke="#d95926" stroke-width="1.7" stroke-linecap="round"><line x1="12" y1="3" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="21"/><line x1="3" y1="12" x2="6" y2="12"/><line x1="18" y1="12" x2="21" y2="12"/></g></svg>`;
+  const chips = rows
+    .map((r) => {
+      const g = r.precip === "wetter" ? drop : r.precip === "drier" ? dry : "";
+      const word = r.precip === "wetter" ? "wet" : r.precip === "drier" ? "dry" : "–";
+      return `<div class="chip p-${r.precip}"><span class="m">${r.label}</span>${g}<span class="w">${word}</span></div>`;
+    })
+    .join("");
+
+  return `<!doctype html><html><head><meta charset="utf-8"><style>${WIDGET_CSS}
+  #chips { display:flex; gap:${n > 8 ? 2 : 4}px; margin-top:6px; }
+  .chip { flex:1; min-width:0; display:flex; align-items:center; justify-content:center;
+          gap:3px; background:#16222e; border:1px solid #223140; border-radius:7px;
+          padding:3px 2px; font-size:${n > 8 ? 8 : 9}px; color:#9db0c0; }
+  .chip .m { font-weight:700; color:#c6d3de; }
+  .chip.p-normal { opacity:.75; }
+  #sentence { margin-top:7px; font-size:10.5px; font-style:italic; color:#9db0c0;
+              line-height:1.35; }
+  </style></head><body>
+  <div id="titlebar">
+    <div id="title">METEORA <span>· ${n}-month outlook — ${esc(location)}</span></div>
+    <div id="legend"><span><i style="background:#d95926"></i>monthly avg</span><span><i style="background:#2a3742; border-radius:2px"></i>normal band</span></div>
+  </div>
+  <svg width="${W}" height="134" viewBox="0 0 ${W} 134">
+    ${grid}
+    ${bandD ? `<path d="${bandD}" fill="#22303c"/>` : ""}
+    ${n > 1 ? `<path d="${smoothPath(avgPts)}" fill="none" stroke="#d95926" stroke-width="2" stroke-linecap="round"/>` : ""}
+    ${markers}${endLabels}${monthLabels}
+  </svg>
+  <div id="chips">${chips}</div>
+  <div id="sentence">${esc(outlookSentence(location, rows))}</div>
+  </body></html>`;
+}
+
+// ── protocol plumbing ───────────────────────────────────────────────────────
+
+const agentCard = {
+  protocolVersion: "0.2.5",
+  name: "Meteora",
+  description: "A long-range forecaster fluent in seasons, not just weekends.",
+  version: "1.0.0",
+  url: `http://localhost:${port}/a2a`,
+  capabilities: { streaming: false, pushNotifications: false },
+  defaultInputModes: ["text/plain"],
+  defaultOutputModes: ["text/plain"],
+  skills: [
+    {
+      id: "forecast",
+      name: "Forecast",
+      description: "Daily forecasts up to 14 days and climate outlooks up to 12 months.",
+      tags: ["demo", "weather"],
+    },
+  ],
+};
+
+/** Pull a location out of free text, loosely. */
+function parseLocation(text: string): string {
+  const m = text.match(/(?:in|for|at|near)\s+([A-Z][\w'.-]*(?:[ ,]+[A-Z][\w'.-]*)*)/);
+  if (m) return m[1].replace(/[?.!,]+$/, "").trim();
+  return DEFAULT_LOCATION;
+}
+
+function sevenDaySummary(location: string): string {
+  const days = forecast(location, 7);
+  const lines = days
+    .map((d, i) => `${i === 0 ? "Today" : d.weekday} ${d.hi}/${d.lo} ${d.condition}${d.precip >= 50 ? ` (${d.precip}% precip)` : ""}`)
+    .join(", ");
+  const warmest = days.reduce((b, d) => (d.hi > b.hi ? d : b));
+  return `Meteora 7-day for ${location}: ${lines}. Warmest ${warmest.weekday} at ${warmest.hi}°F.`;
+}
+
+function readBody(req: import("node:http").IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (c) => (data += c));
+    req.on("end", () => resolve(data));
+    req.on("error", reject);
+  });
+}
+
+const server = createServer((req, res) => {
+  void (async () => {
+    const path = new URL(req.url ?? "/", `http://localhost:${port}`).pathname;
+
+    if (req.method === "GET" && path === "/.well-known/agent-card.json") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(agentCard));
+      return;
+    }
+
+    if (req.method === "POST" && path === "/a2a") {
+      const rpc = JSON.parse(await readBody(req));
+      const parts: Array<{ kind?: string; text?: string }> =
+        rpc?.params?.message?.parts ?? [];
+      const asked = parts.filter((p) => p.kind === "text").map((p) => p.text).join(" ");
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: rpc.id ?? null,
+          result: {
+            kind: "message",
+            messageId: randomUUID(),
+            role: "agent",
+            parts: [{ kind: "text", text: sevenDaySummary(parseLocation(asked)) }],
+          },
+        }),
+      );
+      return;
+    }
+
+    if (path === "/mcp") {
+      const raw = await readBody(req);
+      let parsed: unknown;
+      try {
+        parsed = raw ? JSON.parse(raw) : undefined;
+      } catch {
+        res.writeHead(400).end();
+        return;
+      }
+      const mcp = new McpServer({ name: "meteora", version: "1.0.0" });
+      mcp.registerTool(
+        "get_forecast",
+        {
+          description:
+            "Daily weather forecast for a location, 1–14 days out (default 7). Returns JSON (hi/lo °F, precip %, condition) plus a forecast-panel widget the client may render.",
+          inputSchema: {
+            location: z.string().min(1),
+            days: z.number().int().min(1).max(14).optional(),
+          },
+        },
+        async ({ location, days }) => {
+          const n = days ?? 7;
+          const rows = forecast(location, n);
+          return {
+            content: [
+              { type: "text", text: JSON.stringify({ location, days: rows }) },
+              {
+                type: "resource",
+                resource: {
+                  uri: `ui://meteora/forecast/${randomUUID()}`,
+                  mimeType: "text/html",
+                  text: dailyWidgetHtml(location, rows),
+                },
+              },
+            ],
+          };
+        },
+      );
+      mcp.registerTool(
+        "get_climate_outlook",
+        {
+          description:
+            "Long-range monthly climate outlook for a location, 1–12 months out (default 6). Returns JSON (monthly avg vs normal °F, wetter/drier lean) plus an outlook widget the client may render.",
+          inputSchema: {
+            location: z.string().min(1),
+            months: z.number().int().min(1).max(12).optional(),
+          },
+        },
+        async ({ location, months }) => {
+          const rows = climateOutlook(location, months ?? 6);
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  location,
+                  months: rows,
+                  outlook: outlookSentence(location, rows),
+                }),
+              },
+              {
+                type: "resource",
+                resource: {
+                  uri: `ui://meteora/outlook/${randomUUID()}`,
+                  mimeType: "text/html",
+                  text: climateWidgetHtml(location, rows),
+                },
+              },
+            ],
+          };
+        },
+      );
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      await mcp.connect(transport);
+      await transport.handleRequest(req, res, parsed);
+      await transport.close();
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("try /mcp, /a2a, or /.well-known/agent-card.json");
+  })().catch((err) => {
+    if (!res.headersSent) {
+      res.writeHead(500);
+      res.end(String(err));
+    }
+  });
+});
+
+server.listen(port, () => {
+  console.log(`meteora demo: http://localhost:${port}`);
+  console.log(`  MCP:      http://localhost:${port}/mcp`);
+  console.log(`  A2A card: http://localhost:${port}/.well-known/agent-card.json`);
+});

--- a/examples/agent-browser/index.html
+++ b/examples/agent-browser/index.html
@@ -67,7 +67,7 @@
   .ui-resource { margin-top: 8px; }
   .ui-resource .ui-label { font-size: 11px; color: var(--dim); font-family: ui-monospace, monospace; margin-bottom: 3px; }
   .ui-resource iframe {
-    width: 100%; max-width: 560px; height: 160px; border: 1px solid var(--line);
+    width: 100%; max-width: 560px; height: 320px; border: 1px solid var(--line);
     border-radius: 8px; background: var(--panel);
   }
   #composer { border-top: 1px solid var(--line); padding: 14px 24px; }


### PR DESCRIPTION
## What this PR contains

Three rich demo agents for the agent-browser example (follow-up to #334), each serving both protocol faces (MCP tools with mcp-ui HTML widgets + A2A card and `message/send`) on its own port so they can all be attached to one chat:

- **Hearthstone** (`demo-house.ts`, :7435) — stateful house controller: five rooms of lights, furnace with target temperature and real time-based thermal drift. Every tool returns a dashboard widget reflecting the new state (amber-glowing lit rooms, animated furnace flame, thermometer readout). Its A2A face also executes simple spoken commands (lights on/off, furnace to N) against the same live state, not just status reports.
- **Meteora** (`demo-weather.ts`, :7436) — long-range forecaster: deterministic seeded forecasts (same location + day = same numbers), 14-day SVG hi/lo temperature band with precipitation bars and glyph day-cards, plus a monthly climate outlook against a normal band.
- **Atlas** (`demo-atlas.ts`, :7437) — route planner on stable fictional geography: place names hash to fixed map coordinates, animated mode-colored route polylines, numbered markers, per-leg distance/ETA legend, and a landmarks view.

Supporting changes: chat iframe height raised to 320px for the richer widgets; README "More demo agents" section; TESTING.md §6 walkthrough; CLAUDE.md port table rows (7435–7437).

All widgets are fully self-contained HTML/SVG (sandboxed `srcdoc` iframes permit nothing external); chart colors validated with the dataviz palette checker on each widget's own surface; every tool returns a text JSON block before the UI resource so text-only clients degrade gracefully.

## Testing
- Each server's card + tool list verified via `discoverAgentEndpoint`; tool results asserted to carry text-first + `ui://` text/html resources; house state transitions and forecast determinism verified live; A2A command parsing verified (`turn on the porch light and set the furnace to 72` → state mutates, reply confirms).
- Widgets render-checked via headless Chromium (screenshots in the session).
- `pnpm test:run`: 2510 tests / 201 files green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Y6ycySLTXAYSbToMhdoum

---
_Generated by [Claude Code](https://claude.ai/code/session_013Y6ycySLTXAYSbToMhdoum)_