### PR TITLE
Exchange: expire quiet Suppliers by default, and give them a heartbeat

### DIFF
--- a/docs/adr/0022-when-a-probe-goes-stale.md
+++ b/docs/adr/0022-when-a-probe-goes-stale.md
@@ -92,3 +92,30 @@ which is a cost with no corresponding benefit.
 Runtime death skips the threshold entirely. It is not per-Model and it is not in
 doubt, and waiting three cycles to say so would route three cycles of traffic
 into a process that is not running.
+
+## The heartbeat, and why silence has to mean something
+
+Withdrawal has two halves, and they are meant to overlap so that neither is a
+single point of failure:
+
+- A **live agent withdraws** the moment it knows an Offer is broken.
+- The **Exchange expires** Offers from a Supplier that has gone quiet.
+
+The second half is the one that survives everything the first cannot cover — the
+agent process killed, the machine losing power, the network going away. But it
+only works if silence actually means something, and silence cannot mean anything
+unless a healthy agent is reliably noisy.
+
+So a healthy agent republishes its unchanged Offer set every **5 minutes**, and
+the Exchange expires an Offer not republished within **15 minutes** — three
+chances to be heard, so one publish lost to a flaky link does not take a working
+machine out of the pool.
+
+This is the one place the no-churn rule does not apply, and the distinction is
+worth stating: a re-probe republish carries *new information* and is suppressed
+when there is none, while a heartbeat republish carries *the fact that we are
+still here*, which is new every time.
+
+The Exchange's window is **on by default**. An expiry window nobody remembered
+to configure is a window that never fires, and then the two mechanisms above
+stop being two.

--- a/packages/exchange/src/dispatch.test.ts
+++ b/packages/exchange/src/dispatch.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { dispatch, rankingPrice } from "./dispatch.js";
+import { DEFAULT_STALE_AFTER_MS, dispatch, rankingPrice } from "./dispatch.js";
 import type { Offer } from "./types.js";
+
+/**
+ * The supplier agent's heartbeat interval, restated rather than imported: the
+ * exchange does not depend on the supplier package and must not start.
+ */
+const HEARTBEAT_INTERVAL_MS = 5 * 60_000;
 
 const MODEL = "gemma-4-26b";
 
@@ -17,7 +23,9 @@ function offer(overrides: Partial<Offer> = {}): Offer {
     retailPromptPerMillion: 100,
     retailCompletionPerMillion: 100,
     enabled: true,
-    publishedAt: new Date("2026-07-28T00:00:00Z"),
+    // Freshly published, because staleness is on by default and these tests
+    // are about the other filters. The staleness tests set this explicitly.
+    publishedAt: new Date(),
     ...overrides,
   };
 }
@@ -154,6 +162,44 @@ describe("dispatch", () => {
       );
 
       expect(result.offer).toBeDefined();
+    });
+
+    it("expires without being configured to", () => {
+      // An expiry window nobody remembered to switch on is a window that never
+      // fires, and then the live agent's withdrawal and the Exchange's expiry
+      // stop being two mechanisms and become one.
+      const old = new Date(Date.now() - DEFAULT_STALE_AFTER_MS - 1_000);
+      const result = dispatch([offer({ publishedAt: old })], { model: MODEL });
+
+      expect(result.offer).toBeUndefined();
+      expect(result.considered[0].reason).toBe("offer-stale");
+    });
+
+    it("leaves room for a missed heartbeat", () => {
+      // The agent republishes every five minutes. One publish lost to a flaky
+      // link must not take a working machine out of the pool.
+      const oneMissed = new Date(Date.now() - 2 * HEARTBEAT_INTERVAL_MS);
+      expect(dispatch([offer({ publishedAt: oneMissed })], { model: MODEL }).offer).toBeDefined();
+    });
+
+    it("can be turned off deliberately", () => {
+      // Distinct from never having been turned on: an operator running a
+      // Supplier that publishes by hand should be able to say so.
+      const ancient = new Date("2020-01-01T00:00:00Z");
+      const result = dispatch([offer({ publishedAt: ancient })], { model: MODEL }, {
+        staleAfterMs: 0,
+      });
+      expect(result.offer).toBeDefined();
+    });
+
+    it("brings a resumed Supplier's Offers back without operator action", () => {
+      // Republishing is the whole recovery path — nothing to re-enable, and
+      // nothing to re-register.
+      const wasStale = offer({ publishedAt: new Date(Date.now() - 60 * 60_000) });
+      expect(dispatch([wasStale], { model: MODEL }).offer).toBeUndefined();
+
+      const republished = { ...wasStale, publishedAt: new Date() };
+      expect(dispatch([republished], { model: MODEL }).offer).toBeDefined();
     });
   });
 

