### PR TITLE
Let a mounted repo clone use the habitat's own GitHub token

### DIFF
--- a/packages/habitat/src/provision/execute.test.ts
+++ b/packages/habitat/src/provision/execute.test.ts
@@ -6,6 +6,10 @@ import type { ProvisionExecutorDeps, ProvisionResult } from "./execute.js";
 import type { HabitatConfig } from "../types.js";
 import type { ProvisionPlan, ProvisionStep, VolumeState } from "./types.js";
 
+/** The habitat boot-token passthrough every scoped git command carries. */
+const GIT_CRED =
+  'GIT_CONFIG_COUNT="$GIT_CONFIG_COUNT" GIT_CONFIG_KEY_0="$GIT_CONFIG_KEY_0" GIT_CONFIG_VALUE_0="$GIT_CONFIG_VALUE_0"';
+
 interface Recorder {
   deps: ProvisionExecutorDeps;
   commands: { command: string; cwd: string }[];
@@ -145,10 +149,86 @@ describe("commandFor", () => {
 
     expect(await commandFor(only(plan, "clone-agent-repo"), withSecrets)).toEqual({
       command:
-        'env -i PATH="$PATH" HOME="$HOME" DEPLOY_KEY=\'s3cr3t\' ' +
+        'env -i PATH="$PATH" HOME="$HOME" ' + GIT_CRED + ' DEPLOY_KEY=\'s3cr3t\' ' +
         'git clone --branch trunk "git@github.com:acme/web.git" "/data/agents/web/repo"',
       cwd: ".",
     });
+  });
+
+  /**
+   * The regression this guards: `env -i` used to drop the habitat's
+   * github-token git config along with everything else, so a read-only mount
+   * had no credential at all and every clone of a private repo died with
+   * "could not read Username". Mounts are private repos by definition
+   * (ADR 0006), so this broke the whole feature.
+   */
+  it("carries the habitat's github credential into a mount clone", async () => {
+    const plan = planFor({
+      agents: [
+        {
+          id: "web",
+          name: "web",
+          projectPath: "",
+          gitRemote: "https://github.com/acme/web.git",
+          mode: "read",
+        },
+      ],
+    });
+
+    const { command } = await commandFor(
+      only(plan, "clone-agent-repo"),
+      recorder({}).deps,
+    );
+
+    for (const name of [
+      "GIT_CONFIG_COUNT",
+      "GIT_CONFIG_KEY_0",
+      "GIT_CONFIG_VALUE_0",
+    ]) {
+      expect(command).toContain(`${name}="$${name}"`);
+    }
+  });
+
+  /**
+   * By reference, never by value: the token lives inside GIT_CONFIG_KEY_0, and
+   * command strings are the one place a provisioning secret could surface in a
+   * log or an error. The running shell expands it; we never interpolate it.
+   */
+  it("passes the credential by reference so the token never enters the command", async () => {
+    const plan = planFor({
+      agents: [
+        { id: "web", name: "web", projectPath: "", gitRemote: "https://github.com/acme/web.git" },
+      ],
+    });
+    const leaky = recorder({
+      secrets: {
+        GIT_CONFIG_KEY_0:
+          "url.https://x-access-token:ghs_SUPERSECRET@github.com/.insteadOf",
+      },
+    }).deps;
+
+    const { command } = await commandFor(only(plan, "clone-agent-repo"), leaky);
+
+    expect(command).not.toContain("ghs_SUPERSECRET");
+  });
+
+  /** Agent isolation is unchanged — only the habitat's own grant is shared. */
+  it("still keeps one agent's declared secrets out of another's clone", async () => {
+    const plan = planFor({
+      agents: [
+        { id: "a", name: "a", projectPath: "", gitRemote: "git@github.com:acme/a.git", secrets: ["A_KEY"] },
+        { id: "b", name: "b", projectPath: "", gitRemote: "git@github.com:acme/b.git", secrets: ["B_KEY"] },
+      ],
+    });
+    const deps = recorder({ secrets: { A_KEY: "aaa", B_KEY: "bbb" } }).deps;
+
+    const clones = plan.steps.filter((s) => s.kind === "clone-agent-repo");
+    const [a, b] = await Promise.all(clones.map((s) => commandFor(s, deps)));
+
+    expect(a!.command).toContain("A_KEY='aaa'");
+    expect(a!.command).not.toContain("bbb");
+    expect(b!.command).toContain("B_KEY='bbb'");
+    expect(b!.command).not.toContain("aaa");
   });
 
   it("shell-quotes secret values so they cannot break out of the assignment", async () => {
@@ -212,7 +292,7 @@ describe("executeProvisionPlan", () => {
     expect(rec.commands.map((c) => c.command)).toEqual([
       'git clone "https://example.com/ops.git" "/data/project"',
       "pnpm install --prod",
-      'env -i PATH="$PATH" HOME="$HOME" git clone "git@github.com:acme/web.git" "/data/agents/web/repo"',
+      `env -i PATH="$PATH" HOME="$HOME" ${GIT_CRED} git clone "git@github.com:acme/web.git" "/data/agents/web/repo"`,
       'npx skills@latest add "acme/skills" --all -y 2>&1',
     ]);
     expect(rec.dirs).toEqual(["/data/agents", "/data/agents/web"]);

--- a/packages/habitat/src/provision/execute.ts
+++ b/packages/habitat/src/provision/execute.ts
@@ -45,11 +45,36 @@ function shellQuote(value: string): string {
 }
 
 /**
+ * The habitat's github.com credential, as `entrypoint.sh` exports it.
+ *
+ * This is the habitat's *own* boot token (ADR 0004) — Gaia mints it scoped to
+ * exactly the repos the registry entry declares under `github.read`. It is not
+ * an agent credential, so carrying it into a per-agent clone grants nothing the
+ * habitat was not already granted for that repo.
+ */
+const GIT_CREDENTIAL_ENV = [
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_KEY_0",
+  "GIT_CONFIG_VALUE_0",
+] as const;
+
+/**
  * `env -i` plus only this agent's declared env, for any git operation against
- * its repo. Everything else is dropped — including the habitat's github-token
- * git config — so one agent's credentials can never authenticate another's
- * remote. `$PATH` / `$HOME` are left for the shell running the command to
- * expand, so the operation keeps the container's toolchain and nothing else.
+ * its repo. Agent-specific secrets stay agent-specific: one agent's declared
+ * env can never authenticate another's remote.
+ *
+ * The habitat's github-token git config IS carried through. It was dropped
+ * originally, on the reasoning that any credential is an agent credential —
+ * but the boot token is the habitat's ambient read grant, already narrowed by
+ * Gaia to the declared repos. Dropping it left read-only mounts with no
+ * credential at all, so every mounted-repo clone fell back to anonymous and
+ * failed with "could not read Username" against a private repo, which is the
+ * whole population of mounts (ADR 0006). Isolation between agents is unchanged;
+ * what changes is that the habitat may use its own grant.
+ *
+ * `$PATH` / `$HOME` and the credential are left for the shell running the
+ * command to expand — so the token never appears in a command string — and an
+ * unset credential expands to empty, which git ignores.
  */
 function scopedEnvPrefix(envNames: string[], deps: ProvisionExecutorDeps): string {
   const assignments = envNames
@@ -58,7 +83,8 @@ function scopedEnvPrefix(envNames: string[], deps: ProvisionExecutorDeps): strin
       return value ? ` ${name}=${shellQuote(value)}` : "";
     })
     .join("");
-  return `env -i PATH="$PATH" HOME="$HOME"${assignments}`;
+  const credential = GIT_CREDENTIAL_ENV.map((name) => ` ${name}="$${name}"`).join("");
+  return `env -i PATH="$PATH" HOME="$HOME"${credential}${assignments}`;
 }
 
 async function conditionHolds(


### PR DESCRIPTION
Mounted repos never checked out — `.provisioned` marker over an empty directory. Every clone died with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

## The token was never the problem

Diagnosed against the live `upperhand` habitat:

| Check | Result |
|---|---|
| boot token → `/installation/repositories` | all 4 declared repos visible |
| boot token → `contents/README.md` | **200** |
| clone under `env -i` (what the provisioner does) | `could not read Username` |
| identical clone, `GIT_CONFIG_*` intact | **597 files cloned** |

A valid 390-char `ghs_` installation token with `contents:read`. The provisioner just couldn't use it.

## Cause

`scopedEnvPrefix` runs per-agent git under `env -i` so one agent's declared secrets can't authenticate another's remote. That's correct and is kept.

But it also dropped the habitat's github-token git config, on the reading that any credential is an agent credential. The boot token isn't one — it's the habitat's *ambient read grant*, already narrowed by Gaia to exactly the repos the registry declares under `github.read` (ADR 0004). Dropping it left a read-only mount with **no credential at all**, and mounts are private repos by definition (ADR 0006), so the feature could not work for anyone.

## Fix

`GIT_CONFIG_COUNT` / `KEY_0` / `VALUE_0` pass through, **by reference** like `$PATH` and `$HOME`:

- the token never appears in a command string (command strings are the one place a provisioning secret could surface in a log)
- an unset credential expands to empty, which git ignores — checked against git in the habitat image rather than assumed

Agent isolation is unchanged. What changes is that the habitat may use its own grant.

## Tests

Three new, all of which fail on the old code path or pin a property worth keeping:

- the credential reaches a mount clone
- it is never interpolated by value (a leaky `GIT_CONFIG_KEY_0` secret must not appear in the command)
- one agent's declared secrets still stay out of another agent's clone

## Verification

- `pnpm test:run` — 203 files, 2535 tests passing
- `tsc --noEmit` clean across every package
- eslint clean on both changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_