### PR TITLE
Gaia: do not block a secret-less habitat on a missing fnox

### DIFF
--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -21,6 +21,7 @@ import {
 	nodeVaultDeps,
 	resolveHabitatVault,
 	VaultResolutionError,
+	VaultToolingMissingError,
 	HABITAT_VAULT_FILE,
 } from "../habitat-vault.js";
 import { secretNeeds, unmetNeeds } from "../required-secrets.js";
@@ -50,8 +51,20 @@ export async function startHabitatContainer(
 	// to the master vault, exactly as before (#283 is the expand step). Gaia
 	// resolves on the host either way — no container ever holds a credential
 	// that could open a vault.
-	const resolved = entry.vaultToml
-		? (
+	// Declared needs are read first because they decide what a missing fnox
+	// means. A habitat that needs nothing is not made safer by refusing to
+	// start it over a vault it would never have read.
+	const declaredNeeds = secretNeeds(entry.config, entry.secretBindings);
+	// Asked of `unmetNeeds` rather than recomputed: it already owns the
+	// required-vs-optional and contract-vs-bindings rules, and a second copy
+	// here would be a second place for them to drift. Against an empty
+	// resolution it answers exactly "is any vault secret required at all".
+	const requiresSecrets = unmetNeeds(declaredNeeds, {}).missingRequired.length > 0;
+
+	let resolved: Record<string, string> | undefined;
+	if (entry.vaultToml) {
+		try {
+			resolved = (
 				await resolveHabitatVault(
 					{ id, vaultToml: entry.vaultToml },
 					nodeVaultDeps(registry.habitatDataDir(id), (event) =>
@@ -61,8 +74,19 @@ export async function startHabitatContainer(
 						),
 					),
 				)
-			).secrets
-		: undefined;
+			).secrets;
+		} catch (err) {
+			// Missing tooling only blocks a habitat that actually declared a need.
+			// Anything else — bad toml, refused credential, non-JSON — is this
+			// habitat's own misconfiguration and still fails the start.
+			if (!(err instanceof VaultToolingMissingError) || requiresSecrets) throw err;
+			console.log(
+				`[vault] ${id} skipped — ${HABITAT_VAULT_FILE} present but fnox is not installed, ` +
+					`and this habitat declares no required secrets. Starting without vault secrets. ` +
+					`Install fnox on the Gaia host to give it its own vault.`,
+			);
+		}
+	}
 
 	// A declared need its vault cannot supply fails the start. Starting anyway
 	// produces a container that boots, passes its health check — health does
@@ -72,8 +96,7 @@ export async function startHabitatContainer(
 		// Checked against what the habitat declared, so an OAuth credential it
 		// mints itself is never counted as missing — it is absent until a user
 		// connects, which is normal. Optional entries do not block either.
-		const needs = secretNeeds(entry.config, entry.secretBindings);
-		const { missingRequired } = unmetNeeds(needs, resolved);
+		const { missingRequired } = unmetNeeds(declaredNeeds, resolved);
 		if (missingRequired.length) {
 			throw new VaultResolutionError(
 				`Habitat "${id}" requires ${missingRequired.join(", ")}, which its vault did not supply. ` +

--- a/packages/habitat/src/tools/gaia/habitat-vault.test.ts
+++ b/packages/habitat/src/tools/gaia/habitat-vault.test.ts
@@ -7,6 +7,7 @@ import {
 	resolveHabitatVault,
 	unmetBindings,
 	VaultResolutionError,
+	VaultToolingMissingError,
 	type VaultAuditEvent,
 } from "./habitat-vault.js";
 
@@ -180,6 +181,100 @@ describe("resolveHabitatVault", () => {
 			expect(events[0]).toMatchObject({ ok: false, names: [] });
 			expect(events[0].error).toContain("vault unreachable");
 		});
+	});
+});
+
+describe("missing fnox is distinguishable from a failed vault", () => {
+	/**
+	 * The distinction the caller needs: a host without fnox says nothing about
+	 * whether *this* habitat needed a secret, so `startHabitatContainer` can
+	 * let a habitat that declares none through. A vault that answers badly is
+	 * this habitat's own misconfiguration and must keep failing the start.
+	 */
+	const enoent = () => {
+		const err: NodeJS.ErrnoException = new Error("spawn fnox ENOENT");
+		err.code = "ENOENT";
+		return err;
+	};
+
+	it("raises VaultToolingMissingError when fnox is not installed", async () => {
+		const dataDir = await mkdtemp(join(tmpdir(), "umwl-vault-"));
+		try {
+			await expect(
+				resolveHabitatVault(
+					{ id: "operations", vaultToml: TOML },
+					{
+						dataDir,
+						exportVault: async () => {
+							throw enoent();
+						},
+					},
+				),
+			).rejects.toBeInstanceOf(VaultToolingMissingError);
+		} finally {
+			await rm(dataDir, { recursive: true, force: true });
+		}
+	});
+
+	it("says fnox belongs on the host, not in the habitat image", async () => {
+		const dataDir = await mkdtemp(join(tmpdir(), "umwl-vault-"));
+		try {
+			await resolveHabitatVault(
+				{ id: "operations", vaultToml: TOML },
+				{
+					dataDir,
+					exportVault: async () => {
+						throw enoent();
+					},
+				},
+			);
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect((err as Error).message).toMatch(/not installed on this host/);
+			expect((err as Error).message).toMatch(/not in the habitat image/);
+		} finally {
+			await rm(dataDir, { recursive: true, force: true });
+		}
+	});
+
+	it("still raises a plain VaultResolutionError for a vault that fails", async () => {
+		const dataDir = await mkdtemp(join(tmpdir(), "umwl-vault-"));
+		try {
+			const err = await resolveHabitatVault(
+				{ id: "operations", vaultToml: TOML },
+				{
+					dataDir,
+					exportVault: async () => {
+						throw new Error("1Password: item not found");
+					},
+				},
+			).catch((e) => e);
+			expect(err).toBeInstanceOf(VaultResolutionError);
+			expect(err).not.toBeInstanceOf(VaultToolingMissingError);
+		} finally {
+			await rm(dataDir, { recursive: true, force: true });
+		}
+	});
+
+	it("audits the missing-tooling failure like any other", async () => {
+		const dataDir = await mkdtemp(join(tmpdir(), "umwl-vault-"));
+		const events: VaultAuditEvent[] = [];
+		try {
+			await resolveHabitatVault(
+				{ id: "operations", vaultToml: TOML },
+				{
+					dataDir,
+					audit: (e) => events.push(e),
+					exportVault: async () => {
+						throw enoent();
+					},
+				},
+			).catch(() => {});
+			expect(events).toHaveLength(1);
+			expect(events[0]).toMatchObject({ habitatId: "operations", ok: false, names: [] });
+		} finally {
+			await rm(dataDir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/habitat/src/tools/gaia/habitat-vault.ts
+++ b/packages/habitat/src/tools/gaia/habitat-vault.ts
@@ -43,6 +43,31 @@ export class VaultResolutionError extends Error {
 	}
 }
 
+/**
+ * The vault tooling itself is absent — fnox is not on this host.
+ *
+ * Distinguished from a failed resolution because the two want opposite
+ * handling. A bad `fnox.toml`, a rejected credential, or a vault that answers
+ * with nonsense is a misconfiguration of *this habitat*, and starting it
+ * anyway produces the under-configured container `startHabitatContainer`
+ * exists to prevent. Missing tooling is a property of the *host*, and it says
+ * nothing about whether this habitat needs a secret: a habitat that declares
+ * none is blocked by a vault it would never have read.
+ *
+ * So the caller decides, and it can only decide if it can tell the two apart.
+ */
+export class VaultToolingMissingError extends VaultResolutionError {
+	constructor(message: string, habitatId: string) {
+		super(message, habitatId);
+		this.name = "VaultToolingMissingError";
+	}
+}
+
+/** ENOENT from spawning fnox — the binary is not installed, not a vault fault. */
+function isMissingTooling(err: unknown): boolean {
+	return (err as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
 export interface VaultResolution {
 	/** Resolved name → value. Never logged. */
 	secrets: Record<string, string>;
@@ -99,9 +124,15 @@ export async function resolveHabitatVault(
 		await writeFile(join(dir, HABITAT_VAULT_FILE), vaultToml, { mode: 0o600 });
 		stdout = await deps.exportVault(dir, profile);
 	} catch (err) {
-		return fail(
-			`Could not resolve the vault for "${id}": ${err instanceof Error ? err.message : String(err)}`,
-		);
+		const message = err instanceof Error ? err.message : String(err);
+		if (isMissingTooling(err)) {
+			const text =
+				`Could not resolve the vault for "${id}": fnox is not installed on this host. ` +
+				`Gaia brokers every habitat's secrets itself, so fnox belongs on the host, not in the habitat image.`;
+			deps.audit?.({ habitatId: id, ok: false, names: [], profile, error: text });
+			throw new VaultToolingMissingError(text, id);
+		}
+		return fail(`Could not resolve the vault for "${id}": ${message}`);
 	} finally {
 		// Best effort — a leftover declaration is a stale copy, not a secret.
 		await rm(dir, { recursive: true, force: true }).catch(() => {});


### PR DESCRIPTION
## The bug

A habitat whose repo contains `fnox.toml` cannot start on a host without `fnox` — even when it declares no secrets at all. Hit live standing up an `operations` habitat:

```
Habitat "operations" failed to start:
Could not resolve the vault for "operations": spawn fnox ENOENT
```

Its declaration is `"requiredSecrets": []`. It asks for nothing, and was still blocked by a vault it would never have read.

`startHabitatContainer` resolved the vault whenever `entry.vaultToml` was present, and any failure aborted the start. Presence of the file isn't the same question as whether the habitat needs anything from it.

There's an existing asymmetry this closes: Gaia's *own* master vault already tolerates a missing fnox — `fnox.ts` says it "falls back to .env / process.env when fnox is not installed," and `isAvailable()` exists for exactly that. Per-habitat vaults had no such path.

## The fix

Missing tooling now raises `VaultToolingMissingError`, distinct from the `VaultResolutionError` a genuinely failing vault raises. The start path treats them differently:

| situation | before | after |
|---|---|---|
| fnox present | resolves | unchanged |
| absent, no required secrets | **fails to start** | logs, starts without vault secrets |
| absent, required secrets declared | fails | fails, now saying to install fnox on the host |
| bad toml / refused credential / non-JSON | fails | unchanged |

The distinction matters because the remedies differ. Missing tooling is a property of the *host*. A vault that answers badly is that *habitat's* own misconfiguration, and starting it under-configured is precisely what the existing check prevents — that behaviour is untouched.

The error text says explicitly that fnox belongs on the host and not in the habitat image. That's the natural wrong guess, and acting on it would break the invariant stated in `fnox.ts`: *"Habitats never call fnox — Gaia is the sole broker."* A habitat running its own fnox needs a credential that opens the entire vault, so every container becomes a credential-holder.

`requiresSecrets` is asked of `unmetNeeds(needs, {})` rather than recomputed, so the required-vs-optional and contract-vs-bindings rules stay in one place instead of being duplicated at the call site.

## Verification

- `tsc --noEmit` clean on `@umwelten/habitat`
- `pnpm test:run` — 2684 tests / 212 files, green
- Four new cases in `habitat-vault.test.ts`: ENOENT raises the new type, a failing vault still raises the plain one, the message names the host-vs-image distinction, and the audit record is still emitted on the missing-tooling path

## Not in scope

Installing `fnox` on gaia-host is still the right move if a habitat should actually *get* its own vault secrets — this change only stops the absence from blocking habitats that need none.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_