### PR TITLE
Bound read_file results so one large file cannot end the turn

### DIFF
--- a/packages/core/src/stimulus/tools/fs-tools.test.ts
+++ b/packages/core/src/stimulus/tools/fs-tools.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Bounded reads.
+ *
+ * The case these exist for: a habitat mounted on a docs repo containing a
+ * 5.2 MB `.eml` answered one question by calling read_file on it, and the
+ * provider rejected the request at 1,154,415 tokens against a 1,000,000
+ * limit. The turn did not degrade — it ended, with no answer and nothing the
+ * model could do differently, because it had no way to know the size before
+ * asking.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DEFAULT_MAX_READ_BYTES, boundSlice, readBounded } from './fs-tools.js';
+
+describe('readBounded', () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'umwl-fs-'));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const write = async (name: string, content: string) => {
+    const path = join(dir, name);
+    await writeFile(path, content);
+    return path;
+  };
+
+  it('returns a small file whole, with no truncation metadata', async () => {
+    const path = await write('small.md', 'hello\nworld\n');
+    const result = await readBounded(path);
+
+    expect(result.content).toBe('hello\nworld\n');
+    expect(result.truncated).toBeUndefined();
+    expect(result.hint).toBeUndefined();
+  });
+
+  it('truncates a file past the cap instead of returning it whole', async () => {
+    const line = `${'x'.repeat(99)}\n`;
+    const path = await write('big.eml', line.repeat(5000)); // ~500 KB
+    const result = await readBounded(path);
+
+    expect(result.truncated).toBe(true);
+    expect(Buffer.byteLength(result.content, 'utf-8')).toBeLessThanOrEqual(
+      DEFAULT_MAX_READ_BYTES,
+    );
+    expect(result.totalBytes).toBe(500_000);
+  });
+
+  it('reports the real size so the model can tell how much it is missing', async () => {
+    const path = await write('big.eml', `${'y'.repeat(99)}\n`.repeat(5000));
+    const result = await readBounded(path);
+
+    expect(result.totalBytes).toBe(500_000);
+    expect(result.bytesReturned).toBeLessThan(result.totalBytes);
+    expect(result.hint).toMatch(/offset and limit/);
+  });
+
+  /**
+   * A half-line is worse than a missing line: the model cannot tell a record
+   * that ends early from one whose value really is that short.
+   */
+  it('cuts on a line boundary, never mid-line', async () => {
+    const path = await write('rows.csv', `${'z'.repeat(999)}\n`.repeat(400));
+    const result = await readBounded(path);
+
+    expect(result.truncated).toBe(true);
+    for (const line of result.content.split('\n').filter(Boolean)) {
+      expect(line).toHaveLength(999);
+    }
+  });
+
+  it('honours an explicit cap', async () => {
+    const path = await write('mid.txt', `${'q'.repeat(99)}\n`.repeat(200)); // 20 KB
+    const result = await readBounded(path, 4096);
+
+    expect(result.truncated).toBe(true);
+    expect(Buffer.byteLength(result.content, 'utf-8')).toBeLessThanOrEqual(4096);
+  });
+
+  /** A single unbroken line has no boundary to cut on; bound it anyway. */
+  it('still bounds a file with no newline at all', async () => {
+    const path = await write('oneline.json', 'a'.repeat(400_000));
+    const result = await readBounded(path);
+
+    expect(result.truncated).toBe(true);
+    expect(Buffer.byteLength(result.content, 'utf-8')).toBeLessThanOrEqual(
+      DEFAULT_MAX_READ_BYTES,
+    );
+  });
+
+  it('does not truncate a file sitting exactly on the cap', async () => {
+    const path = await write('exact.txt', 'a'.repeat(DEFAULT_MAX_READ_BYTES));
+    const result = await readBounded(path);
+
+    expect(result.truncated).toBeUndefined();
+    expect(result.content).toHaveLength(DEFAULT_MAX_READ_BYTES);
+  });
+});
+
+describe('boundSlice', () => {
+  /**
+   * The paged path asks in lines, and a line count says nothing about byte
+   * size — one row of a data file can be megabytes, so `limit: 500` is not by
+   * itself a bound.
+   */
+  it('bounds a slice whose lines are individually enormous', () => {
+    const sliced = `${'x'.repeat(500_000)}\n${'y'.repeat(500_000)}`;
+    const { content, meta } = boundSlice(sliced);
+
+    expect(meta.truncated).toBe(true);
+    expect(Buffer.byteLength(content, 'utf-8')).toBeLessThanOrEqual(
+      DEFAULT_MAX_READ_BYTES,
+    );
+    expect(meta.hint).toMatch(/limit/);
+  });
+
+  it('leaves a normal slice untouched, with no metadata', () => {
+    const { content, meta } = boundSlice('one\ntwo\nthree');
+
+    expect(content).toBe('one\ntwo\nthree');
+    expect(meta).toEqual({});
+  });
+});

