### PR TITLE
Gaia: point build_image at the habitat Dockerfile

### DIFF
--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -78,6 +78,12 @@ function resolveNetworkName(): string {
 }
 /** Default image every habitat runs unless its registry entry says otherwise. */
 export const DEFAULT_IMAGE_NAME = "habitat";
+
+/**
+ * Habitat Dockerfile, relative to the repo root that is the build context.
+ * Kept next to the image name so the two cannot drift apart.
+ */
+export const HABITAT_DOCKERFILE = "packages/habitat/Dockerfile";
 const CONTAINER_PREFIX = "gaia-";
 
 /** First port in the habitat container range. */
@@ -212,11 +218,25 @@ export class DockerManager {
     }
   }
 
-  /** Build the habitat image from the project root. */
+  /**
+   * Build the habitat image.
+   *
+   * The context is the repo root — the Dockerfile copies `pnpm-workspace.yaml`
+   * and the whole `packages/` tree, so it cannot build from its own directory —
+   * but the Dockerfile itself lives in `packages/habitat/`, so `-f` is required.
+   * Without it docker looks for a Dockerfile at the context root, which does
+   * not exist, and `build_image` fails for every caller:
+   *
+   *   unable to prepare context: unable to evaluate symlinks in Dockerfile
+   *   path: lstat /habitat/Dockerfile: no such file or directory
+   *
+   * That made the tool unusable exactly when it is needed — after merging a fix
+   * to shared code, which only reaches habitats through a rebuilt image.
+   */
   async buildImage(): Promise<string> {
     const { stdout, stderr } = await execFile(
       "docker",
-      ["build", "-t", DEFAULT_IMAGE_NAME, "."],
+      ["build", "-f", HABITAT_DOCKERFILE, "-t", DEFAULT_IMAGE_NAME, "."],
       { cwd: this.projectRoot, maxBuffer: 10 * 1024 * 1024 },
     );
     return stdout + stderr;


### PR DESCRIPTION
## The bug

`build_image` ran `docker build -t habitat .` from the repo root and failed for every caller:

```
unable to prepare context: unable to evaluate symlinks in Dockerfile path:
lstat /habitat/Dockerfile: no such file or directory
```

The **context** was right — the Dockerfile copies `pnpm-workspace.yaml` and the whole `packages/` tree, so it can't build from its own directory, and the root is where `.dockerignore` lives. Only `-f` was missing: the Dockerfile is at `packages/habitat/Dockerfile`, not at the context root.

## Why it matters

This bit exactly when the tool matters. Shared-code fixes reach habitats **only** through a rebuilt image — `rebuild_habitat` says so in its own description:

> Runs the image the habitat already uses — it does NOT rebuild any Docker image; run `build_image` first to pick up new code.

So with `build_image` broken there was no supported path for getting merged code into a running habitat. Found while trying to land #356 on the fleet: the habitat refreshed its content repos happily and kept running the old framework code, and the tool meant to fix that couldn't run.

## The fix

Add `-f packages/habitat/Dockerfile`, as a named constant beside `DEFAULT_IMAGE_NAME` so the two can't drift.

## Verification

- The Dockerfile exists at that path, and its `COPY` lines confirm the repo root is the intended context
- The resulting argv is the one that builds by hand
- `tsc --noEmit` clean on `@umwelten/habitat`; `pnpm test:run` green (2693 tests, 213 files)

No docker daemon in the environment this was written in, so the build itself is unverified end-to-end — the path, flags, and context are.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_