### PR TITLE
Strip dead and heavyweight dependencies across the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "vite": "^8.1.5",
     "vitepress": "2.0.0-alpha.18",
     "vitest": "^4.1.10",
-    "zod": "^4.4.3"
+    "zod": "^4.4.3",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.220"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,14 +29,10 @@
     "@umwelten/evaluation": "workspace:*",
     "@umwelten/sessions": "workspace:*",
     "@umwelten/ui": "workspace:*",
-    "ai": "^7.0.41",
     "file-type": "^22.0.1",
-    "ink": "^7.1.1",
-    "react": "^19.2.8",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^15.0.0",
-    "ora": "^9.4.1",
     "@umwelten/supplier": "workspace:*"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,25 +31,19 @@
   "dependencies": {
     "@ai-sdk/google": "^4.0.27",
     "@ai-sdk/openai-compatible": "^3.0.16",
-    "@google/generative-ai": "^0.24.1",
     "@json-render/core": "^0.19.0",
     "@openrouter/ai-sdk-provider": "^3.0.0",
     "ai": "^7.0.41",
     "better-sqlite3": "^12.11.1",
-    "chalk": "^5.6.2",
     "dotenv": "^17.4.2",
     "fast-xml-parser": "^5.10.1",
     "file-type": "^22.0.1",
-    "glob": "^13.0.6",
     "gray-matter": "^4.0.3",
     "ollama-ai-provider-v2": "^4.0.1",
     "streammark": "^1.0.4",
-    "tiktoken": "^1.0.22",
     "turndown": "^7.2.4",
     "undici": "^8.9.0",
-    "uuid": "^14.0.1",
-    "zod": "^4.4.3",
-    "zod-to-json-schema": "^3.25.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/core/src/dialogue/dialogue.ts
+++ b/packages/core/src/dialogue/dialogue.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import type { StreamObserver } from "../cognition/types.js";
 import { RoundRobinPolicy } from "./policies/round-robin.js";
 import { writeDialogueSession } from "./persist.js";
@@ -66,7 +66,7 @@ export class Dialogue {
     if (ids.size !== options.participants.length) {
       throw new Error("Dialogue participant ids must be unique");
     }
-    this.id = options.id ?? `dialogue-${uuidv4()}`;
+    this.id = options.id ?? `dialogue-${randomUUID()}`;
     this.participants = options.participants;
     this.policy = options.policy ?? new RoundRobinPolicy();
     // ?? per field (not a spread) so an explicitly-undefined maxTurns can't

--- a/packages/core/src/interaction/core/interaction.ts
+++ b/packages/core/src/interaction/core/interaction.ts
@@ -13,7 +13,7 @@ import { Stimulus } from "../../stimulus/stimulus.js";
 import { getCompactionSegment } from "../../context/segment.js";
 import { getCompactionStrategy } from "../../context/registry.js";
 
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import {
   NormalizedSession,
   SessionSource,
@@ -60,7 +60,7 @@ export class Interaction {
     this.modelDetails = modelDetails;
     this.stimulus = stimulus;
 
-    this.id = options?.id || uuidv4();
+    this.id = options?.id || randomUUID();
     this.metadata = {
       created: options?.created || new Date(),
       updated: options?.updated || new Date(),

--- a/packages/core/src/interaction/persistence/interaction-store.ts
+++ b/packages/core/src/interaction/persistence/interaction-store.ts
@@ -1,5 +1,4 @@
 
-import { v4 as uuidv4 } from 'uuid';
 import { join } from 'path';
 import fs from 'fs/promises';
 import {

--- a/packages/core/src/stimulus/stimulus.ts
+++ b/packages/core/src/stimulus/stimulus.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 import { ModelOptions } from "../cognition/types.js";
 import { Tool } from "ai";
 import type { SkillDefinition } from "./skills/types.js";
@@ -130,7 +129,13 @@ export class Stimulus {
   }
 
   setOutputSchema(schema: z.ZodType<any>) {
-    const schemaString = JSON.stringify(zodToJsonSchema(schema as any), null, 2);
+    // zod v4's native converter; unrepresentable: "any" matches the old
+    // zod-to-json-schema behavior of degrading rather than throwing.
+    const schemaString = JSON.stringify(
+      z.toJSONSchema(schema as any, { unrepresentable: "any" }),
+      null,
+      2,
+    );
     this.options.output = [schemaString];
   }
 

--- a/packages/evaluation/package.json
+++ b/packages/evaluation/package.json
@@ -32,9 +32,6 @@
     "@umwelten/core": "workspace:*",
     "@umwelten/sessions": "workspace:*",
     "ai": "^7.0.41",
-    "chalk": "^5.6.2",
-    "cli-table3": "^0.6.5",
-    "glob": "^13.0.6",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/habitat/package.json
+++ b/packages/habitat/package.json
@@ -31,25 +31,32 @@
   },
   "dependencies": {
     "@a2a-js/sdk": "^1.0.1",
-    "@anthropic-ai/claude-agent-sdk": "^0.3.220",
     "@mcp-ui/server": "^6.1.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "@tavily/core": "^0.7.6",
     "@umwelten/core": "workspace:*",
     "@umwelten/protocols": "workspace:*",
     "ai": "^7.0.41",
     "chalk": "^5.6.2",
     "commander": "^15.0.0",
-    "discord.js": "^14.27.0",
-    "glob": "^13.0.6",
     "gray-matter": "^4.0.3",
     "jose": "^6.2.4",
-    "uuid": "^14.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
+  },
+  "peerDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+    "@tavily/core": "^0.7.6"
+  },
+  "peerDependenciesMeta": {
+    "@anthropic-ai/claude-agent-sdk": {
+      "optional": true
+    },
+    "@tavily/core": {
+      "optional": true
+    }
   }
 }

--- a/packages/habitat/src/claude-sdk-runner.ts
+++ b/packages/habitat/src/claude-sdk-runner.ts
@@ -4,23 +4,100 @@
  * Wraps @anthropic-ai/claude-agent-sdk's query() to run Claude Code
  * as an agentic subprocess. Used by agent_ask_claude to delegate
  * coding tasks to Claude's full toolset (Read, Edit, Bash, Grep, etc.).
+ *
+ * The SDK is an optional peer dependency (~280 MB installed — it bundles
+ * the Claude Code binary), loaded lazily on first use. The lite types
+ * below mirror the slice of the SDK's message stream this runner reads,
+ * so nothing here needs the SDK present at typecheck or import time.
  */
 
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { query } from "@anthropic-ai/claude-agent-sdk";
-import type {
-  SDKMessage,
-  SDKResultMessage,
-  SDKAssistantMessage,
-  Options,
-} from "@anthropic-ai/claude-agent-sdk";
 import type {
   BridgeEventHandlers,
   RuntimeContext,
   RuntimeResult,
   RuntimeRunner,
 } from "./bridge/types.js";
+
+// ── Lite SDK types (structural subset of @anthropic-ai/claude-agent-sdk) ──
+
+export interface SDKContentBlock {
+  type: string;
+  text?: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+export interface SDKAssistantMessage {
+  type: "assistant";
+  error?: string;
+  message?: {
+    content?: SDKContentBlock[];
+  };
+}
+
+export interface SDKResultMessage {
+  type: "result";
+  subtype: string;
+  result?: string;
+  error?: string;
+  num_turns?: number;
+  duration_ms?: number;
+}
+
+export interface SDKSystemMessage {
+  type: "system";
+  subtype?: string;
+  session_id?: string;
+}
+
+export type SDKMessage =
+  | SDKAssistantMessage
+  | SDKResultMessage
+  | SDKSystemMessage
+  | { type: string; [key: string]: unknown };
+
+export interface ClaudeSDKQueryOptions {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  model?: string;
+  maxTurns?: number;
+  abortController?: AbortController;
+  permissionMode?: string;
+  allowedTools?: string[];
+  disallowedTools?: string[];
+  systemPrompt?: string;
+}
+
+export type ClaudeSdkQueryFn = (args: {
+  prompt: string;
+  options: ClaudeSDKQueryOptions;
+}) => AsyncIterable<SDKMessage>;
+
+let cachedQuery: ClaudeSdkQueryFn | undefined;
+
+/**
+ * Resolve the SDK's query() on first use. Non-literal specifier so tsc
+ * doesn't require the optional peer to be installed (same posture as
+ * streammark in core and @tavily/core in search-tools).
+ */
+async function loadSdkQuery(): Promise<ClaudeSdkQueryFn> {
+  if (!cachedQuery) {
+    const pkg = "@anthropic-ai/claude-agent-sdk"; // non-literal: optional peer
+    try {
+      const mod = await import(pkg);
+      cachedQuery = mod.query as ClaudeSdkQueryFn;
+    } catch {
+      throw new Error(
+        "The claude-sdk runtime requires @anthropic-ai/claude-agent-sdk. " +
+          "Install it (pnpm add @anthropic-ai/claude-agent-sdk) to use " +
+          "agent_ask_claude or the claude-sdk channel runtime.",
+      );
+    }
+  }
+  return cachedQuery;
+}
 
 export interface ClaudeSDKRunnerOptions {
   /** Working directory for Claude Code (typically agent's projectPath) */
@@ -50,7 +127,7 @@ export interface ClaudeSDKRunnerOptions {
    * query). Lets unit tests drive the message loop — init session-id
    * extraction, result handling — with the subprocess layer stubbed.
    */
-  queryFn?: typeof query;
+  queryFn?: ClaudeSdkQueryFn;
 }
 
 export interface ClaudeSDKProgress {
@@ -141,7 +218,7 @@ export async function runClaudeSDK(
     env.ANTHROPIC_API_KEY = options.apiKey;
   }
 
-  const queryOptions: Options = {
+  const queryOptions: ClaudeSDKQueryOptions = {
     cwd: options.cwd,
     env,
     maxTurns: options.maxTurns ?? 20,
@@ -167,7 +244,7 @@ export async function runClaudeSDK(
 
   let resultMessage: SDKResultMessage | undefined;
   let nativeSessionId: string | undefined;
-  const queryFn = options.queryFn ?? query;
+  const queryFn = options.queryFn ?? (await loadSdkQuery());
 
   for await (const message of queryFn({ prompt, options: queryOptions })) {
     switch (message.type) {

--- a/packages/habitat/src/discord-provision.ts
+++ b/packages/habitat/src/discord-provision.ts
@@ -4,14 +4,45 @@
  * Gated by DISCORD_AUTO_CHANNELS=1 and Manage Channels permission.
  */
 
-import type { CategoryChannel, Guild, TextChannel } from 'discord.js';
-import { ChannelType, PermissionFlagsBits } from 'discord.js';
 import { setChannelRoute } from './bridge/routing.js';
 
 const CATEGORY_NAME = 'Jeeves';
 
+// Discord API constants, inlined so habitat doesn't depend on discord.js
+// (the actual bot lives in @umwelten/ui). Values are wire-protocol stable:
+// https://discord.com/developers/docs/resources/channel#channel-object-channel-types
+const CHANNEL_TYPE_GUILD_TEXT = 0;
+const CHANNEL_TYPE_GUILD_CATEGORY = 4;
+const PERMISSION_MANAGE_CHANNELS = 1n << 4n;
+
+/** Structural subset of a discord.js guild channel used by provisioning. */
+export interface ProvisionGuildChannel {
+  id: string;
+  name: string;
+  type: number;
+}
+
+/**
+ * Structural subset of discord.js's Guild used by provisioning. A real
+ * `Guild` satisfies this shape; callers outside discord.js can stub it.
+ */
+export interface ProvisionGuild {
+  members: {
+    me: { permissions: { has(permission: bigint): boolean } } | null;
+  };
+  channels: {
+    cache: { values(): IterableIterator<ProvisionGuildChannel> };
+    create(options: {
+      name: string;
+      type: number;
+      parent?: string;
+      reason?: string;
+    }): Promise<ProvisionGuildChannel>;
+  };
+}
+
 export interface DiscordProvisionOptions {
-  guild: Guild;
+  guild: ProvisionGuild;
   workDir: string;
   agentId: string;
   /** Channel name (slug), e.g. operations */
@@ -42,20 +73,23 @@ export async function provisionDiscordAgentChannel(
   }
 
   const me = options.guild.members.me;
-  if (!me?.permissions.has(PermissionFlagsBits.ManageChannels)) {
+  if (!me?.permissions.has(PERMISSION_MANAGE_CHANNELS)) {
     return { ok: false, error: 'Bot lacks Manage Channels permission in this server.' };
   }
 
   const slug = slugChannelName(options.channelName);
-  let category = options.guild.channels.cache.find(
-    (c): c is CategoryChannel =>
-      c.type === ChannelType.GuildCategory && c.name === CATEGORY_NAME,
-  );
+  let category: ProvisionGuildChannel | undefined;
+  for (const c of options.guild.channels.cache.values()) {
+    if (c.type === CHANNEL_TYPE_GUILD_CATEGORY && c.name === CATEGORY_NAME) {
+      category = c;
+      break;
+    }
+  }
   if (!category) {
     try {
       category = await options.guild.channels.create({
         name: CATEGORY_NAME,
-        type: ChannelType.GuildCategory,
+        type: CHANNEL_TYPE_GUILD_CATEGORY,
         reason: 'Jeeves habitat agent channels',
       });
     } catch (e) {
@@ -66,11 +100,11 @@ export async function provisionDiscordAgentChannel(
     }
   }
 
-  let channel: TextChannel;
+  let channel: ProvisionGuildChannel;
   try {
     channel = await options.guild.channels.create({
       name: slug,
-      type: ChannelType.GuildText,
+      type: CHANNEL_TYPE_GUILD_TEXT,
       parent: category.id,
       reason: `Agent ${options.agentId}`,
     });

--- a/packages/protocols/package.json
+++ b/packages/protocols/package.json
@@ -36,8 +36,6 @@
     "@neondatabase/serverless": "^1.1.0",
     "ai": "^7.0.41",
     "chalk": "^5.6.2",
-    "undici": "^8.9.0",
-    "uuid": "^14.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/sessions/package.json
+++ b/packages/sessions/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@umwelten/core": "workspace:*",
     "@umwelten/ui": "workspace:*",
-    "ai": "^7.0.41",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^15.0.0"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,9 +37,7 @@
     "test:run": "vitest run --reporter=verbose"
   },
   "dependencies": {
-    "@ai-sdk/react": "^4.0.44",
     "@grammyjs/files": "^1.2.0",
-    "@inkjs/ui": "^2.0.0",
     "@types/react": "^19.2.17",
     "@umwelten/core": "workspace:*",
     "@umwelten/evaluation": "workspace:*",
@@ -50,7 +48,6 @@
     "fullscreen-ink": "^0.1.0",
     "grammy": "^1.45.1",
     "ink": "^7.1.1",
-    "ora": "^9.4.1",
     "react": "^19.2.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.3.220
+        version: 0.3.220(@anthropic-ai/sdk@0.90.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)
       '@dagger.io/dagger':
         specifier: ^0.21.7
         version: 0.21.7
@@ -113,9 +116,6 @@ importers:
       '@umwelten/ui':
         specifier: workspace:*
         version: link:../ui
-      ai:
-        specifier: ^7.0.41
-        version: 7.0.41(zod@4.4.3)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -128,15 +128,6 @@ importers:
       file-type:
         specifier: ^22.0.1
         version: 22.0.1
-      ink:
-        specifier: ^7.1.1
-        version: 7.1.1(@types/react@19.2.17)(react@19.2.8)
-      ora:
-        specifier: ^9.4.1
-        version: 9.4.1
-      react:
-        specifier: ^19.2.8
-        version: 19.2.8
     devDependencies:
       '@types/node':
         specifier: ^26.1.2
@@ -159,9 +150,6 @@ importers:
       '@ai-sdk/openai-compatible':
         specifier: ^3.0.16
         version: 3.0.16(zod@4.4.3)
-      '@google/generative-ai':
-        specifier: ^0.24.1
-        version: 0.24.1
       '@json-render/core':
         specifier: ^0.19.0
         version: 0.19.0(zod@4.4.3)
@@ -174,9 +162,6 @@ importers:
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
-      chalk:
-        specifier: ^5.6.2
-        version: 5.6.2
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -186,9 +171,6 @@ importers:
       file-type:
         specifier: ^22.0.1
         version: 22.0.1
-      glob:
-        specifier: ^13.0.6
-        version: 13.0.6
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -198,24 +180,15 @@ importers:
       streammark:
         specifier: ^1.0.4
         version: 1.0.4
-      tiktoken:
-        specifier: ^1.0.22
-        version: 1.0.22
       turndown:
         specifier: ^7.2.4
         version: 7.2.4
       undici:
         specifier: ^8.9.0
         version: 8.9.0
-      uuid:
-        specifier: ^14.0.1
-        version: 14.0.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
-      zod-to-json-schema:
-        specifier: ^3.25.2
-        version: 3.25.2(zod@4.4.3)
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -241,15 +214,6 @@ importers:
       ai:
         specifier: ^7.0.41
         version: 7.0.41(zod@4.4.3)
-      chalk:
-        specifier: ^5.6.2
-        version: 5.6.2
-      cli-table3:
-        specifier: ^0.6.5
-        version: 0.6.5
-      glob:
-        specifier: ^13.0.6
-        version: 13.0.6
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -318,21 +282,12 @@ importers:
       commander:
         specifier: ^15.0.0
         version: 15.0.0
-      discord.js:
-        specifier: ^14.27.0
-        version: 14.27.0
-      glob:
-        specifier: ^13.0.6
-        version: 13.0.6
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
       jose:
         specifier: ^6.2.4
         version: 6.2.4
-      uuid:
-        specifier: ^14.0.1
-        version: 14.0.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -367,12 +322,6 @@ importers:
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
-      undici:
-        specifier: ^8.9.0
-        version: 8.9.0
-      uuid:
-        specifier: ^14.0.1
-        version: 14.0.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -395,9 +344,6 @@ importers:
       '@umwelten/ui':
         specifier: workspace:*
         version: link:../ui
-      ai:
-        specifier: ^7.0.41
-        version: 7.0.41(zod@4.4.3)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -439,15 +385,9 @@ importers:
 
   packages/ui:
     dependencies:
-      '@ai-sdk/react':
-        specifier: ^4.0.44
-        version: 4.0.44(react@19.2.8)(zod@4.4.3)
       '@grammyjs/files':
         specifier: ^1.2.0
         version: 1.2.0(grammy@1.45.1)
-      '@inkjs/ui':
-        specifier: ^2.0.0
-        version: 2.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.8))
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -478,9 +418,6 @@ importers:
       ink:
         specifier: ^7.1.1
         version: 7.1.1(@types/react@19.2.17)(react@19.2.8)
-      ora:
-        specifier: ^9.4.1
-        version: 9.4.1
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -558,12 +495,6 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/mcp@2.0.18':
-    resolution: {integrity: sha512-0NEiqoS3PzkITQFldRuuPyO+CckgUPb9wWkp2hQlcaGxKu9ebFJDyjxGYEySE7TQN7mYc8PUuaNEODvky51NaA==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   '@ai-sdk/openai-compatible@3.0.16':
     resolution: {integrity: sha512-beXoYtlCnI02BYZU6oGfOPI40xC8MJx+Ek0SM8XZ8RcBBP7SaQ0qIV5DO3Y1euHMLMD92zE7nNHM0WcnnnX58A==}
     engines: {node: '>=22'}
@@ -589,12 +520,6 @@ packages:
   '@ai-sdk/provider@4.0.4':
     resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
     engines: {node: '>=22'}
-
-  '@ai-sdk/react@4.0.44':
-    resolution: {integrity: sha512-n/ouApRYXh//hxAItWg5xdKYGKhVigoWU/sf7uZExPB3uvQcrOKNCcNhF3r0WTdvWHQj+XHVqiRtPj/mMSVh8g==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@alcalzone/ansi-tokenize@0.3.0':
     resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
@@ -940,10 +865,6 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@google/generative-ai@0.24.1':
-    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
-    engines: {node: '>=18.0.0'}
-
   '@grammyjs/files@1.2.0':
     resolution: {integrity: sha512-UhQNGe2gpGgGMdrAUFXrZld3qQjt/3oYBHIo1aU0zIrKKvI5bgxzXSjPaJpx69HUO9mM7TbOaSsJL8lWbqnzJw==}
     engines: {node: ^12.20.0 || >=14.13.1}
@@ -998,12 +919,6 @@ packages:
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
-
-  '@inkjs/ui@2.0.0':
-    resolution: {integrity: sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      ink: '>=5'
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -2182,10 +2097,6 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
-
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
     engines: {node: 20 || >=22}
@@ -2243,18 +2154,6 @@ packages:
   cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
-
-  cli-spinners@3.3.0:
-    resolution: {integrity: sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ==}
-    engines: {node: '>=18.20'}
-
-  cli-spinners@3.4.0:
-    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
-    engines: {node: '>=18.20'}
 
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
@@ -2351,10 +2250,6 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  deepmerge@4.3.1:
-    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
-    engines: {node: '>=0.10.0'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -2700,10 +2595,6 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -2867,10 +2758,6 @@ packages:
     resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
     engines: {node: '>=20'}
     hasBin: true
-
-  is-interactive@2.0.0:
-    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
-    engines: {node: '>=12'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -3040,20 +2927,12 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
-  log-symbols@7.0.1:
-    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
-    engines: {node: '>=18'}
-
   long@2.4.0:
     resolution: {integrity: sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ==}
     engines: {node: '>=0.6'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
-
-  lru-cache@11.2.4:
-    resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
-    engines: {node: 20 || >=22}
 
   magic-bytes.js@1.13.1:
     resolution: {integrity: sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw==}
@@ -3114,17 +2993,9 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
-
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
-
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -3230,10 +3101,6 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
-
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
 
@@ -3247,10 +3114,6 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
-
-  ora@9.4.1:
-    resolution: {integrity: sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==}
-    engines: {node: '>=20'}
 
   oxc-parser@0.140.0:
     resolution: {integrity: sha512-h6QFWd6lBMfjESqgQ27GjzrSDb0qbznp7VDQqp2zvgsrWut4vcchyMIzOVXvGQ2GMZgKw9RWrFNWv9WqGL0p7Q==}
@@ -3294,10 +3157,6 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
-
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -3434,10 +3293,6 @@ packages:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
-
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3552,10 +3407,6 @@ packages:
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
-  stdin-discarder@0.3.2:
-    resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
-    engines: {node: '>=18'}
-
   streammark@1.0.4:
     resolution: {integrity: sha512-2r1Jtw8P3wdsqjmwo6fIYZZeyc99seYyM63DEEuMbDmFqLD8xO8L6+ovThcR67eQSs51NOnH0gLLySB4Mksm3A==}
 
@@ -3569,10 +3420,6 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
-
-  string-width@8.2.1:
-    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
-    engines: {node: '>=20'}
 
   string-width@8.2.2:
     resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
@@ -3615,11 +3462,6 @@ packages:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
 
-  swr@2.4.2:
-    resolution: {integrity: sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
@@ -3646,13 +3488,6 @@ packages:
     resolution: {integrity: sha512-UcuBd3eanB3T10nXWRRMwfwoaC6VMk7qe3/5YIWP2Jtw+EbHqJ0p1/K3x8ixiR5dozKSSfcg1W+0e33G1Di3XA==}
     engines: {node: '>= 0.10.x'}
     hasBin: true
-
-  throttleit@2.1.0:
-    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
-    engines: {node: '>=18'}
-
-  tiktoken@1.0.22:
-    resolution: {integrity: sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3777,20 +3612,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
-    hasBin: true
-
-  uuid@14.0.1:
-    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   uuid@8.3.2:
@@ -4044,13 +3870,6 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.14(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/mcp@2.0.18(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.4
-      '@ai-sdk/provider-utils': 5.0.14(zod@4.4.3)
-      pkce-challenge: 5.0.1
-      zod: 4.4.3
-
   '@ai-sdk/openai-compatible@3.0.16(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.4
@@ -4080,18 +3899,6 @@ snapshots:
   '@ai-sdk/provider@4.0.4':
     dependencies:
       json-schema: 0.4.0
-
-  '@ai-sdk/react@4.0.44(react@19.2.8)(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/mcp': 2.0.18(zod@4.4.3)
-      '@ai-sdk/provider': 4.0.4
-      '@ai-sdk/provider-utils': 5.0.14(zod@4.4.3)
-      ai: 7.0.41(zod@4.4.3)
-      react: 19.2.8
-      swr: 2.4.2(react@19.2.8)
-      throttleit: 2.1.0
-    transitivePeerDependencies:
-      - zod
 
   '@alcalzone/ansi-tokenize@0.3.0':
     dependencies:
@@ -4382,8 +4189,6 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@google/generative-ai@0.24.1': {}
-
   '@grammyjs/files@1.2.0(grammy@1.45.1)':
     dependencies:
       grammy: 1.45.1
@@ -4431,14 +4236,6 @@ snapshots:
       '@iconify/types': 2.0.0
 
   '@iconify/types@2.0.0': {}
-
-  '@inkjs/ui@2.0.0(ink@7.1.1(@types/react@19.2.17)(react@19.2.8))':
-    dependencies:
-      chalk: 5.6.2
-      cli-spinners: 3.3.0
-      deepmerge: 4.3.1
-      figures: 6.1.0
-      ink: 7.1.1(@types/react@19.2.17)(react@19.2.8)
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -5568,10 +5365,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.5:
-    dependencies:
-      balanced-match: 4.0.4
-
   brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
@@ -5621,14 +5414,6 @@ snapshots:
   cli-cursor@4.0.0:
     dependencies:
       restore-cursor: 4.0.0
-
-  cli-cursor@5.0.0:
-    dependencies:
-      restore-cursor: 5.1.0
-
-  cli-spinners@3.3.0: {}
-
-  cli-spinners@3.4.0: {}
 
   cli-table3@0.6.5:
     dependencies:
@@ -5705,8 +5490,6 @@ snapshots:
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
-
-  deepmerge@4.3.1: {}
 
   delayed-stream@1.0.0: {}
 
@@ -6135,12 +5918,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@13.0.6:
-    dependencies:
-      minimatch: 10.2.4
-      minipass: 7.1.3
-      path-scurry: 2.0.2
-
   gopd@1.2.0: {}
 
   grammy@1.45.1:
@@ -6320,8 +6097,6 @@ snapshots:
 
   is-in-ci@2.0.0: {}
 
-  is-interactive@2.0.0: {}
-
   is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
@@ -6460,16 +6235,9 @@ snapshots:
 
   lodash@4.18.1: {}
 
-  log-symbols@7.0.1:
-    dependencies:
-      is-unicode-supported: 2.1.0
-      yoctocolors: 2.1.2
-
   long@2.4.0: {}
 
   long@5.3.2: {}
-
-  lru-cache@11.2.4: {}
 
   magic-bytes.js@1.13.1: {}
 
@@ -6528,13 +6296,7 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  mimic-function@5.0.1: {}
-
   mimic-response@3.1.0: {}
-
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.5
 
   minimatch@10.2.5:
     dependencies:
@@ -6614,10 +6376,6 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
-
   oniguruma-parser@0.12.2: {}
 
   oniguruma-to-es@4.3.6:
@@ -6636,17 +6394,6 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
-
-  ora@9.4.1:
-    dependencies:
-      chalk: 5.6.2
-      cli-cursor: 5.0.0
-      cli-spinners: 3.4.0
-      is-interactive: 2.0.0
-      is-unicode-supported: 2.1.0
-      log-symbols: 7.0.1
-      stdin-discarder: 0.3.2
-      string-width: 8.2.1
 
   oxc-parser@0.140.0:
     dependencies:
@@ -6716,11 +6463,6 @@ snapshots:
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
-
-  path-scurry@2.0.2:
-    dependencies:
-      lru-cache: 11.2.4
-      minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
 
@@ -6863,11 +6605,6 @@ snapshots:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-
-  restore-cursor@5.1.0:
-    dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
 
   rolldown@1.1.5:
     dependencies:
@@ -7022,8 +6759,6 @@ snapshots:
 
   std-env@4.2.0: {}
 
-  stdin-discarder@0.3.2: {}
-
   streammark@1.0.4:
     dependencies:
       chalk: 5.6.2
@@ -7040,11 +6775,6 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
-
-  string-width@8.2.1:
-    dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
@@ -7086,12 +6816,6 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
-  swr@2.4.2(react@19.2.8):
-    dependencies:
-      dequal: 2.0.3
-      react: 19.2.8
-      use-sync-external-store: 1.6.0(react@19.2.8)
-
   tabbable@6.5.0: {}
 
   tagged-tag@1.0.0: {}
@@ -7126,10 +6850,6 @@ snapshots:
       bufrw: 1.4.0
       error: 7.0.2
       long: 2.4.0
-
-  throttleit@2.1.0: {}
-
-  tiktoken@1.0.22: {}
 
   tinybench@2.9.0: {}
 
@@ -7237,15 +6957,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-sync-external-store@1.6.0(react@19.2.8):
-    dependencies:
-      react: 19.2.8
-
   util-deprecate@1.0.2: {}
 
   uuid@11.1.1: {}
-
-  uuid@14.0.1: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
## What

Cuts the published install footprint by ~300 MB and removes 17 dependency declarations, with no behavior change for the dev workspace or Docker images.

### Claude Agent SDK → optional peer (~280 MB)

`@anthropic-ai/claude-agent-sdk` was a hard dependency of `@umwelten/habitat`, statically imported in `claude-sdk-runner.ts` — so every install of habitat (and everything above it: ui, cli, the `umwelten` meta-package) pulled the full Claude Code binary (~275 MB for the platform package), even when the `claude-sdk` runtime and `agent_ask_claude` were never used.

Now:
- The runner lazy-loads `query()` on first use and throws a clear install hint when the SDK is absent — the same pattern already used for `streammark` (core observers) and `@tavily/core` (search tools).
- Local structural "lite" types replace the SDK's type imports, so the raw-TS-published source typechecks without the package installed.
- Habitat declares it under `peerDependencies` + `peerDependenciesMeta.optional`.
- The workspace root keeps it as a devDependency: `habitat serve` in dev and both Dockerfiles (which run a full `pnpm install`) behave exactly as before. Verified the SDK resolves from inside `packages/habitat` at runtime.

### Dead dependencies removed (declared, never imported)

- core: `tiktoken` (23 MB WASM), `@google/generative-ai`, `glob`, `chalk`
- evaluation: `glob`, `chalk`, `cli-table3`
- habitat: `glob`, `uuid`
- protocols: `undici`, `uuid`
- cli: `ai`, `ink`, `react`, `ora`
- ui: `@ai-sdk/react`, `@inkjs/ui`, `ora`
- sessions: `ai`

### Replaced with built-ins

- `uuid` → `node:crypto` `randomUUID()` (3 call sites in core)
- `zod-to-json-schema` → zod v4's native `z.toJSONSchema()` with `unrepresentable: "any"` to preserve the old degrade-don't-throw behavior

### discord.js out of habitat

`discord-provision.ts` was habitat's only discord.js usage — two enum values and some types. It now uses inlined wire-protocol constants (channel types 0/4, ManageChannels bit) and a structural `ProvisionGuild` type that the real discord.js `Guild` passed by `DiscordAdapter` satisfies with no casts. The bot itself stays in `@umwelten/ui`, which keeps discord.js.

`@tavily/core` (already dynamically imported) also becomes an optional peer of habitat.

### Deliberately left alone

- `@types/react` stays in ui's `dependencies`: these packages publish raw TS source, so consumers compiling ui's `.tsx` need the React types.
- `better-sqlite3` (27 MB + native build, Cursor adapter only) — optionalizing it touches the Cursor session load path and deserves its own pass.

## Verification

- `pnpm test:run` — 201 files, 2510 tests, all green
- `pnpm typecheck` — clean across all packages + gated examples
- `pnpm lint` — 0 errors (warnings pre-existing)
- Runtime resolution of the SDK from `packages/habitat` via the root devDependency confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgjKK61q1DNCV86Dtnh62h

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgjKK61q1DNCV86Dtnh62h)_