### PR TITLE
Make redeploy.sh work with a multi-key GAIA_API_KEY

### DIFF
--- a/deploy/gaia/.env.example
+++ b/deploy/gaia/.env.example
@@ -12,6 +12,15 @@ GAIA_PORT=7420
 # Bearer token the SaaS must present to Gaia's API. REQUIRED on any reachable
 # deploy — empty means open auth (control of the host's docker + secret vault).
 # Generate: openssl rand -hex 32
+#
+# Accepts SEVERAL comma-separated keys; any one of them authenticates. They are
+# equivalent (same rights, same identity) — a list of accepted values, not
+# roles. Give each consumer its own so it can be revoked on its own:
+#
+#   GAIA_API_KEY=<saas-key>,<cli-key>,<agent-key>
+#
+# Keep the SaaS key FIRST: redeploy.sh and the connect-flow state secret both
+# take the first entry.
 # GAIA_API_KEY=
 
 # Provider key Gaia uses for its own chat. Set the one matching GAIA_PROVIDER.

--- a/deploy/gaia/redeploy.sh
+++ b/deploy/gaia/redeploy.sh
@@ -36,7 +36,12 @@ set +a
 : "${GAIA_API_KEY:?GAIA_API_KEY must be set in $ENV_FILE}"
 
 GAIA_URL="https://$GAIA_HOSTNAME"
-AUTH=(-H "Authorization: Bearer $GAIA_API_KEY")
+# GAIA_API_KEY may hold several comma-separated keys — Gaia accepts any of them,
+# but a bearer header carries exactly one. Take the first; the whole list would
+# be sent as a single token and 401 on every child cycle below.
+GAIA_PRIMARY_KEY="$(printf '%s' "${GAIA_API_KEY%%,*}" | tr -d '[:space:]')"
+: "${GAIA_PRIMARY_KEY:?GAIA_API_KEY must contain at least one non-empty key}"
+AUTH=(-H "Authorization: Bearer $GAIA_PRIMARY_KEY")
 
 log() { echo "[redeploy] $*"; }
 


### PR DESCRIPTION
Follow-up to #335, and now urgent: the Gaia host's `.env` already holds two comma-separated keys.

`redeploy.sh` passes `$GAIA_API_KEY` straight into an `Authorization` header:

```bash
AUTH=(-H "Authorization: Bearer $GAIA_API_KEY")
```

Gaia accepts any *one* key from the list, but a bearer header carries exactly one token. With a multi-key value the whole comma string is sent as a single token, every child-cycle call 401s, and `set -euo pipefail` kills the run partway — after Gaia has been recreated but before any child is cycled.

It now takes the first entry, and fails loudly if that entry is empty rather than sending `Bearer ` and getting a confusing 401.

Also documents the list form in `.env.example`, including that the SaaS key belongs first: both this script and the connect-flow state secret read entry one.

## Side effect, and the reason for merging now

This touches `deploy/gaia/**`, so it triggers the "Deploy Gaia host" workflow. That run checks out this commit, so the fixed script is the one that executes, and `docker compose up -d gaia` picks up the host's already-edited `.env` — applying the new key in the same run that makes the script safe to use with it.

## Verification

- `bash -n deploy/gaia/redeploy.sh` clean
- First-key extraction checked against `a,b,c`, `a, b ,c` (whitespace), and a single key with no comma

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_