### PR TITLE
Supplier: drop the duplicated --heartbeat-interval option (unbreaks the CLI)

### DIFF
--- a/packages/supplier/src/command.ts
+++ b/packages/supplier/src/command.ts
@@ -657,7 +657,6 @@ addProbeOptions(
     .option("--reprobe-interval <hours>", "Backstop re-probe interval", "24")
     .option("--health-interval <seconds>", "How often to check what we published", "30")
     .option("--heartbeat-interval <minutes>", "How often to republish an unchanged set", "5")
-    .option("--heartbeat-interval <minutes>", "How often to republish an unchanged set", "5")
     .option("--resume", "Reuse the saved configuration and credential"),
 ).action(async (opts: CliOptions) => {
   // Resume first: a machine coming back from a reboot has nobody at the


### PR DESCRIPTION
## Production is down on `main` right now

`191ff24` (#345) added `--heartbeat-interval` to `supplier serve` **twice**, as two byte-identical `.option()` lines (`packages/supplier/src/command.ts:659-660`). Commander 15 throws on a duplicate flag:

```
Error: Cannot add option '--heartbeat-interval <minutes>' to command 'serve'
due to conflicting flag '--heartbeat-interval'
  at packages/supplier/src/command.ts:660:6
  at async packages/cli/src/entry.ts:29:1
```

It throws at **module-import time**, so `packages/cli/src/entry.ts` can't finish loading and *every* `umwelten` CLI invocation dies before it reaches a command — not just `supplier serve`.

**Blast radius:** Gaia restarted, its provision ran in `mode=refresh`, pulled this commit, and has been crash-looping since — `gaia.habitats.thefocus.ai` is 502 and the child habitat subdomains are unreachable with it. Any habitat that restarts and refreshes onto current `main` hits the same wall, so the rest of the fleet is armed too.

## The fix

Delete the second line.

There is exactly one `heartbeatInterval` on `CliOptions` (line 72) and exactly one read of it (line 747), and no `retryInterval` exists anywhere in the package — so the duplicate is a copy-paste, not a mis-typed second flag that was meant to be something else. Nothing else needs to change.

```diff
     .option("--heartbeat-interval <minutes>", "How often to republish an unchanged set", "5")
-    .option("--heartbeat-interval <minutes>", "How often to republish an unchanged set", "5")
     .option("--resume", "Reuse the saved configuration and credential"),
```

## Verification

- `pnpm run cli -- supplier serve --help` — loads, exit 0, lists a single `--heartbeat-interval`
- `pnpm test:run` — 2680 tests / 212 files, all green

## After merge

Gaia needs a restart so its refresh pulls the fixed `main`. Worth considering separately: a smoke check that just runs `umwelten --help` in CI would have caught this, since the failure is total and immediate rather than behavioral.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_