--- a/packages/exchange/src/dispatch.ts
+++ b/packages/exchange/src/dispatch.ts
@@ -70,6 +70,21 @@ export function rankingPrice(offer: Offer): MicroDollars {
 }
 
 /**
+ * How long an Offer stays dispatchable without being republished.
+ *
+ * A supplier agent heartbeats every five minutes, so fifteen is three chances
+ * to be heard — one missed publish over a flaky link does not take a working
+ * machine out of the pool, and a machine that has genuinely been unplugged is
+ * out of it within a quarter of an hour.
+ *
+ * This is the half of withdrawal that survives an agent it cannot run: a live
+ * agent withdraws the moment it knows, and this catches everything that killed
+ * the agent before it could say anything. Neither is the single point of
+ * failure, which is only true because both are on by default.
+ */
+export const DEFAULT_STALE_AFTER_MS = 15 * 60_000;
+
+/**
  * @param now  Injected so staleness is testable without waiting.
  */
 export function dispatch(
@@ -98,10 +113,11 @@ export function dispatch(
       note("offer-disabled");
       continue;
     }
-    if (
-      opts.staleAfterMs !== undefined &&
-      now.getTime() - offer.publishedAt.getTime() > opts.staleAfterMs
-    ) {
+    // Defaulted rather than opt-in. An expiry window nobody remembered to
+    // configure is an expiry window that never fires, and then the two
+    // mechanisms that were supposed to overlap are one.
+    const staleAfterMs = opts.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+    if (staleAfterMs > 0 && now.getTime() - offer.publishedAt.getTime() > staleAfterMs) {
       // A Supplier that stopped reporting has probably gone. Its last known
       // capabilities are a guess, and dispatching on a guess is how a buyer
       // discovers an unplugged machine.

--- a/packages/exchange/src/index.ts
+++ b/packages/exchange/src/index.ts
@@ -44,7 +44,7 @@ export type { RequestRecord } from "./types.js";
 export { createModelsHandler, summarizeOffers, MODELS_PATH } from "./buyer/models.js";
 export type { ModelEntry } from "./buyer/models.js";
 
-export { dispatch, rankingPrice } from "./dispatch.js";
+export { DEFAULT_STALE_AFTER_MS, dispatch, rankingPrice } from "./dispatch.js";
 export type {
   Considered,
   DispatchRequirements,

--- a/packages/supplier/src/command.ts
+++ b/packages/supplier/src/command.ts
@@ -69,6 +69,7 @@ interface CliOptions {
   resume?: boolean;
   reprobeInterval?: string;
   healthInterval?: string;
+  heartbeatInterval?: string;
   kind?: string;
   user?: string;
 }
@@ -655,6 +656,8 @@ addProbeOptions(
     .option("--guarantees <names>", "Guarantees to claim, comma-separated")
     .option("--reprobe-interval <hours>", "Backstop re-probe interval", "24")
     .option("--health-interval <seconds>", "How often to check what we published", "30")
+    .option("--heartbeat-interval <minutes>", "How often to republish an unchanged set", "5")
+    .option("--heartbeat-interval <minutes>", "How often to republish an unchanged set", "5")
     .option("--resume", "Reuse the saved configuration and credential"),
 ).action(async (opts: CliOptions) => {
   // Resume first: a machine coming back from a reboot has nobody at the
@@ -739,6 +742,9 @@ addProbeOptions(
     await runServeLoop(supervisor, buildServeEffects({ config, client, runtime, opts, inputs }), {
       healthIntervalMs: Number(opts.healthInterval ?? 30) * 1_000,
       reprobeIntervalMs: Number(opts.reprobeInterval ?? 24) * 3_600_000,
+      // The Exchange expires a quiet Supplier. Staying audible is what makes
+      // that expiry mean "gone" rather than "has not changed lately".
+      heartbeatIntervalMs: Number(opts.heartbeatInterval ?? 5) * 60_000,
       signal: abort.signal,
       probeInputs: inputs,
       previous: {

--- a/packages/supplier/src/index.ts
+++ b/packages/supplier/src/index.ts
@@ -63,7 +63,7 @@ export type { RuntimeEffects, SpawnedProcess } from "./runtime.js";
 export { OfferSupervisor, WITHDRAW_AFTER_FAILURES } from "./supervisor.js";
 export type { OfferHealth, SupervisorChange } from "./supervisor.js";
 
-export { HEALTH_INTERVAL_MS, runServeLoop } from "./serve.js";
+export { HEALTH_INTERVAL_MS, HEARTBEAT_INTERVAL_MS, runServeLoop } from "./serve.js";
 export type { ServeEffects, ServeOptions } from "./serve.js";
 
 export {

--- a/packages/supplier/src/serve.test.ts
+++ b/packages/supplier/src/serve.test.ts
@@ -141,6 +141,9 @@ async function runFor(
   await runServeLoop(supervisor, wrapped, {
     healthIntervalMs: 30_000,
     reprobeIntervalMs: 24 * 3_600_000,
+    // Off unless a test is about it, so an unrelated assertion on `published`
+    // is not counting heartbeats.
+    heartbeatIntervalMs: 365 * 24 * 3_600_000,
     signal: abort.signal,
     probeInputs: INPUTS,
     previous: {
@@ -153,12 +156,38 @@ async function runFor(
 }
 
 describe("runServeLoop", () => {
-  it("publishes nothing while everything is healthy", async () => {
-    // Republishing on a timer would be a write per interval that says exactly
-    // what the last one said.
+  it("publishes nothing extra between heartbeats while everything is healthy", async () => {
     const h = harness();
-    await runFor(4, new OfferSupervisor([draft("a"), draft("b")]), h);
+    await runFor(4, new OfferSupervisor([draft("a"), draft("b")]), h, {
+      heartbeatIntervalMs: 60 * 60_000,
+    });
     expect(h.published).toEqual([]);
+  });
+
+  it("heartbeats an unchanged Offer set", async () => {
+    // Not churn. The Exchange expires Offers from a Supplier that has gone
+    // quiet, and that only means anything if a healthy agent is reliably
+    // noisy — it is the half of withdrawal that survives this process being
+    // killed, losing power, or losing its network.
+    const h = harness();
+    // 30s cycles, 5-minute heartbeat: 12 cycles is two heartbeats.
+    await runFor(24, new OfferSupervisor([draft("a"), draft("b")]), h, {
+      heartbeatIntervalMs: 5 * 60_000,
+    });
+
+    expect(h.published.length).toBeGreaterThanOrEqual(2);
+    // And every heartbeat carries the whole live set, because publishing is
+    // total — a heartbeat that sent nothing would withdraw the machine.
+    for (const publish of h.published) expect(publish.map((o) => o.model)).toEqual(["a", "b"]);
+  });
+
+  it("heartbeats only the Offers that are still live", async () => {
+    const h = harness();
+    h.broken.add("b");
+    await runFor(24, new OfferSupervisor([draft("a"), draft("b")]), h, {
+      heartbeatIntervalMs: 5 * 60_000,
+    });
+    expect(h.published[h.published.length - 1].map((o) => o.model)).toEqual(["a"]);
   });
 
   it("republishes the moment an Offer crosses the withdrawal threshold", async () => {

--- a/packages/supplier/src/serve.ts
+++ b/packages/supplier/src/serve.ts
@@ -29,6 +29,21 @@ import type { OfferDraft, ProbedOffer } from "./types.js";
  */
 export const HEALTH_INTERVAL_MS = 30_000;
 
+/**
+ * How often a healthy agent republishes an unchanged Offer set.
+ *
+ * Not churn — a heartbeat. The Exchange expires Offers from a Supplier that has
+ * gone quiet, which is the half of withdrawal that survives this process being
+ * killed, losing power, or losing its network. That mechanism only works if
+ * silence actually means something, and it cannot mean anything unless a
+ * healthy agent is reliably noisy.
+ *
+ * Five minutes against the Exchange's fifteen gives three chances to be heard
+ * before an Offer goes stale, so one missed publish over a flaky link does not
+ * take a working machine out of the pool.
+ */
+export const HEARTBEAT_INTERVAL_MS = 5 * 60_000;
+
 export interface ServeEffects {
   /** Is the runtime we started still answering? */
   runtimeAlive(): Promise<boolean>;
@@ -50,6 +65,7 @@ export interface ServeEffects {
 export interface ServeOptions {
   healthIntervalMs?: number;
   reprobeIntervalMs?: number;
+  heartbeatIntervalMs?: number;
   /** Stops the loop. */
   signal?: AbortSignal;
   probeInputs: ProbeInputs;
@@ -71,7 +87,9 @@ export async function runServeLoop(
 ): Promise<void> {
   const healthMs = opts.healthIntervalMs ?? HEALTH_INTERVAL_MS;
   const reprobeMs = opts.reprobeIntervalMs ?? DEFAULT_REPROBE_INTERVAL_MS;
+  const heartbeatMs = opts.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS;
   let lastProbe = opts.previous;
+  let lastPublished = effects.now();
 
   const report = (change: SupervisorChange) => {
     for (const note of change.notes) effects.log(note);
@@ -110,7 +128,10 @@ export async function runServeLoop(
 
     // Immediately, not at the next scheduled publish. An agent that waits is
     // an agent that lets Dispatch route into a known failure.
-    if (dirty) await republish(supervisor, effects);
+    if (dirty || effects.now() - lastPublished >= heartbeatMs) {
+      await republish(supervisor, effects);
+      lastPublished = effects.now();
+    }
 
     const reason = reprobeReason({
       previous: lastProbe,
@@ -144,6 +165,7 @@ export async function runServeLoop(
     for (const line of diff.summary) effects.log(line);
     supervisor.replace(drafts);
     await republish(supervisor, effects);
+    lastPublished = effects.now();
   }
 }
 


### PR DESCRIPTION
Closes #299.

Most of this ticket's operator surface landed with #317 and I checked each criterion against the code rather than assuming:

| Criterion | Where |
|---|---|
| Register a Supplier, issue a bearer credential | `Operator.registerSupplier` — credential shown once, only its hash stored |
| Grant Guarantees, change the set later | `Operator.grantGuarantees` |
| A claim beyond the grant is rejected, naming the Guarantee | `GuaranteeNotGrantedError`, thrown on publish |
| Granted claims accepted unchanged | supply handler |
| Disable/re-enable one Offer, history retained | `setOfferEnabled`, `offer-disabled` in dispatch |
| Disable a whole Supplier in one step | `setSupplierEnabled`; both stores filter `listOffers` on it |
| Offers from a quiet Supplier stop being dispatched | `offer-stale` in dispatch — **was opt-in** |
| A resumed Supplier recovers without operator action | republish refreshes `publishedAt` |

## The gap

`staleAfterMs` was opt-in. An Offer from a machine unplugged a month ago stayed dispatchable unless somebody had remembered to configure a window.

That matters more than it looks, because ADR 0022 claims the live agent's withdrawal and the Exchange's expiry overlap *so that neither is a single point of failure*. With the second half off by default, they were one — and the half that was on is precisely the half that cannot cover a killed process, a power cut, or a network partition.

Worse, my own `serve` loop from #344 only publishes on change, so switching expiry on without a heartbeat would have expired healthy machines. Both halves were needed together:

- **The Exchange** expires an Offer not republished within **15 minutes**, without being configured to. Passing `0` still turns it off — a different thing from never having turned it on, and the case for an operator publishing by hand.
- **The agent** republishes its unchanged live set every **5 minutes**. Three chances to be heard, so one publish lost to a flaky link does not take a working machine out of the pool.

The heartbeat is the one place ADR 0022's no-churn rule doesn't apply, and the distinction is worth keeping: a re-probe republish carries *new information* and is suppressed when there is none; a heartbeat carries *the fact that we are still here*, which is new every time. It also always sends the live set, since publishing is total — a heartbeat that sent nothing would withdraw the machine it was meant to keep alive.

## Changes

- `packages/exchange/src/dispatch.ts` — `DEFAULT_STALE_AFTER_MS`, applied unless overridden
- `packages/supplier/src/serve.ts` — `HEARTBEAT_INTERVAL_MS`, `--heartbeat-interval`
- `docs/adr/0022-when-a-probe-goes-stale.md` — records both halves and why silence has to mean something

## Verification

2679 unit tests pass, typecheck clean, lint clean (0 errors).

Turning the default on broke seven existing dispatch tests whose fixture used a fixed 2026-07-28 timestamp — which is the check working. Fixture now publishes fresh; the staleness tests set the timestamp explicitly. New cases cover expiring without configuration, surviving one missed heartbeat, being deliberately turned off, and a resumed Supplier coming back with no operator action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG)_