### PR TITLE
Supplier: retry a failed publish on the next cycle, not the next heartbeat

### DIFF
--- a/packages/supplier/src/serve.test.ts
+++ b/packages/supplier/src/serve.test.ts
@@ -203,6 +203,51 @@ describe("runServeLoop", () => {
     expect(h.published[0].map((o) => o.model)).toEqual(["a"]);
   });
 
+  it("keeps going when a publish fails, and the next one carries the whole set", async () => {
+    // Retry without duplication, and it costs nothing to get right because
+    // publishing is total: the next publish *is* the retry, and an Offer
+    // published twice is an Offer published once. An agent that gave up on a
+    // failed publish would sit healthy and unlisted until someone noticed.
+    // 30s health cycles, 5-minute heartbeat: due every 10th cycle. Recording
+    // the cycle each attempt lands on is what distinguishes a prompt retry
+    // from one that waited out another full interval.
+    const attempts: { cycle: number; offers: OfferDraft[] }[] = [];
+    let cycle = 0;
+    let failNext = true;
+    const h = harness({
+      publish: async (offers) => {
+        attempts.push({ cycle, offers });
+        if (failNext) {
+          failNext = false;
+          return { ok: false, detail: "unreachable" };
+        }
+        return { ok: true };
+      },
+    });
+    const counting: ServeEffects = {
+      ...h.effects,
+      sleep: async (ms) => {
+        await h.effects.sleep(ms);
+        cycle += 1;
+      },
+    };
+
+    await runFor(24, new OfferSupervisor([draft("a"), draft("b")]), { ...h, effects: counting }, {
+      heartbeatIntervalMs: 5 * 60_000,
+    });
+
+    expect(h.logs).toContain("publish failed: unreachable");
+    // Three attempts, not two: the failure at cycle 10, its retry one cycle
+    // later, and the next heartbeat. Resetting the clock on a failure would
+    // have given two attempts ten cycles apart, and left the machine unlisted
+    // for five minutes of a fifteen-minute expiry window.
+    expect(attempts).toHaveLength(3);
+    expect(attempts[1].cycle - attempts[0].cycle).toBe(1);
+    // Every attempt is the complete live set, not a delta, so a retry cannot
+    // leave the Exchange holding half a machine.
+    for (const attempt of attempts) expect(attempt.offers.map((o) => o.model)).toEqual(["a", "b"]);
+  });
+
   it("keeps the machine's other Offers up when one Model breaks", async () => {
     const h = harness();
     h.broken.add("b");

--- a/packages/supplier/src/serve.ts
+++ b/packages/supplier/src/serve.ts
@@ -129,8 +129,11 @@ export async function runServeLoop(
     // Immediately, not at the next scheduled publish. An agent that waits is
     // an agent that lets Dispatch route into a known failure.
     if (dirty || effects.now() - lastPublished >= heartbeatMs) {
-      await republish(supervisor, effects);
-      lastPublished = effects.now();
+      // Only a publish the Exchange accepted resets the heartbeat clock. A
+      // failed one leaves it due, so the next health cycle retries in seconds
+      // rather than minutes — three failed heartbeats is an expired Offer, and
+      // a machine sitting healthy and unlisted is the worst way to lose money.
+      if (await republish(supervisor, effects)) lastPublished = effects.now();
     }
 
     const reason = reprobeReason({
@@ -164,12 +167,12 @@ export async function runServeLoop(
 
     for (const line of diff.summary) effects.log(line);
     supervisor.replace(drafts);
-    await republish(supervisor, effects);
-    lastPublished = effects.now();
+    if (await republish(supervisor, effects)) lastPublished = effects.now();
   }
 }
 
-async function republish(supervisor: OfferSupervisor, effects: ServeEffects): Promise<void> {
+/** Send the live set. Returns whether the Exchange accepted it. */
+async function republish(supervisor: OfferSupervisor, effects: ServeEffects): Promise<boolean> {
   const live = supervisor.live();
   const result = await effects.publish(live);
   effects.log(
@@ -177,4 +180,5 @@ async function republish(supervisor: OfferSupervisor, effects: ServeEffects): Pr
       ? `published ${live.length} offer(s)`
       : `publish failed: ${result.detail ?? "unknown"}`,
   );
+  return result.ok;
 }


### PR DESCRIPTION
Closes the last uncovered seam named in #303's Testing Decisions — *"a publish failure is retried without duplicating Offers"* — and writing the test found the retry was slower than it should be.

## The defect

A failed publish reset the heartbeat clock exactly like a successful one. So a transient network blip cost a full **5 minutes unlisted** against the Exchange's **15-minute** expiry window (both from #345). Three in a row and a healthy machine is out of the pool, having never stopped working.

Now only a publish the Exchange accepted resets the clock. A failed one leaves the heartbeat due, so the next health cycle retries in ~30 seconds.

There is no duplication to guard against, which is why this costs nothing to get right: publishing is total, so an Offer published twice is an Offer published once, and the next publish *is* the retry.

## The test discriminates

It records the cycle each publish attempt lands on, not just the count. Against the fixed code it sees three attempts — the failure at cycle 10, its retry at cycle 11, the next heartbeat at cycle 21. Against the old code it sees two, ten cycles apart, and fails:

```
→ expected [ …(2) ] to have a length of 3 but got 2
```

I reverted the fix locally to confirm that, rather than assuming a passing test was a meaningful one.

## Verification

2680 unit tests pass, typecheck clean, lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG)_