### PR TITLE
Gaia: announce habitats to the Habitats SaaS

### DIFF
--- a/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/habitats.ts
@@ -18,6 +18,11 @@ import { recordHabitatActivity } from "../reaper.js";
 import { HabitatWaker, createWakeTools } from "../waker.js";
 import { habitatSecretStatus } from "../secret-status.js";
 import {
+	announceHabitat,
+	announceOnStart,
+	resolveSaasRegistryConfig,
+} from "../saas-registry.js";
+import {
 	nodeVaultDeps,
 	resolveHabitatVault,
 	VaultResolutionError,
@@ -140,6 +145,13 @@ export async function startHabitatContainer(
 	// A start counts as activity, so a habitat is not reaped in the
 	// window between being started and first being asked anything.
 	await recordHabitatActivity(registry, id);
+
+	// Tell the SaaS this habitat exists, at this address, under this name.
+	// Deliberately not awaited into the start's success: a habitat that is
+	// running matters more than the SaaS knowing about it this second, and the
+	// next start announces again. Inert unless the registry env is configured.
+	void announceOnStart({ ...entry, containerPort: port });
+
 	return port;
 }
 
@@ -165,6 +177,51 @@ export function createHabitatLifecycleTools(
 
 	return {
 		...createWakeTools(waker, { listIds: () => registry.list().map((h) => h.id) }),
+
+		register_in_saas: tool({
+			description:
+				"Announce habitats to the Habitats SaaS so they appear as agents there. Starting a habitat already announces it; call this to backfill habitats that have not restarted since the registry was configured, or after changing which workspace they belong to. Omit `id` to announce every habitat. Safe to repeat — the SaaS updates the existing agent rather than creating a second one.",
+			inputSchema: z.object({
+				id: z
+					.string()
+					.optional()
+					.describe("Habitat to announce; omit for all of them"),
+			}),
+			execute: async ({ id }) => {
+				const config = resolveSaasRegistryConfig();
+				if (!config) {
+					return (
+						"The SaaS registry is not configured, so nothing was announced. " +
+						"Set HABITATS_SAAS_REGISTRY_URL and HABITATS_SAAS_REGISTRY_SECRET " +
+						"(and optionally HABITATS_SAAS_REGISTRY_WORKSPACE) on Gaia."
+					);
+				}
+				const entries = id
+					? registry.list().filter((e) => e.id === id)
+					: registry.list();
+				if (entries.length === 0) {
+					return id ? `No habitat "${id}".` : "No habitats registered.";
+				}
+
+				const lines: string[] = [];
+				for (const entry of entries) {
+					const outcome = await announceHabitat(entry, config, {
+						fetch: globalThis.fetch,
+					});
+					if (outcome.ok === true) {
+						lines.push(
+							`${entry.id}: ${outcome.created ? "registered" : "updated"}` +
+								`${outcome.agentKey ? ` (${outcome.agentKey})` : ""}`,
+						);
+					} else if (outcome.ok === "skipped") {
+						lines.push(`${entry.id}: skipped — ${outcome.reason}`);
+					} else {
+						lines.push(`${entry.id}: FAILED — ${outcome.reason}`);
+					}
+				}
+				return lines.join("\n");
+			},
+		}),
 		list_habitats: tool({
 			description:
 				"List all registered habitats with their container status. Includes the web UI URL with auth token for running habitats.",

--- a/packages/habitat/src/tools/gaia/saas-registry.test.ts
+++ b/packages/habitat/src/tools/gaia/saas-registry.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	announceHabitat,
+	buildAnnouncement,
+	resolveSaasRegistryConfig,
+} from "./saas-registry.js";
+import type { GaiaHabitatEntry } from "./types.js";
+
+function entry(over: Partial<GaiaHabitatEntry> = {}): GaiaHabitatEntry {
+	return {
+		id: "operations",
+		name: "Operations",
+		apiKey: "gaia_secret_key",
+		config: {},
+		secretBindings: [],
+		createdAt: "2026-08-05T00:00:00Z",
+		...over,
+	} as GaiaHabitatEntry;
+}
+
+const CONFIG = {
+	url: "https://habitats.thefocus.ai/api/admin/umwelten/register",
+	secret: "shh",
+	workspace: "the-focus-ai",
+};
+
+describe("resolveSaasRegistryConfig", () => {
+	it("is null when nothing is configured, so announcing is opt-in", () => {
+		expect(resolveSaasRegistryConfig({})).toBeNull();
+	});
+
+	/**
+	 * Either half alone is a half-configured integration that could only ever
+	 * produce failing calls — better to stay inert than to retry forever.
+	 */
+	it("is null when only the URL or only the secret is set", () => {
+		expect(resolveSaasRegistryConfig({ HABITATS_SAAS_REGISTRY_URL: "u" })).toBeNull();
+		expect(
+			resolveSaasRegistryConfig({ HABITATS_SAAS_REGISTRY_SECRET: "s" }),
+		).toBeNull();
+	});
+
+	it("reads url, secret and optional workspace", () => {
+		expect(
+			resolveSaasRegistryConfig({
+				HABITATS_SAAS_REGISTRY_URL: " https://x/register ",
+				HABITATS_SAAS_REGISTRY_SECRET: " s ",
+				HABITATS_SAAS_REGISTRY_WORKSPACE: " ws ",
+			}),
+		).toEqual({ url: "https://x/register", secret: "s", workspace: "ws" });
+	});
+
+	it("omits the workspace when unset, leaving the receiver to default it", () => {
+		const c = resolveSaasRegistryConfig({
+			HABITATS_SAAS_REGISTRY_URL: "u",
+			HABITATS_SAAS_REGISTRY_SECRET: "s",
+		});
+		expect(c).not.toBeNull();
+		expect(c && "workspace" in c).toBe(false);
+	});
+});
+
+describe("buildAnnouncement", () => {
+	it("announces the public https address", () => {
+		const p = buildAnnouncement(
+			entry({ hostname: "operations.habitats.thefocus.ai" }),
+			CONFIG,
+		);
+		expect(p?.endpoint).toBe("https://operations.habitats.thefocus.ai");
+		expect(p?.habitatId).toBe("operations");
+		expect(p?.workspaceSlug).toBe("the-focus-ai");
+	});
+
+	/**
+	 * The token travels as a field, not in the URL: the receiver logs endpoints,
+	 * and a credential in a logged URL is a credential in the logs.
+	 */
+	it("keeps the token out of the endpoint", () => {
+		const p = buildAnnouncement(
+			entry({ hostname: "operations.habitats.thefocus.ai" }),
+			CONFIG,
+		);
+		expect(p?.endpoint).not.toContain("token");
+		expect(p?.token).toBe("gaia_secret_key");
+	});
+
+	/**
+	 * A habitat reachable only on host loopback could never be dispatched to
+	 * from Vercel; recording it would put a row in the product that looks
+	 * attached and can never answer.
+	 */
+	it("returns null for a habitat with no public hostname", () => {
+		expect(buildAnnouncement(entry({ containerPort: 7450 }), CONFIG)).toBeNull();
+	});
+});
+
+describe("announceHabitat", () => {
+	it("posts the payload with the shared secret as a bearer", async () => {
+		const fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({ created: true, agentKey: "gaia-operations" }),
+		});
+		const out = await announceHabitat(
+			entry({ hostname: "operations.habitats.thefocus.ai" }),
+			CONFIG,
+			{ fetch: fetch as unknown as typeof globalThis.fetch },
+		);
+
+		expect(out).toMatchObject({ ok: true, created: true, agentKey: "gaia-operations" });
+		const [url, init] = fetch.mock.calls[0];
+		expect(url).toBe(CONFIG.url);
+		expect(init.headers.authorization).toBe("Bearer shh");
+		expect(JSON.parse(init.body)).toMatchObject({
+			habitatId: "operations",
+			workspaceSlug: "the-focus-ai",
+		});
+	});
+
+	it("reports a non-2xx as a reason rather than throwing", async () => {
+		const fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 403,
+			text: async () => "forbidden",
+		});
+		const out = await announceHabitat(
+			entry({ hostname: "h.example.com" }),
+			CONFIG,
+			{ fetch: fetch as unknown as typeof globalThis.fetch },
+		);
+		expect(out).toEqual({ ok: false, reason: "HTTP 403 forbidden" });
+	});
+
+	/** The caller is a start path; a network fault must never surface as a throw. */
+	it("reports a network failure rather than throwing", async () => {
+		const fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+		const out = await announceHabitat(
+			entry({ hostname: "h.example.com" }),
+			CONFIG,
+			{ fetch: fetch as unknown as typeof globalThis.fetch },
+		);
+		expect(out).toEqual({ ok: false, reason: "ECONNREFUSED" });
+	});
+
+	it("skips, without calling out, when there is no public hostname", async () => {
+		const fetch = vi.fn();
+		const out = await announceHabitat(entry(), CONFIG, {
+			fetch: fetch as unknown as typeof globalThis.fetch,
+		});
+		expect(out).toMatchObject({ ok: "skipped" });
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("bounds the request so a hanging SaaS cannot stall a start", async () => {
+		const fetch = vi.fn(
+			(_u: unknown, init: { signal: AbortSignal }) =>
+				new Promise((_res, rej) =>
+					init.signal.addEventListener("abort", () => rej(new Error("aborted"))),
+				),
+		);
+		const out = await announceHabitat(
+			entry({ hostname: "h.example.com" }),
+			CONFIG,
+			{ fetch: fetch as unknown as typeof globalThis.fetch, timeoutMs: 10 },
+		);
+		expect(out).toMatchObject({ ok: false });
+	});
+});

--- a/packages/habitat/src/tools/gaia/saas-registry.ts
+++ b/packages/habitat/src/tools/gaia/saas-registry.ts
@@ -1,0 +1,188 @@
+/**
+ * Announce habitats to the Habitats SaaS (dynamic registry).
+ *
+ * Gaia is the only thing that knows the fleet: which habitats exist, what
+ * they are called, where they are served. The SaaS learned that only when a
+ * human pasted a URL and token into its attach form, so its view of the fleet
+ * was a snapshot of whoever had bothered, and drifted from the moment a
+ * habitat was created, renamed, or moved.
+ *
+ * This closes that loop from the side that has the facts. Three properties
+ * shape the design:
+ *
+ *  - **Announcement is a statement, not an event.** Gaia announces on every
+ *    start, and the receiver upserts. Nothing has to remember whether a
+ *    habitat was announced before, which means no local state to fall out of
+ *    sync and no backfill problem after an outage.
+ *  - **It never fails a start.** A habitat that is running is more important
+ *    than the SaaS knowing about it. Every failure here is logged and
+ *    swallowed; the next start announces again.
+ *  - **It is off unless configured.** With no URL or secret this is inert, so
+ *    a local Gaia or a fresh deploy gains no surprise outbound call.
+ *
+ * The token sent is the habitat's own per-container API key — the same one
+ * `entryOpenUrl` puts in a browser link. Habitats that advertise per-user JWT
+ * auth do not need it, but sending it keeps bearer-only habitats attachable;
+ * the receiver stores it encrypted and prefers minted per-user grants when the
+ * card says it can.
+ */
+
+import type { GaiaHabitatEntry } from "./types.js";
+import { resolveHabitatHostname } from "./docker.js";
+
+export interface SaasRegistryConfig {
+	/** Full URL of the SaaS register endpoint. */
+	url: string;
+	/** Shared secret presented as a bearer token. */
+	secret: string;
+	/** Workspace slug new habitats attach to; the receiver may also default it. */
+	workspace?: string;
+}
+
+/**
+ * Registry settings from the environment. Null — meaning "do not announce" —
+ * unless both the URL and the secret are present, because either alone is a
+ * half-configured integration that would only produce failing calls.
+ *
+ * - `HABITATS_SAAS_REGISTRY_URL`
+ * - `HABITATS_SAAS_REGISTRY_SECRET`
+ * - `HABITATS_SAAS_REGISTRY_WORKSPACE` (optional)
+ */
+export function resolveSaasRegistryConfig(
+	env: NodeJS.ProcessEnv = process.env,
+): SaasRegistryConfig | null {
+	const url = env.HABITATS_SAAS_REGISTRY_URL?.trim();
+	const secret = env.HABITATS_SAAS_REGISTRY_SECRET?.trim();
+	if (!url || !secret) return null;
+	const workspace = env.HABITATS_SAAS_REGISTRY_WORKSPACE?.trim();
+	return { url, secret, ...(workspace ? { workspace } : {}) };
+}
+
+export interface AnnouncePayload {
+	habitatId: string;
+	endpoint: string;
+	name: string;
+	token: string;
+	workspaceSlug?: string;
+}
+
+/**
+ * Build the announcement for one habitat, or null when it has no public
+ * address.
+ *
+ * A habitat reachable only on a host loopback port is deliberately not
+ * announced: the SaaS runs on Vercel and could never dispatch to it, so
+ * recording it would put a row in the product that looks attached and can
+ * never answer. `entryOpenUrl` falls back to localhost for exactly the local
+ * case this must skip, which is why this derives the hostname directly.
+ *
+ * The endpoint carries no token — the receiver takes it as a field and stores
+ * it encrypted, rather than keeping a credential in a URL it will log.
+ */
+export function buildAnnouncement(
+	entry: GaiaHabitatEntry,
+	config: SaasRegistryConfig,
+): AnnouncePayload | null {
+	const host = resolveHabitatHostname(entry);
+	if (!host) return null;
+	return {
+		habitatId: entry.id,
+		endpoint: `https://${host}`,
+		name: entry.name,
+		token: entry.apiKey,
+		...(config.workspace ? { workspaceSlug: config.workspace } : {}),
+	};
+}
+
+export interface AnnounceDeps {
+	fetch: typeof globalThis.fetch;
+	log?: (message: string) => void;
+	/** Bounded so a slow or hanging SaaS cannot stall a habitat start. */
+	timeoutMs?: number;
+}
+
+export type AnnounceOutcome =
+	| { ok: true; created?: boolean; agentKey?: string }
+	| { ok: false; reason: string }
+	| { ok: "skipped"; reason: string };
+
+/**
+ * Announce one habitat. Never throws — the caller is a start path.
+ */
+export async function announceHabitat(
+	entry: GaiaHabitatEntry,
+	config: SaasRegistryConfig,
+	deps: AnnounceDeps,
+): Promise<AnnounceOutcome> {
+	const payload = buildAnnouncement(entry, config);
+	if (!payload) {
+		return {
+			ok: "skipped",
+			reason: `${entry.id} has no public hostname; nothing the SaaS could dispatch to`,
+		};
+	}
+
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), deps.timeoutMs ?? 10_000);
+	try {
+		const res = await deps.fetch(config.url, {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				authorization: `Bearer ${config.secret}`,
+			},
+			body: JSON.stringify(payload),
+			signal: controller.signal,
+		});
+		if (!res.ok) {
+			const body = await res.text().catch(() => "");
+			return { ok: false, reason: `HTTP ${res.status} ${body.slice(0, 200)}` };
+		}
+		const json = (await res.json().catch(() => ({}))) as {
+			created?: boolean;
+			agentKey?: string;
+		};
+		deps.log?.(
+			`[saas-registry] ${entry.id} ${json.created ? "registered" : "updated"}` +
+				`${json.agentKey ? ` as ${json.agentKey}` : ""}`,
+		);
+		return {
+			ok: true,
+			...(json.created !== undefined ? { created: json.created } : {}),
+			...(json.agentKey ? { agentKey: json.agentKey } : {}),
+		};
+	} catch (err) {
+		return {
+			ok: false,
+			reason: err instanceof Error ? err.message : String(err),
+		};
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/**
+ * Announce a habitat as a side effect of starting it.
+ *
+ * Swallows everything: a failed announcement is logged and forgotten, because
+ * the next start announces again and a running habitat matters more than the
+ * SaaS's view of it being current this second.
+ */
+export async function announceOnStart(
+	entry: GaiaHabitatEntry,
+	deps: Partial<AnnounceDeps> = {},
+): Promise<void> {
+	const config = resolveSaasRegistryConfig();
+	if (!config) return;
+	const log = deps.log ?? ((m: string) => console.log(m));
+	const outcome = await announceHabitat(entry, config, {
+		fetch: deps.fetch ?? globalThis.fetch,
+		log,
+		...(deps.timeoutMs !== undefined ? { timeoutMs: deps.timeoutMs } : {}),
+	});
+	if (outcome.ok === false) {
+		log(`[saas-registry] ${entry.id} announcement failed: ${outcome.reason}`);
+	} else if (outcome.ok === "skipped") {
+		log(`[saas-registry] skipped ${outcome.reason}`);
+	}
+}


### PR DESCRIPTION
Outbound half of the dynamic registry. Pairs with The-Focus-AI/habitats#124, which accepts these announcements.

## Why

Gaia is the only thing that knows the fleet — which habitats exist, what they're called, where they're served. The SaaS learned that only when a human pasted a URL and token into its attach form, so its view was a snapshot of whoever had bothered, and drifted the moment a habitat was created, renamed, or moved.

Sixteen habitats on the host; seven in the SaaS's status roster.

## What

Gaia announces a habitat when it starts it. `register_in_saas` backfills habitats that haven't restarted since the registry was configured, or after changing which workspace they belong to.

Three properties shape the design:

- **Announcement is a statement, not an event.** Gaia announces on every start and the receiver upserts — so there's no local "already announced" state to fall out of sync, and no backfill problem after an outage.
- **It never fails a start.** A running habitat matters more than the SaaS knowing about it this second. Every failure is logged and swallowed; the next start announces again. The request is time-bounded so a hanging SaaS can't stall a start.
- **It's inert unless configured.** Both `HABITATS_SAAS_REGISTRY_URL` and `HABITATS_SAAS_REGISTRY_SECRET` must be set — either alone is a half-configured integration that could only produce failing calls.

## Two deliberate choices

A habitat with **no public hostname is skipped**, not announced. It's reachable only on host loopback; the SaaS runs on Vercel and could never dispatch to it, so recording it would put a row in the product that looks attached and can never answer. (`entryOpenUrl` falls back to localhost for exactly the local case this must skip, which is why this derives the hostname directly.)

The habitat's API key travels as a **payload field, not in the endpoint URL** — the receiver logs endpoints.

## Config

| | |
|---|---|
| `HABITATS_SAAS_REGISTRY_URL` | required |
| `HABITATS_SAAS_REGISTRY_SECRET` | required |
| `HABITATS_SAAS_REGISTRY_WORKSPACE` | optional; receiver may default it |

## Verification

- `tsc --noEmit` clean on `@umwelten/habitat`
- `pnpm test:run` green — 2705 tests / 214 files
- 12 new cases: opt-in config (null unless both halves present), loopback skip without calling out, non-2xx and network failure returned as reasons rather than thrown, and the timeout bound

Not exercised against a live SaaS — that needs habitats#124 deployed with the shared secret set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_