### PR TITLE
Agent-browser: live widget clicks via host-mediated tool calls

### DIFF
--- a/examples/agent-browser/TESTING.md
+++ b/examples/agent-browser/TESTING.md
@@ -118,6 +118,14 @@ faces), then try:
 - `Turn on the porch light and set the furnace to 72` — the house dashboard
   should show the porch glowing amber and the furnace flame lit, with the
   indoor temperature drifting toward target on later calls.
+- **Click the dashboard itself.** Room cards and the furnace are live
+  controls: a click posts a `ui-tool-call` to the host page, the host runs
+  the real tool through the chat server, the widget refreshes in place with
+  the new state, and the row gains a `set_light ⚡` chip. Then ask
+  `What's the house status?` — the model already knows about your click,
+  because the bridge feeds UI actions back into the conversation context
+  (the MCP Apps host-mediated pattern in miniature). Opening the widget
+  outside the chat falls back to a local preview after a beat.
 - `What's the 14-day outlook for Chicago?` — a hi/lo temperature band chart
   with precipitation bars and per-day glyph cards. Ask again: forecasts are
   deterministic per location + day, so the numbers agree.

--- a/examples/agent-browser/demo-house.ts
+++ b/examples/agent-browser/demo-house.ts
@@ -158,7 +158,7 @@ function dashboardHtml(): string {
       <div id="temp"></div>
     </div>
   </div>
-  <div id="note">Click rooms or the furnace for a local preview — ask the agent to actually switch anything.</div>
+  <div id="note">Click rooms or the furnace — changes go through the host (or stay a local preview without one).</div>
   <script>
   const ROOMS = ${JSON.stringify(ROOMS)};
   let s = ${JSON.stringify(s)};
@@ -190,9 +190,42 @@ function dashboardHtml(): string {
       (s.furnace.on ? s.furnace.targetF : ${COLD_FLOOR_F}) + '°F</span>' +
       '<div class="mode">' + modeText + '</div></div>';
     for (const el of document.querySelectorAll(".room"))
-      el.onclick = () => { s.rooms[el.dataset.room] = !s.rooms[el.dataset.room]; poke(); };
-    f.onclick = () => { s.furnace.on = !s.furnace.on; retrend(); poke(); };
+      el.onclick = () => {
+        const room = el.dataset.room;
+        bridge("set_light", { room, on: !s.rooms[room] },
+          () => { s.rooms[room] = !s.rooms[room]; poke(); });
+      };
+    f.onclick = () => {
+      bridge("set_furnace", { on: !s.furnace.on },
+        () => { s.furnace.on = !s.furnace.on; retrend(); poke(); });
+    };
   }
+  // The MCP Apps pattern in miniature: the sandboxed app never talks to the
+  // server itself — it asks the HOST to run the tool call. A host that
+  // implements the bridge answers with ui-tool-result and replaces this
+  // widget with the fresh dashboard; without a host we fall back to the
+  // local preview after a short wait.
+  function bridge(tool, args, localFallback) {
+    const id = Math.random().toString(36).slice(2);
+    let settled = false;
+    const onMsg = (e) => {
+      const m = e.data;
+      if (!m || m.type !== "ui-tool-result" || m.id !== id) return;
+      settled = true;
+      window.removeEventListener("message", onMsg);
+      if (!m.ok) note("⚠ " + (m.error || tool + " failed"));
+    };
+    window.addEventListener("message", onMsg);
+    try { window.parent.postMessage({ type: "ui-tool-call", id, tool, args }, "*"); } catch {}
+    note("… " + tool);
+    setTimeout(() => {
+      if (settled) return;
+      window.removeEventListener("message", onMsg);
+      localFallback();
+      note("local preview — no host bridge answered; ask the agent instead");
+    }, 1200);
+  }
+  function note(t) { document.getElementById("note").textContent = t; }
   function retrend() {
     const target = s.furnace.on ? s.furnace.targetF : ${COLD_FLOOR_F};
     s.trend = Math.abs(target - s.indoorF) < .3 ? 'holding'

--- a/examples/agent-browser/index.html
+++ b/examples/agent-browser/index.html
@@ -162,7 +162,7 @@ function renderState(s) {
       ${m.toolCalls?.length ? `<div class="tools">${m.toolCalls.map((c) => `<span>${esc(c)}</span>`).join("")}</div>` : ""}
       ${(m.ui || []).map((u) => `<div class="ui-resource">
         <div class="ui-label">${esc(u.tool)}${u.uri ? " · " + esc(u.uri) : ""}</div>
-        <iframe sandbox="allow-scripts" srcdoc="${esc(u.html)}"></iframe>
+        <iframe sandbox="allow-scripts" data-uri="${esc(u.uri || "")}" srcdoc="${esc(u.html)}"></iframe>
       </div>`).join("")}
     </div>`).join("");
   t.scrollTop = t.scrollHeight;
@@ -228,6 +228,31 @@ async function send() {
 $("send").onclick = send;
 $("message").addEventListener("keydown", (e) => { if (e.key === "Enter") send(); });
 $("reset").onclick = async () => renderState(await api("/api/reset", {}));
+
+// Host side of the widget bridge (the MCP Apps pattern in miniature): a
+// sandboxed widget posts { type: "ui-tool-call", id, tool, args } to this
+// page, the page runs the tool through the chat server — which also tells
+// the model what happened — and the fresh widget replaces the old one.
+window.addEventListener("message", async (e) => {
+  const m = e.data;
+  if (!m || m.type !== "ui-tool-call" || typeof m.tool !== "string") return;
+  const iframe = [...document.querySelectorAll(".ui-resource iframe")]
+    .find((f) => f.contentWindow === e.source);
+  try {
+    const res = await api("/api/ui-tool", {
+      tool: m.tool,
+      args: m.args ?? {},
+      uri: iframe?.dataset.uri || undefined,
+    });
+    e.source?.postMessage({ type: "ui-tool-result", id: m.id, ok: res.success !== false }, "*");
+    renderState(res); // transcript row updated in place server-side
+  } catch (err) {
+    e.source?.postMessage(
+      { type: "ui-tool-result", id: m.id, ok: false, error: err.message || String(err) },
+      "*",
+    );
+  }
+});
 
 api("/api/state").then(renderState).catch(() => {});
 </script>

--- a/examples/agent-browser/server.ts
+++ b/examples/agent-browser/server.ts
@@ -323,6 +323,79 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
       return;
     }
 
+    if (req.method === "POST" && url.pathname === "/api/ui-tool") {
+      // Host side of the widget bridge (the MCP Apps pattern in miniature):
+      // a widget asked the host to run a tool call on its behalf. Execute it
+      // on the already-connected client, swap the originating widget's
+      // transcript entry for the fresh one, and — crucially — tell the model
+      // what happened so the conversation doesn't go stale behind the UI.
+      const body = await readBody(req);
+      const toolName = String(body.tool ?? "");
+      const args = (body.args ?? {}) as Record<string, unknown>;
+      const sourceUri = body.uri ? String(body.uri) : undefined;
+      const toolImpl = collectTools()[toolName];
+      if (!toolImpl?.execute) {
+        sendJson(res, 404, { error: `unknown tool: ${toolName}` });
+        return;
+      }
+
+      const result = (await toolImpl.execute(args, {
+        toolCallId: `ui-${Date.now()}`,
+        messages: [],
+      } as never)) as { success?: boolean; data?: unknown };
+
+      const blocks = Array.isArray(result.data) ? (result.data as Array<Record<string, any>>) : [];
+      const ui: UiResource[] = blocks
+        .filter(
+          (b) =>
+            b?.type === "resource" &&
+            typeof b.resource?.text === "string" &&
+            String(b.resource?.mimeType ?? "").startsWith("text/html"),
+        )
+        .map((b) => ({ tool: toolName, uri: b.resource.uri, html: b.resource.text }));
+      const text =
+        blocks.find((b) => b?.type === "text")?.text ??
+        (typeof result.data === "string" ? result.data : "");
+
+      // Replace the originating widget in place so the transcript shows the
+      // house as it now is, and mark the row with a widget-driven call chip.
+      if (sourceUri) {
+        for (let i = state.transcript.length - 1; i >= 0; i--) {
+          const row = state.transcript[i];
+          const idx = row.ui?.findIndex((u) => u.uri === sourceUri) ?? -1;
+          if (idx >= 0 && row.ui) {
+            if (ui[0]) row.ui[idx] = ui[0];
+            row.toolCalls.push(`${toolName} ⚡`);
+            break;
+          }
+        }
+      } else if (ui.length) {
+        state.transcript.push({
+          role: "assistant",
+          text: `⚡ ${toolName} via widget`,
+          toolCalls: [toolName],
+          ui,
+        });
+      }
+
+      // MCP Apps' "update the model's context" leg: the next turn's model
+      // sees what the user did in the UI instead of reasoning from stale state.
+      ensureInteraction().addMessage({
+        role: "user",
+        content: `[widget] I used the ${toolName} control (${JSON.stringify(args)}). Result: ${
+          text || (result.success !== false ? "ok" : "failed")
+        }. No reply needed.`,
+      });
+
+      sendJson(res, 200, {
+        success: result.success !== false,
+        text,
+        ui,
+        ...publicState(),
+      });
+      return;
+    }
+
     if (req.method === "POST" && url.pathname === "/api/reset") {
       state.transcript = [];
       state.contextId = randomUUID();


### PR DESCRIPTION
## What this PR contains

The Hearthstone dashboard's controls now work — implementing the MCP Apps host-mediated pattern in miniature (follow-up to #336):

1. **Widget → host**: room/furnace clicks post `{type: "ui-tool-call", tool, args}` to the parent page via postMessage (the sandboxed iframe still cannot reach any server directly).
2. **Host → chat server**: the page relays to a new `POST /api/ui-tool`, including the originating widget's `ui://` URI.
3. **Server executes the real tool** on the already-connected MCP client — the same path the model uses.
4. **Widget refreshes in place**: the originating transcript row's iframe swaps to the fresh dashboard and gains a `set_light ⚡` chip, visually distinguishing widget-driven calls from model-driven ones.
5. **Model context stays current**: the server appends a `[widget] I used the … control` note to the Interaction, so the next question is answered from live state — the "update model context" leg of the MCP Apps design.

Opened outside a bridging host, the widget waits 1.2s for an ack and falls back to the previous local-preview behavior with an honest note.

## Testing
- Verified over HTTP end to end: connect + `set_light` (row appended with widget UI), `set_furnace` with source URI (row replaced in place — porch stayed lit, furnace ON in the fresh HTML), state persistent across calls, chips accumulate.
- TESTING.md §6 gains the click-the-dashboard walkthrough (including the "ask the model afterwards — it already knows" check).
- The browser-side postMessage hop is exercised manually per TESTING.md (not covered headlessly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Y6ycySLTXAYSbToMhdoum

---
_Generated by [Claude Code](https://claude.ai/code/session_013Y6ycySLTXAYSbToMhdoum)_