--- a/packages/core/src/stimulus/tools/fs-tools.ts
+++ b/packages/core/src/stimulus/tools/fs-tools.ts
@@ -7,7 +7,7 @@
  * over these.
  */
 
-import { readFile, writeFile, mkdir, readdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, readdir, stat, open } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -44,6 +44,109 @@ const ripgrepSchema = z.object({
   fileType: z.string().optional().describe('File type filter (e.g., "ts", "js", "md")'),
 });
 
+/**
+ * Most bytes a single read returns when the caller did not ask for a slice.
+ *
+ * A file read is the one tool result whose size is set by the repo rather than
+ * by anything the model chose, and it cannot see the size before asking. An
+ * unbounded read of a big file does not degrade the turn, it ends it: the
+ * provider rejects the whole request and the model gets no answer and no way
+ * to recover. Observed against a 5.2 MB `.eml` in a habitat's mounted repo —
+ * 1,154,415 tokens against a 1,000,000 limit, from one `read_file`.
+ *
+ * 256 KiB clears every source and document file in practice while staying far
+ * enough under the smallest context window that a truncated read is always
+ * survivable. Files above it are not refused — the head comes back with the
+ * real size and an instruction to page, which is a thing the model can act on.
+ *
+ * This bounds an *input* the model did not choose. It is not an output cap:
+ * nothing here touches maxOutputTokens/maxTokens, and generation still runs to
+ * its natural stop.
+ */
+export const DEFAULT_MAX_READ_BYTES = 256 * 1024;
+
+export interface BoundedRead {
+  content: string;
+  /** Whole-file byte length, whether or not the read was truncated. */
+  totalBytes: number;
+  /** Set only when bytes were withheld, so a full read stays shaped as before. */
+  truncated?: true;
+  bytesReturned?: number;
+  hint?: string;
+}
+
+/**
+ * Read at most `maxBytes`, cutting on a line boundary.
+ *
+ * Opens a handle and reads only the prefix rather than reading the file and
+ * slicing: a 8.5 MB read that gets thrown away is still 8.5 MB through the
+ * process, and habitats run many of these concurrently.
+ */
+export async function readBounded(
+  resolved: string,
+  maxBytes: number = DEFAULT_MAX_READ_BYTES,
+): Promise<BoundedRead> {
+  const { size } = await stat(resolved);
+  if (size <= maxBytes) {
+    return { content: await readFile(resolved, 'utf-8'), totalBytes: size };
+  }
+
+  const handle = await open(resolved, 'r');
+  let raw: string;
+  try {
+    const buf = Buffer.alloc(maxBytes);
+    const { bytesRead } = await handle.read(buf, 0, maxBytes, 0);
+    raw = buf.subarray(0, bytesRead).toString('utf-8');
+  } finally {
+    await handle.close();
+  }
+
+  // Drop the trailing partial line so the model never parses half a record —
+  // and a final partial multi-byte character with it.
+  const cut = raw.lastIndexOf('\n');
+  const content = cut > 0 ? raw.slice(0, cut) : raw;
+
+  return {
+    content,
+    totalBytes: size,
+    truncated: true,
+    bytesReturned: Buffer.byteLength(content, 'utf-8'),
+    hint:
+      `File is ${size} bytes; returned the first ${Buffer.byteLength(content, 'utf-8')}. ` +
+      `Use offset and limit to page through the rest, or ripgrep to search it without reading it whole.`,
+  };
+}
+
+/**
+ * Bound an already-materialised slice, on a line boundary.
+ *
+ * The offset/limit path asks in lines, so the cap has to be applied after the
+ * slice exists. Shared by both read tools so a paged read of a file with very
+ * long lines is bounded the same way an unpaged one is.
+ */
+export function boundSlice(
+  sliced: string,
+  maxBytes: number = DEFAULT_MAX_READ_BYTES,
+): { content: string; meta: Record<string, unknown> } {
+  const size = Buffer.byteLength(sliced, 'utf-8');
+  if (size <= maxBytes) return { content: sliced, meta: {} };
+
+  const head = Buffer.from(sliced, 'utf-8').subarray(0, maxBytes).toString('utf-8');
+  const cut = head.lastIndexOf('\n');
+  const content = cut > 0 ? head.slice(0, cut) : head;
+  return {
+    content,
+    meta: {
+      truncated: true,
+      totalBytes: size,
+      bytesReturned: Buffer.byteLength(content, 'utf-8'),
+      hint:
+        `The requested range is ${size} bytes; returned the first ` +
+        `${Buffer.byteLength(content, 'utf-8')}. Narrow the range with limit, or use ripgrep.`,
+    },
+  };
+}
+
 function classify(err: unknown, rawPath: string) {
   if (err instanceof Error) {
     if (err.message.startsWith(OUTSIDE_ALLOWED_PATH)) return { error: err.message };
@@ -66,25 +169,42 @@ export function createReadTool(roots: string[]): Tool {
       try {
         const resolved = resolveSandboxPath(rawPath, roots);
         ensureAllowed(resolved, roots);
-        const fullContent = await readFile(resolved, 'utf-8');
 
         if (offset !== undefined || limit !== undefined) {
+          // Line addressing needs whole lines, so this path reads the file and
+          // slices — then bounds the slice, because a line count says nothing
+          // about byte size and one row of a data file can be megabytes.
+          const fullContent = await readFile(resolved, 'utf-8');
           const lines = fullContent.split('\n');
           const totalLines = lines.length;
           const startLine = offset ?? 0;
           const endLine = limit !== undefined ? startLine + limit : totalLines;
-          const slicedContent = lines.slice(startLine, endLine).join('\n');
+          const sliced = lines.slice(startLine, endLine).join('\n');
+          const capped = boundSlice(sliced);
           return {
             path: resolved,
-            content: slicedContent,
+            content: capped.content,
             totalLines,
             startLine,
             endLine: Math.min(endLine, totalLines),
             hasMore: endLine < totalLines,
+            ...capped.meta,
           };
         }
 
-        return { path: resolved, content: fullContent };
+        const read = await readBounded(resolved);
+        return {
+          path: resolved,
+          content: read.content,
+          ...(read.truncated
+            ? {
+                truncated: true,
+                totalBytes: read.totalBytes,
+                bytesReturned: read.bytesReturned,
+                hint: read.hint,
+              }
+            : {}),
+        };
       } catch (err) {
         return classify(err, rawPath);
       }

--- a/packages/habitat/src/tools/file-tools.ts
+++ b/packages/habitat/src/tools/file-tools.ts
@@ -23,6 +23,7 @@ import {
   ensureAllowed,
   OUTSIDE_ALLOWED_PATH,
 } from '@umwelten/core/stimulus/tools/path-sandbox.js';
+import { readBounded, boundSlice } from '@umwelten/core/stimulus/tools/fs-tools.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -90,25 +91,38 @@ export function createFileTools(ctx: FileToolsContext): Record<string, Tool> {
       try {
         const resolved = resolveHabitatPath(rawPath, agentId, ctx);
         ensureAllowed(resolved, allowedRoots);
-        const fullContent = await readFile(resolved, 'utf-8');
 
         if (offset !== undefined || limit !== undefined) {
+          const fullContent = await readFile(resolved, 'utf-8');
           const lines = fullContent.split('\n');
           const totalLines = lines.length;
           const startLine = offset ?? 0;
           const endLine = limit !== undefined ? startLine + limit : totalLines;
-          const slicedContent = lines.slice(startLine, endLine).join('\n');
+          const capped = boundSlice(lines.slice(startLine, endLine).join('\n'));
           return {
             path: resolved,
-            content: slicedContent,
+            content: capped.content,
             totalLines,
             startLine,
             endLine: Math.min(endLine, totalLines),
             hasMore: endLine < totalLines,
+            ...capped.meta,
           };
         }
 
-        return { path: resolved, content: fullContent };
+        const read = await readBounded(resolved);
+        return {
+          path: resolved,
+          content: read.content,
+          ...(read.truncated
+            ? {
+                truncated: true,
+                totalBytes: read.totalBytes,
+                bytesReturned: read.bytesReturned,
+                hint: read.hint,
+              }
+            : {}),
+        };
       } catch (err: unknown) {
         if (err instanceof Error) {
           if (err.message.startsWith('AGENT_NOT_FOUND')) return { error: err.message };


### PR DESCRIPTION
## The bug

An `operations` habitat asked a question about a client read a 5.2 MB `.eml` out of its mounted repo, and the provider rejected the whole request:

```
prompt is too long: 1154415 tokens > 1000000 maximum
```

Both read tools — `createReadTool` in core and the habitat wrapper — called `readFile` and returned whatever came back. `offset`/`limit` existed, but they're opt-in and the model **cannot see a file's size before asking**, so there was no way to use them in time.

The failure mode is the bad one. Not a degraded answer — *no* answer, and nothing the model could have done differently. `ripgrep` already caps its results; `read_file` didn't.

This isn't specific to that repo. Any habitat mounted on a repo containing one large file has the same landmine.

## The fix

`readBounded()` returns at most `DEFAULT_MAX_READ_BYTES` (256 KiB), cut on a line boundary, along with the real size and an instruction to page. Both tools use it, so the habitat and agent-kit paths behave identically.

`boundSlice()` applies the same bound to the `offset`/`limit` path — a line count says nothing about byte size, so `limit: 500` was never a bound by itself when one row of a data file can be megabytes.

The unpaged read opens a handle and reads only the prefix rather than reading the whole file and slicing: an 8.5 MB read that gets discarded is still 8.5 MB through the process, and habitats run these concurrently.

**Truncation is additive.** A file under the cap returns exactly as before, with no new fields — so nothing that reads normal files changes shape.

## Verified against the repo that caused it

| file | before | after | |
|---|---|---|---|
| `john-follow-up.eml` | 5,169,592 B — ~1,148,800 tok | ~58,200 tok | truncated |
| `19db6f455a045829.eml` | 8,458,381 B — ~1,879,600 tok | ~58,250 tok | truncated |
| `CLAUDE.md` | 18,662 B | unchanged | whole |
| `README.md` | 106,359 B | unchanged | whole |

The estimate for the first file lands within 0.5% of the 1,154,415 tokens the provider actually reported, which is what confirms it was a single `read_file` and not accumulated history.

## Not an output cap

To be explicit, since this is adjacent to a documented invariant: this bounds an **input** the model did not choose. Nothing here touches `maxOutputTokens`/`maxTokens`, no shared default gains a cap, and generation still runs to its natural stop. `request-options.test.ts` is untouched.

## Verification

- `tsc --noEmit` clean on `@umwelten/core` and `@umwelten/habitat`
- `pnpm test:run` — 2693 tests / 213 files, green
- 9 new cases: small files pass through, oversized files truncate, line boundaries hold, files with no newline are still bounded, a file exactly on the cap is not truncated, explicit caps are honoured, and the paged path is bounded when individual lines are enormous

## Follow-up, not in this PR

Those 46 `.eml` files are ~30 MB of base64 in a documents repo. Bounded reads stop them from breaking a turn, but they're still not useful to an agent — worth excluding from the mount or moving them out of git.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_