### PR TITLE
Mycel: catalogue sync, container, compose service, and a port that works

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -628,6 +628,8 @@ All umwelten services use the 74xx port range to avoid conflicts with common dev
 | House demo (Hearthstone)| **7435**      | `examples/agent-browser/demo-house.ts`     |
 | Weather demo (Meteora)  | **7436**      | `examples/agent-browser/demo-weather.ts`   |
 | Atlas demo (routes)     | **7437**      | `examples/agent-browser/demo-atlas.ts`     |
+| Mycel (the Exchange)    | **7438**      | `mycel serve` — fixed, below Gaia's range  |
+| Supplier managed runtime| **7439**      | llama-swap the supplier agent owns         |
 | Managed containers      | **7440–7499** | Gaia assigns sequentially from this range  |
 | Internal container port | **8080**      | Inside Docker only, never exposed directly |
 

--- a/deploy/mycel/.env.example
+++ b/deploy/mycel/.env.example
@@ -1,0 +1,29 @@
+# Mycel compose config. Copy to .env and fill in.
+#
+# Secrets are resolved by fnox at container start, so the values below can stay
+# empty in a deploy that has fnox configured — this file then carries only the
+# non-sensitive shape. Filling them in directly works too, and is how you'd run
+# it somewhere fnox is not set up.
+
+# Public hostname. Caddy issues the cert from the container label, so this needs
+# an A record at the host's static IP.
+#
+# NOT under *.habitats.thefocus.ai: the wildcard would be free, but Mycel is not
+# a habitat, and putting it there says it is.
+MYCEL_HOSTNAME=mycel.thefocus.ai
+
+# Below 7440, where Gaia starts assigning ports to the containers it manages.
+MYCEL_PORT=7438
+
+# Its own Neon project, separate from the one habitats use. Neon's blast-radius
+# boundary is the project, and this one holds a money ledger.
+MYCEL_DATABASE_URL=
+
+# Upstream keys — what Mycel pays Suppliers with. A Supplier record stores only
+# the NAME of one of these, so a database compromise yields nothing spendable.
+#
+# Mint a SECOND OpenRouter key rather than reusing Gaia's: Mycel's whole job is
+# metering, and having its upstream spend independently visible in OpenRouter's
+# own dashboard is how you find out the metering is wrong.
+OPENROUTER_API_KEY=
+GOOGLE_GENERATIVE_AI_API_KEY=

--- a/deploy/mycel/README.md
+++ b/deploy/mycel/README.md
@@ -1,32 +1,36 @@
 # Running Mycel
 
-Start, stop, roll back, and diagnose. The reasoning behind the shape is
-`docs/architecture/mycel-deployment.md`; this is the operating manual.
+The operating manual: bring it up, onboard someone, deploy a change, work out
+what broke. The reasoning behind the shape is
+`docs/architecture/mycel-deployment.md`.
 
-## First time
+## The one alias to set first
+
+Every operator command needs the database, and the container already has it
+resolved. Running them inside it means no connection string on your shell and no
+chance of pointing a grant at the wrong database:
 
 ```bash
-docker network create gaia-net           # already exists if Gaia is running
-docker build -t mycel -f packages/mycel/Dockerfile .
-cp deploy/mycel/.env.example deploy/mycel/.env   # then fill it in
-docker compose --project-directory deploy/mycel up -d
-curl https://mycel.thefocus.ai/health
+alias mycel='docker compose --project-directory /opt/umwelten/deploy/mycel exec mycel pnpm exec tsx packages/cli/src/entry.ts mycel'
 ```
 
-`/health` reports whether the **store** is reachable, not merely whether the
-process is up:
+Everything below assumes that alias. Without it, `umwelten mycel …` on the host
+will fail with "No database" — correctly, because it has none.
 
-```json
-{ "status": "ok" }
-{ "status": "degraded", "store": "…" }   // 503
+## Bringing it up
+
+```bash
+docker network create gaia-net                    # exists already if Gaia runs
+cp deploy/mycel/.env.example deploy/mycel/.env    # then fill it in
+./deploy/mycel/deploy.sh
 ```
 
-A service that answers while its database is gone is worse than one that does
-not answer, because Dispatch keeps sending it traffic.
+`deploy.sh` builds, recreates the container, and waits for `/health`. Nothing
+else to run.
 
-**Run the store conformance suite against a Neon branch before the first boot.**
-`serve` runs the schema DDL on start, so otherwise the deploy is the first time
-that code has ever executed:
+**Before the very first boot**, run the store conformance suite against a
+throwaway Neon branch. `serve` executes the schema DDL on start, so otherwise
+the deploy is the first time that code has ever run:
 
 ```bash
 MYCEL_DATABASE_URL='postgres://…branch…' \
@@ -36,25 +40,28 @@ MYCEL_DATABASE_URL='postgres://…branch…' \
 ## Onboarding
 
 ```bash
-# A Supplier. The credential-env is the NAME of an env var, never the key.
-umwelten mycel supplier register openrouter \
+# A Supplier. --credential-env is the NAME of an env var, never the key itself.
+mycel supplier register openrouter \
   --display-name "OpenRouter" \
   --base-url https://openrouter.ai/api/v1 \
   --credential-env OPENROUTER_API_KEY
 
-# Its catalogue. A vendor runs no agent, so the operator publishes for it —
-# and this must keep running, because it IS the heartbeat.
-umwelten mycel offers sync openrouter \
+# Its catalogue. A vendor runs no agent, so the operator publishes for it — and
+# this has to keep running, because it IS the heartbeat. See the failure below.
+mycel offers sync openrouter \
   --models anthropic/claude-sonnet-5,google/gemini-3-flash-preview \
   --watch 5
 
 # A buyer.
-umwelten mycel client create the-focus-ai --name "The Focus AI"
-umwelten mycel application create help-habitat --client the-focus-ai
-umwelten mycel grant the-focus-ai 50000000        # $50
+mycel client create the-focus-ai --name "The Focus AI"
+mycel application create help-habitat --client the-focus-ai   # credential, once
+mycel grant the-focus-ai 50000000                             # $50
 ```
 
-Money is integer micro-dollars everywhere. `50000000` is $50.00.
+Money is integer micro-dollars everywhere: `50000000` is $50.00.
+
+The Application's credential is printed once and only its hash is stored. Lose
+it and you rotate — there is no path that recovers it.
 
 ## Deploying a change
 
@@ -62,46 +69,25 @@ Money is integer micro-dollars everywhere. `50000000` is $50.00.
 ./deploy/mycel/deploy.sh
 ```
 
-That is the whole thing. It tags the running image so there is something to roll
-back to, builds, recreates the container, and waits for `/health` to report the
-**store** reachable. If it never gets there it prints the logs and **rolls back
-by itself** — the alternative is a broken Exchange sitting there while somebody
+It tags the running image so there is something to roll back to, builds,
+recreates, and waits for `/health` to report the **store** reachable rather than
+merely the process up. If it never gets there it prints the logs and rolls back
+by itself — the alternative is a broken Exchange sitting there while somebody
 reads a scrollback.
 
-Deliberate, and **not** part of `deploy/gaia/redeploy.sh`. Mycel is not cycled by
-a push to umwelten main — that separation is the whole reason it is a peer of
-Gaia rather than a habitat Gaia manages. Deploying it is something a person
-decides to do.
+Deliberately **not** part of `deploy/gaia/redeploy.sh`. Mycel is not cycled by a
+push to umwelten main; that separation is the whole reason it is a peer of Gaia
+rather than a habitat Gaia manages.
 
-## Rolling back by hand
-
-The script does this automatically on a failed deploy. To go back later:
+To go back later:
 
 ```bash
 docker tag mycel:previous mycel
 docker compose --project-directory deploy/mycel up -d
 ```
 
-State is in Neon, so a rollback loses nothing. That is the payoff for the
-service holding no volume.
-
-## Running an operator command
-
-The container already has `MYCEL_DATABASE_URL` resolved, so the least
-error-prone place to run these is inside it — no connection string on your
-shell, no chance of pointing at the wrong database:
-
-```bash
-docker compose --project-directory deploy/mycel exec mycel \
-  pnpm exec tsx packages/cli/src/entry.ts mycel balance the-focus-ai
-```
-
-Worth an alias on the host:
-
-```bash
-alias mycel='docker compose --project-directory /opt/umwelten/deploy/mycel exec mycel pnpm exec tsx packages/cli/src/entry.ts mycel'
-mycel grant the-focus-ai 50000000
-```
+State is in Neon, so a rollback loses nothing. That is the payoff for holding no
+volume.
 
 ## Stopping
 
@@ -110,46 +96,51 @@ docker compose --project-directory deploy/mycel stop
 ```
 
 Buyers get connection failures, which is correct — a habitat pointed at Mycel is
-down when Mycel is down. To un-break one, point it back at OpenRouter directly:
-its provider is a registry config value, so that is an edit and a restart, no
-deploy. **Rehearse this once before switching real traffic over.**
+down when Mycel is down. To un-break one, point it back at OpenRouter: its
+provider is a registry config value, so that is an edit and a restart, no deploy.
+**Rehearse this once before switching real traffic over.**
 
 ## Diagnosing
 
-1. `/health` — store reachability first.
-2. Cloud Logging, filtered on container `mycel`. The gcplogs driver is the
+1. **`/health`** — store reachability first.
+   ```json
+   { "status": "ok" }
+   { "status": "degraded", "store": "…" }   // 503
+   ```
+   A service that answers while its database is gone is worse than one that does
+   not answer, because Dispatch keeps sending it traffic.
+2. **Cloud Logging**, filtered on container `mycel`. The gcplogs driver is the
    daemon default on this host, so nothing extra is configured.
-3. A failed dispatch carries a `considered` list: every Offer weighed and why
+3. **The `considered` list** on a failed dispatch: every Offer weighed and why
    each was rejected. "Why did this request go there" is otherwise unanswerable
    after the fact.
-4. `umwelten mycel balance <client>` prints the balance **and** the entries that
-   sum to it. A Balance is never a stored total, so showing both is the check as
-   well as the report.
+4. **`mycel balance <client>`** prints the balance *and* the entries summing to
+   it. A Balance is never a stored total, so showing both is the check as well as
+   the report.
 
-### The failure that will look like a bug first
+### The one that will look like a bug first
 
-**Offers vanishing after fifteen minutes.** Dispatch drops an Offer that has not
-been republished within the staleness window. A machine's agent heartbeats every
-five minutes; a commercial vendor has no agent, so `offers sync --watch` is what
-heartbeats for it. If that process dies, the vendor's Offers expire — which is
-correct behaviour, because a dead sync means we no longer know the vendor's
-state either.
+**Offers vanishing after fifteen minutes.** Symptom: `no_offer` on every request
+for a vendor model, with a `considered` list showing `offer-stale`.
 
-Symptom: `no_offer` on every request for a vendor model, with a `considered`
-list showing `offer-stale`.
+Dispatch drops an Offer not republished within the staleness window. A machine's
+agent heartbeats every five minutes; a vendor has no agent, so
+`offers sync --watch` is what heartbeats for it. If that process died, the
+Offers expire — which is correct, because a dead sync means we no longer know
+the vendor's state either.
 
-### Other likely ones
+### The others worth knowing
 
 **402 on a request you expected to work.** A charge falls through End User →
-Application → Client, stopping at the first with any ledger entry. If a user was
-ever granted anything they are *capped* at it and stay capped once spent — they
-do not fall back to the pool. Check `umwelten mycel balance <user> --application`
+Application → Client, stopping at the first with any ledger entry. A user who
+was ever granted anything is *capped* at it and stays capped once spent — they
+do not fall back to the pool. Check `mycel balance <app>:<user> --application`
 before assuming the Client's balance covers it.
 
-**401 with a valid-looking credential.** A static credential also needs
+**401 with a credential that looks right.** A static credential also needs
 `X-Mycel-End-User`. There is no fallback to the Application's own id, on purpose:
 a caller that forgot the header would otherwise have its whole estate attributed
-to one subject.
+to one subject, and per-user caps would quietly stop being per-user.
 
-**Cost of 0 with a non-zero Charge.** Correct. Charge is independent of Cost
+**A Cost of 0 with a non-zero Charge.** Correct. Charge is independent of Cost
 (ADR 0013), and hardware the operator owns costs nothing to buy from.

--- a/deploy/mycel/README.md
+++ b/deploy/mycel/README.md
@@ -59,27 +59,49 @@ Money is integer micro-dollars everywhere. `50000000` is $50.00.
 ## Deploying a change
 
 ```bash
-docker build -t mycel -f packages/mycel/Dockerfile .
-docker compose --project-directory deploy/mycel up -d
-curl https://mycel.thefocus.ai/health
+./deploy/mycel/deploy.sh
 ```
 
-Deliberate, and **not** part of `deploy/gaia/redeploy.sh`. Mycel is not cycled
-by a push to umwelten main — that separation is the whole reason it is a peer of
-Gaia rather than a habitat Gaia manages.
+That is the whole thing. It tags the running image so there is something to roll
+back to, builds, recreates the container, and waits for `/health` to report the
+**store** reachable. If it never gets there it prints the logs and **rolls back
+by itself** — the alternative is a broken Exchange sitting there while somebody
+reads a scrollback.
 
-## Rolling back
+Deliberate, and **not** part of `deploy/gaia/redeploy.sh`. Mycel is not cycled by
+a push to umwelten main — that separation is the whole reason it is a peer of
+Gaia rather than a habitat Gaia manages. Deploying it is something a person
+decides to do.
 
-Tag before you replace, and keep the previous tag for a day:
+## Rolling back by hand
+
+The script does this automatically on a failed deploy. To go back later:
 
 ```bash
-docker tag mycel mycel:$(date +%Y%m%d)
-# …build, deploy, regret…
-docker tag mycel:20260807 mycel && docker compose --project-directory deploy/mycel up -d
+docker tag mycel:previous mycel
+docker compose --project-directory deploy/mycel up -d
 ```
 
 State is in Neon, so a rollback loses nothing. That is the payoff for the
 service holding no volume.
+
+## Running an operator command
+
+The container already has `MYCEL_DATABASE_URL` resolved, so the least
+error-prone place to run these is inside it — no connection string on your
+shell, no chance of pointing at the wrong database:
+
+```bash
+docker compose --project-directory deploy/mycel exec mycel \
+  pnpm exec tsx packages/cli/src/entry.ts mycel balance the-focus-ai
+```
+
+Worth an alias on the host:
+
+```bash
+alias mycel='docker compose --project-directory /opt/umwelten/deploy/mycel exec mycel pnpm exec tsx packages/cli/src/entry.ts mycel'
+mycel grant the-focus-ai 50000000
+```
 
 ## Stopping
 

--- a/deploy/mycel/README.md
+++ b/deploy/mycel/README.md
@@ -1,0 +1,133 @@
+# Running Mycel
+
+Start, stop, roll back, and diagnose. The reasoning behind the shape is
+`docs/architecture/mycel-deployment.md`; this is the operating manual.
+
+## First time
+
+```bash
+docker network create gaia-net           # already exists if Gaia is running
+docker build -t mycel -f packages/mycel/Dockerfile .
+cp deploy/mycel/.env.example deploy/mycel/.env   # then fill it in
+docker compose --project-directory deploy/mycel up -d
+curl https://mycel.thefocus.ai/health
+```
+
+`/health` reports whether the **store** is reachable, not merely whether the
+process is up:
+
+```json
+{ "status": "ok" }
+{ "status": "degraded", "store": "…" }   // 503
+```
+
+A service that answers while its database is gone is worse than one that does
+not answer, because Dispatch keeps sending it traffic.
+
+**Run the store conformance suite against a Neon branch before the first boot.**
+`serve` runs the schema DDL on start, so otherwise the deploy is the first time
+that code has ever executed:
+
+```bash
+MYCEL_DATABASE_URL='postgres://…branch…' \
+  pnpm vitest run packages/mycel/src/store/neon-store.integration.test.ts
+```
+
+## Onboarding
+
+```bash
+# A Supplier. The credential-env is the NAME of an env var, never the key.
+umwelten mycel supplier register openrouter \
+  --display-name "OpenRouter" \
+  --base-url https://openrouter.ai/api/v1 \
+  --credential-env OPENROUTER_API_KEY
+
+# Its catalogue. A vendor runs no agent, so the operator publishes for it —
+# and this must keep running, because it IS the heartbeat.
+umwelten mycel offers sync openrouter \
+  --models anthropic/claude-sonnet-5,google/gemini-3-flash-preview \
+  --watch 5
+
+# A buyer.
+umwelten mycel client create the-focus-ai --name "The Focus AI"
+umwelten mycel application create help-habitat --client the-focus-ai
+umwelten mycel grant the-focus-ai 50000000        # $50
+```
+
+Money is integer micro-dollars everywhere. `50000000` is $50.00.
+
+## Deploying a change
+
+```bash
+docker build -t mycel -f packages/mycel/Dockerfile .
+docker compose --project-directory deploy/mycel up -d
+curl https://mycel.thefocus.ai/health
+```
+
+Deliberate, and **not** part of `deploy/gaia/redeploy.sh`. Mycel is not cycled
+by a push to umwelten main — that separation is the whole reason it is a peer of
+Gaia rather than a habitat Gaia manages.
+
+## Rolling back
+
+Tag before you replace, and keep the previous tag for a day:
+
+```bash
+docker tag mycel mycel:$(date +%Y%m%d)
+# …build, deploy, regret…
+docker tag mycel:20260807 mycel && docker compose --project-directory deploy/mycel up -d
+```
+
+State is in Neon, so a rollback loses nothing. That is the payoff for the
+service holding no volume.
+
+## Stopping
+
+```bash
+docker compose --project-directory deploy/mycel stop
+```
+
+Buyers get connection failures, which is correct — a habitat pointed at Mycel is
+down when Mycel is down. To un-break one, point it back at OpenRouter directly:
+its provider is a registry config value, so that is an edit and a restart, no
+deploy. **Rehearse this once before switching real traffic over.**
+
+## Diagnosing
+
+1. `/health` — store reachability first.
+2. Cloud Logging, filtered on container `mycel`. The gcplogs driver is the
+   daemon default on this host, so nothing extra is configured.
+3. A failed dispatch carries a `considered` list: every Offer weighed and why
+   each was rejected. "Why did this request go there" is otherwise unanswerable
+   after the fact.
+4. `umwelten mycel balance <client>` prints the balance **and** the entries that
+   sum to it. A Balance is never a stored total, so showing both is the check as
+   well as the report.
+
+### The failure that will look like a bug first
+
+**Offers vanishing after fifteen minutes.** Dispatch drops an Offer that has not
+been republished within the staleness window. A machine's agent heartbeats every
+five minutes; a commercial vendor has no agent, so `offers sync --watch` is what
+heartbeats for it. If that process dies, the vendor's Offers expire — which is
+correct behaviour, because a dead sync means we no longer know the vendor's
+state either.
+
+Symptom: `no_offer` on every request for a vendor model, with a `considered`
+list showing `offer-stale`.
+
+### Other likely ones
+
+**402 on a request you expected to work.** A charge falls through End User →
+Application → Client, stopping at the first with any ledger entry. If a user was
+ever granted anything they are *capped* at it and stay capped once spent — they
+do not fall back to the pool. Check `umwelten mycel balance <user> --application`
+before assuming the Client's balance covers it.
+
+**401 with a valid-looking credential.** A static credential also needs
+`X-Mycel-End-User`. There is no fallback to the Application's own id, on purpose:
+a caller that forgot the header would otherwise have its whole estate attributed
+to one subject.
+
+**Cost of 0 with a non-zero Charge.** Correct. Charge is independent of Cost
+(ADR 0013), and hardware the operator owns costs nothing to buy from.

--- a/deploy/mycel/deploy.sh
+++ b/deploy/mycel/deploy.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Deploy Mycel onto the current checkout.
+#
+# Deliberately NOT called by deploy/gaia/redeploy.sh. Mycel is a peer of Gaia,
+# not a habitat Gaia manages, and the whole point of that separation is that a
+# push to umwelten main does not cycle the service holding the money ledger.
+# Deploying Mycel is something a person decides to do.
+#
+# What it does:
+#   1. Tag the image currently running, so there is something to roll back to
+#   2. Build from the repo root
+#   3. Recreate the container via compose
+#   4. Wait for /health to report the STORE reachable, not just the process up
+#   5. Roll back automatically if it never gets there
+#
+# Requires: docker (daemon access), curl. Run as a user in the docker group.
+#
+# Runbook: deploy/mycel/README.md
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="${MYCEL_ENV_FILE:-$SCRIPT_DIR/.env}"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "error: env file not found: $ENV_FILE" >&2
+  echo "hint: cp $SCRIPT_DIR/.env.example $ENV_FILE and fill it in" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+: "${MYCEL_HOSTNAME:?MYCEL_HOSTNAME must be set in $ENV_FILE}"
+
+URL="https://$MYCEL_HOSTNAME"
+PREVIOUS="mycel:previous"
+
+log() { echo "[mycel] $*"; }
+
+# Health is not "did the container start". It asks whether the store is
+# reachable, because a Mycel that answers while Neon is gone will happily take
+# requests it cannot meter.
+wait_for_health() {
+  local timeout="$1" deadline=$((SECONDS + timeout))
+  until curl -sf --max-time 5 "$URL/health" | grep -q '"status":"ok"'; do
+    if ((SECONDS >= deadline)); then return 1; fi
+    sleep 2
+  done
+}
+
+# Keep the outgoing image addressable before it is replaced. Rolling back is
+# then a retag and a restart, and costs nothing to have prepared.
+if docker image inspect mycel >/dev/null 2>&1; then
+  docker tag mycel "$PREVIOUS"
+  log "tagged the running image as $PREVIOUS"
+  HAVE_PREVIOUS=1
+else
+  log "no existing image — this is a first deploy, nothing to roll back to"
+  HAVE_PREVIOUS=0
+fi
+
+log "building from $ROOT"
+docker build -t mycel -f "$ROOT/packages/mycel/Dockerfile" "$ROOT"
+
+log "recreating the container"
+docker compose --project-directory "$SCRIPT_DIR" --env-file "$ENV_FILE" up -d
+
+log "waiting for $URL/health"
+if wait_for_health 90; then
+  log "healthy — store reachable"
+  log "done"
+  exit 0
+fi
+
+echo "error: never became healthy within 90s" >&2
+docker compose --project-directory "$SCRIPT_DIR" logs --tail 40 mycel >&2 || true
+
+if ((HAVE_PREVIOUS == 0)); then
+  echo "error: no previous image to roll back to; leaving it stopped" >&2
+  docker compose --project-directory "$SCRIPT_DIR" stop || true
+  exit 1
+fi
+
+# Automatic, because the alternative is a broken Exchange sitting there while
+# somebody reads the logs. State is in Neon, so rolling back loses nothing.
+log "rolling back to $PREVIOUS"
+docker tag "$PREVIOUS" mycel
+docker compose --project-directory "$SCRIPT_DIR" --env-file "$ENV_FILE" up -d
+
+if wait_for_health 90; then
+  log "rolled back and healthy — the new image is the problem, not the host"
+  exit 1
+fi
+
+echo "error: the previous image is not healthy either — look at Neon first" >&2
+exit 1

--- a/deploy/mycel/docker-compose.yml
+++ b/deploy/mycel/docker-compose.yml
@@ -1,0 +1,59 @@
+# Mycel — the Exchange.
+#
+# A PEER of Gaia on the same host, not a child of it. Deliberately its own
+# compose file rather than a service inside deploy/gaia/docker-compose.yml,
+# because the whole argument for Mycel not being a Gaia-managed habitat is
+# separate deploy cadence — sharing a file means `docker compose up -d` for a
+# Gaia change cycles the service that holds the money ledger.
+#
+# What it therefore does NOT get, on purpose:
+#   - cycled by deploy/gaia/redeploy.sh on every push to umwelten main
+#   - a named volume (its state is in Neon; it writes nothing to disk)
+#   - Gaia's master vault (it resolves its own secrets — see below)
+#
+# What it shares with everything else on the host:
+#   - gaia-net, so caddy reaches it by container DNS
+#   - the gcplogs docker daemon default, so stdout lands in Cloud Logging
+#
+# Prereqs:
+#   docker build -t mycel -f packages/mycel/Dockerfile .
+#   an A record for MYCEL_HOSTNAME → this host's static IP
+#
+# Runbook: deploy/mycel/README.md · design: docs/architecture/mycel-deployment.md
+
+services:
+  mycel:
+    image: mycel
+    container_name: mycel
+    restart: unless-stopped
+    networks:
+      - gaia-net
+    environment:
+      MYCEL_PORT: ${MYCEL_PORT:-7438}
+      # Resolved by fnox at start (see command below) rather than set here, so
+      # no plaintext lives in this file or in a .env on the host.
+      MYCEL_DATABASE_URL: ${MYCEL_DATABASE_URL:-}
+      # Upstream keys. A Supplier record stores the NAME of one of these, never
+      # the value — so a database compromise hands over nothing that can spend.
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
+    labels:
+      caddy: ${MYCEL_HOSTNAME:-mycel.localhost}
+      caddy.reverse_proxy: "{{upstreams 7438}}"
+    # fnox resolves the secrets above from 1Password at start. Its own scope,
+    # not Gaia's: Gaia is the sole broker for *habitats*, and Mycel is not one.
+    # Keeping the master vault off the money service's dependency path is the
+    # same blast-radius argument as giving it its own Neon project.
+    command:
+      - sh
+      - -c
+      - >
+        fnox exec --
+        pnpm exec tsx packages/cli/src/entry.ts mycel serve --port "$$MYCEL_PORT"
+
+networks:
+  # Created once on the host by `docker network create gaia-net`; external
+  # because DockerManager makes it without compose labels.
+  gaia-net:
+    name: gaia-net
+    external: true

--- a/docs/architecture/mycel-deployment.md
+++ b/docs/architecture/mycel-deployment.md
@@ -318,13 +318,22 @@ looks like success:
 
 ## Part 7 — Running it
 
-**Deploy a change.** Build, `docker compose up -d mycel`, `curl /health`. It is a
-deliberate act — Mycel is *not* cycled by `redeploy.sh`, which is the entire
-argument for it being a peer of Gaia rather than a child.
+**Deploy a change.** `./deploy/mycel/deploy.sh` — tag, build, recreate, wait for
+health, roll back automatically if it never gets there. A deliberate act: Mycel
+is *not* cycled by `redeploy.sh`, which is the entire argument for it being a
+peer of Gaia rather than a child.
 
-**Roll back.** `docker compose up -d` on the previous image tag. State is in
-Neon, so a rollback loses nothing. Keep the previous tag until the new one has
-served for a day.
+**Roll back.** The script does it on a failed deploy. By hand later:
+`docker tag mycel:previous mycel` and `up -d`. State is in Neon, so a rollback
+loses nothing.
+
+**Where the image is built.** On the host, today, matching how Gaia's images are
+built. That is a known liability rather than a good idea — the GCP report traces
+disk pressure on this host to exactly this (6.8 GB of images plus 5.3 GB of build
+cache), and Stage 2 of that plan moves to Cloud Build plus Artifact Registry so
+prod pulls instead of building. Mycel is the natural first service to move,
+having no legacy to carry, but building on the host is what works today and is
+not worth blocking the first deploy on.
 
 **Stop.** `docker compose stop mycel` — buyers get connection failures, which is
 correct: a habitat pointed at Mycel is down when Mycel is down. Point it back at

--- a/docs/architecture/mycel-deployment.md
+++ b/docs/architecture/mycel-deployment.md
@@ -36,9 +36,11 @@ Stage 1 cannot run today. These are the gaps, smallest first.
 | 1 | ~~No entrypoint.~~ **Built.** `umwelten mycel serve`. | — |
 | 2 | ~~No static-credential auth.~~ **Built.** `sk-mycel-…` + `X-Mycel-End-User`, alongside JWKS. | — |
 | 3 | ~~No operator CLI.~~ **Built.** `umwelten mycel client/application/grant/balance/supplier`. | — |
-| 4 | **No way to publish a commercial vendor's catalogue.** The supply endpoint takes a Supplier credential and expects an agent. Nothing lists OpenRouter's models as Offers. | No Offers to dispatch to. |
-| 5 | **No Dockerfile / compose service.** | Nothing to deploy. |
-| 6 | **Port 7450 collides** with Gaia's managed-container range (7440–7499) and with the supplier agent's own runtime default. | Port fight on the host. |
+| 4 | ~~No way to publish a vendor's catalogue.~~ **Built.** `umwelten mycel offers sync --watch`. | — |
+| 5 | ~~No Dockerfile / compose service.~~ **Built.** `packages/mycel/Dockerfile`, `deploy/mycel/`. | — |
+| 6 | ~~Port 7450 collides.~~ **Fixed.** Mycel 7438, supplier runtime 7439 — both below Gaia's 7440. | — |
+
+Everything above is built. **Stage 1 is blocked only on the Neon project.**
 
 Proposed shape for #2 and #3, since they are design and not just plumbing:
 
@@ -179,8 +181,8 @@ deploy/mycel/
 would be free, but Mycel is not a habitat and putting it under that wildcard says
 it is. One A record at the same static IP; caddy issues the cert from the label.
 
-**Port: 7460.** Outside Gaia's 7440–7499 managed range. The supplier agent's
-managed-runtime default moves to 7461 in the same change.
+**Port: 7438.** Below 7440, where Gaia starts assigning ports to managed containers. The supplier agent's
+managed-runtime default moves to 7439 in the same change.
 
 Logging needs nothing: `gcplogs` is the daemon default on that host, so Mycel's
 stdout lands in Cloud Logging beside everything else.

--- a/docs/architecture/mycel-deployment.md
+++ b/docs/architecture/mycel-deployment.md
@@ -1,6 +1,6 @@
 # Deploying Mycel
 
-> Status: plan — 2026-08-07. The runbook for putting the Exchange
+> Status: built, undeployed — 2026-08-07. The runbook for putting the Exchange
 > (`packages/mycel`) into the runtime plane, from nothing to metered traffic.
 > Companion to `production-topology.md` (the three planes) and
 > `packages/mycel/CONTEXT.md` (the vocabulary).
@@ -27,50 +27,44 @@ Stage 3 is identity only.
 
 ---
 
-## Part 0 — What has to be built first
+## Part 0 — What this needed, and what shipped
 
-Stage 1 cannot run today. These are the gaps, smallest first.
+Stage 1 could not run when this was written. Everything below is now built, and
+**stage 1 is blocked only on the Neon project.**
 
-| # | Gap | Why it blocks |
-|---|---|---|
-| 1 | ~~No entrypoint.~~ **Built.** `umwelten mycel serve`. | — |
-| 2 | ~~No static-credential auth.~~ **Built.** `sk-mycel-…` + `X-Mycel-End-User`, alongside JWKS. | — |
-| 3 | ~~No operator CLI.~~ **Built.** `umwelten mycel client/application/grant/balance/supplier`. | — |
-| 4 | ~~No way to publish a vendor's catalogue.~~ **Built.** `umwelten mycel offers sync --watch`. | — |
-| 5 | ~~No Dockerfile / compose service.~~ **Built.** `packages/mycel/Dockerfile`, `deploy/mycel/`. | — |
-| 6 | ~~Port 7450 collides.~~ **Fixed.** Mycel 7438, supplier runtime 7439 — both below Gaia's 7440. | — |
+| Was missing | Now |
+|---|---|
+| An entrypoint — `createExchangeServer` was a library function | `umwelten mycel serve` |
+| Any auth a habitat could use — JWKS only, and a habitat has no signing key | `sk-mycel-…` + `X-Mycel-End-User`, alongside JWKS |
+| A way to onboard anyone or fund a balance | `mycel client` / `application` / `grant` / `balance` |
+| A way to publish a vendor's catalogue — the supply endpoint expects an agent | `mycel offers sync --watch` |
+| A container and a compose service | `packages/mycel/Dockerfile`, `deploy/mycel/` |
+| A port outside Gaia's managed range | Mycel 7438, supplier runtime 7439 |
 
-Everything above is built. **Stage 1 is blocked only on the Neon project.**
+Two of those were design rather than plumbing, and the reasoning is worth
+keeping.
 
-Proposed shape for #2 and #3, since they are design and not just plumbing:
-
-```
-umwelten mycel serve                                  # the service
-umwelten mycel client create <id> --name "Acme"
-umwelten mycel application create <id> --client acme  # prints a credential, once
-umwelten mycel application create <id> --client acme --jwks-url https://…
-umwelten mycel grant <client|application> <micro-dollars>
-umwelten mycel supplier register <id> --base-url … --credential-env OPENROUTER_API_KEY
-umwelten mycel offers sync --supplier openrouter --models a,b,c
-umwelten mycel status
-```
-
-**Static credentials, alongside JWKS, not instead of it.** An Application either
-publishes a JWKS (the SaaS already does, per ADR 0003) or holds a credential
-stored hashed — the same `credentialHash` pattern Suppliers already use. With a
-static credential the End User arrives in a header:
+**Static credentials, alongside JWKS rather than instead of it.** An Application
+either publishes a JWKS (the SaaS already does, per ADR 0003) or holds a
+credential stored hashed — the same pattern Suppliers already use. With a static
+credential the End User arrives in a header:
 
 ```
 Authorization: Bearer sk-mycel-…
 X-Mycel-End-User: user-1234
 ```
 
-This is not the security downgrade it appears to be. **The JWT never
-authenticated the End User** — ADR 0014 has Mycel trust the Application's
-assertion of `sub` either way. The signature only proves *which Application* is
-calling, which a hashed bearer also proves. What the JWT genuinely buys is short
-expiry and no spendable secret at rest in Mycel's database, which is why it stays
-the recommended path for anyone who can run a JWKS endpoint.
+This is not the downgrade it looks like. **The JWT never authenticated the End
+User** — ADR 0014 has Mycel trust the Application's assertion of `sub` either
+way, so a signature only ever proved *which Application* was calling, which a
+hashed bearer proves too. What the JWT genuinely buys is short expiry and no
+spendable secret at rest, which is why it stays recommended for anyone able to
+serve a JWKS.
+
+**No HTTP admin API.** The operator surface is a CLI on the box. These
+operations run rarely, by one person, and each can move money or grant
+eligibility for traffic the operator is liable for (ADR 0012) — a route is a
+larger surface than a command, and the convenience is not worth securing.
 
 ---
 
@@ -207,13 +201,13 @@ A commercial vendor and a box on a desk are the same kind of thing here
 the agent, and a vendor has its catalogue published on its behalf.
 
 ```bash
-umwelten mycel supplier register openrouter \
+mycel supplier register openrouter \
   --display-name "OpenRouter" \
   --base-url https://openrouter.ai/api/v1 \
   --credential-env OPENROUTER_API_KEY \
   --guarantees ""          # a commercial vendor gets none by default
 
-umwelten mycel offers sync --supplier openrouter --models \
+mycel offers sync openrouter --watch 5 --models \
   anthropic/claude-sonnet-5,google/gemini-3-flash-preview
 ```
 
@@ -228,7 +222,7 @@ control means.
 lever:
 
 ```bash
-umwelten mycel price openrouter anthropic/claude-sonnet-5 \
+mycel price openrouter anthropic/claude-sonnet-5 \
   --wholesale-prompt 3000000 --wholesale-completion 15000000 \
   --retail-prompt   3600000 --retail-completion  18000000
 ```
@@ -251,11 +245,11 @@ Application, so there is no billing — this is internal accounting that proves
 the meter.
 
 ```bash
-umwelten mycel client create the-focus-ai --name "The Focus AI"
-umwelten mycel application create help-habitat --client the-focus-ai
+mycel client create the-focus-ai --name "The Focus AI"
+mycel application create help-habitat --client the-focus-ai
 # → sk-mycel-…   shown once, never recoverable
 
-umwelten mycel grant the-focus-ai 50000000        # $50 of credit
+mycel grant the-focus-ai 50000000        # $50 of credit
 ```
 
 Then point the habitat at it — a `secretBindings` change in the Gaia registry:
@@ -286,7 +280,7 @@ The point of the whole exercise. After a handful of turns through the switched
 habitat:
 
 ```bash
-umwelten mycel usage --application help-habitat
+mycel balance the-focus-ai
 ```
 
 Each request should show application, subject, supplier, model, prompt and

--- a/packages/core/src/providers/mycel.ts
+++ b/packages/core/src/providers/mycel.ts
@@ -23,7 +23,7 @@ import type { LanguageModel } from "ai";
 import { BaseProvider } from "./base.js";
 import type { ModelDetails, ModelRoute } from "../cognition/types.js";
 
-const DEFAULT_BASE_URL = "http://localhost:7450";
+const DEFAULT_BASE_URL = "http://localhost:7438";
 
 /** Shape of `GET /v1/models` on the Exchange. Duplicated rather than imported. */
 interface MycelModelEntry {

--- a/packages/mycel/Dockerfile
+++ b/packages/mycel/Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1.4
+#
+# Mycel — the Exchange.
+#
+# Build (from monorepo root):
+#   docker build -t mycel -f packages/mycel/Dockerfile .
+#
+# Run:
+#   docker run -p 7438:7438 -e MYCEL_DATABASE_URL=postgres://… mycel
+#
+# Deliberately NOT built on packages/habitat/Dockerfile. That image carries the
+# Docker CLI, mise, git and ripgrep because a habitat clones repos and runs
+# toolchains. Mycel is an HTTP service over Postgres: it clones nothing, spawns
+# nothing, and needs no volume — its state is in Neon. Every one of those tools
+# would be attack surface on the one service that holds the money ledger.
+
+FROM node:22-slim AS build
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable && corepack prepare pnpm@9.15.5 --activate
+
+WORKDIR /app
+
+# Manifests first, so a source-only change does not reinstall the world.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/core/package.json                packages/core/
+COPY packages/protocols/package.json           packages/protocols/
+COPY packages/sessions/package.json            packages/sessions/
+COPY packages/evaluation/package.json          packages/evaluation/
+COPY packages/habitat/package.json             packages/habitat/
+COPY packages/ui/package.json                  packages/ui/
+COPY packages/mycel/package.json               packages/mycel/
+COPY packages/supplier/package.json            packages/supplier/
+COPY packages/cli/package.json                 packages/cli/
+COPY packages/umwelten/package.json            packages/umwelten/
+
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+FROM node:22-slim
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+ENV NODE_ENV=production
+RUN corepack enable && corepack prepare pnpm@9.15.5 --activate
+
+# curl for the container healthcheck below; nothing else is needed at runtime.
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=build /app /app
+
+# Not root. Mycel writes nothing to disk, so there is no reason for it to be
+# able to.
+RUN useradd --system --uid 10001 mycel && chown -R mycel:mycel /app
+USER mycel
+
+ENV MYCEL_PORT=7438
+EXPOSE 7438
+
+# Reports whether the store is reachable, not merely whether the process is up:
+# a service that answers while its database is gone is worse than one that does
+# not answer, because Dispatch keeps sending it traffic.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD curl -fsS http://127.0.0.1:7438/health || exit 1
+
+CMD ["pnpm", "exec", "tsx", "packages/cli/src/entry.ts", "mycel", "serve"]

--- a/packages/mycel/src/command.ts
+++ b/packages/mycel/src/command.ts
@@ -16,13 +16,10 @@ import { Command } from "commander";
 import { NeonStore } from "./store/neon-store.js";
 import { MemoryStore } from "./store/memory-store.js";
 import { Operator } from "./operator.js";
-import { createExchangeServer } from "./server.js";
+import { DEFAULT_PORT, createExchangeServer } from "./server.js";
 import { Balances, applicationOwner, clientOwner } from "./metering/balances.js";
 import type { ExchangeStore } from "./store/types.js";
-import type { MicroDollars } from "./types.js";
-
-/** Mycel's port. Outside Gaia's managed-container range (7440–7499). */
-export const DEFAULT_PORT = 7460;
+import type { MicroDollars, PublishedOffer } from "./types.js";
 
 interface CliOptions {
   port?: string;
@@ -298,5 +295,90 @@ supplier
       );
       console.log(`\n  ${credential}\n`);
       console.log("Shown once. The agent presents it when publishing Offers.");
+    })(opts);
+  });
+
+const offers = mycelCommand.command("offers").description("What a Supplier is selling");
+
+/**
+ * Default Capability set for a vendor Offer.
+ *
+ * Every mainstream hosted model does these. Anything narrower has to be stated,
+ * and anything broader — tool calling, structured output, reasoning — is per
+ * model and per vendor, so it is opt-in rather than assumed. Over-claiming here
+ * has Dispatch route a tool-calling request somewhere that cannot serve it,
+ * which is the failure ADR 0015 exists to prevent.
+ */
+const DEFAULT_VENDOR_CAPABILITIES = ["chat", "streaming"];
+
+offers
+  .command("sync <supplierId>")
+  .description("Publish a vendor's Models as Offers, on its behalf")
+  .option("--models <names>", "Models to resell, comma-separated")
+  .option("--capabilities <names>", "Applied to every Model", DEFAULT_VENDOR_CAPABILITIES.join(","))
+  .option(
+    "--watch <minutes>",
+    "Keep republishing. A vendor runs no agent, so this IS its heartbeat",
+  )
+  .option("--database <url>")
+  .action(async (supplierId: string, opts: CliOptions & { capabilities?: string; watch?: string }) => {
+    await action(async () => {
+      const models = list(opts.models);
+      if (models.length === 0) {
+        throw new MycelCliError(
+          "Which Models? Pass --models.\n" +
+            "  A curated list, not a whole catalogue: every Offer is a claim, and these\n" +
+            "  are declared rather than probed.",
+        );
+      }
+
+      const operator = new Operator(openStore(opts));
+      const capabilities = list(opts.capabilities) as PublishedOffer["capabilities"];
+
+      const publish = async () => {
+        await operator.publishOffersFor(
+          supplierId,
+          models.map((model) => ({ model, capabilities, servingMode: "adapted" as const })),
+        );
+      };
+
+      await publish();
+      console.log(`Published ${models.length} offer(s) for ${supplierId}: ${models.join(", ")}`);
+      console.log(`Capabilities (declared, not probed): ${capabilities.join(", ")}`);
+
+      if (!opts.watch) {
+        // Said plainly, because it is the first thing that will look like a bug:
+        // Dispatch drops an Offer that has not been republished recently, and a
+        // vendor has no agent heartbeating for it.
+        console.log(
+          "\n⚠ One-shot. Offers not republished within the staleness window stop being\n" +
+            "  dispatched to. Run with --watch <minutes> as a service, or schedule this.",
+        );
+        return;
+      }
+
+      const minutes = Number(opts.watch);
+      if (!Number.isFinite(minutes) || minutes <= 0) {
+        throw new MycelCliError(`"${opts.watch}" is not a number of minutes.`);
+      }
+      console.log(`\nRepublishing every ${minutes}m. This is the heartbeat — if it stops,`);
+      console.log("the Offers expire, which is correct: we no longer know the vendor's state.");
+
+      const timer = setInterval(() => {
+        void publish().catch((error) => {
+          // Keep beating. One failed republish is survivable; giving up is not,
+          // because the Offers then expire for a vendor that is probably fine.
+          console.error(`republish failed: ${error instanceof Error ? error.message : error}`);
+        });
+      }, minutes * 60_000);
+
+      await new Promise<void>((resolve) => {
+        const stop = () => {
+          clearInterval(timer);
+          resolve();
+        };
+        process.once("SIGINT", stop);
+        process.once("SIGTERM", stop);
+      });
     })(opts);
   });

--- a/packages/mycel/src/command.ts
+++ b/packages/mycel/src/command.ts
@@ -35,6 +35,10 @@ interface CliOptions {
   application?: string;
   reason?: string;
   ephemeral?: boolean;
+  wholesalePrompt?: string;
+  wholesaleCompletion?: string;
+  retailPrompt?: string;
+  retailCompletion?: string;
 }
 
 class MycelCliError extends Error {}
@@ -80,20 +84,31 @@ function list(raw: string | undefined): string[] {
   return (raw ?? "").split(",").map((s) => s.trim()).filter(Boolean);
 }
 
-/** Run an action, reporting an operator error as a message rather than a stack. */
-function action(run: (opts: CliOptions) => Promise<void>) {
-  return async (opts: CliOptions) => {
-    try {
-      await run(opts);
-    } catch (error) {
-      if (error instanceof MycelCliError) {
-        console.error(error.message);
-        process.exitCode = 1;
-        return;
-      }
-      throw error;
+/**
+ * Report an operator error as a message rather than a stack.
+ *
+ * Everything here is run by a person at a terminal, usually while something is
+ * already wrong. A stack trace tells them nothing they can act on.
+ */
+async function guard(run: () => Promise<void>): Promise<void> {
+  try {
+    await run();
+  } catch (error) {
+    if (error instanceof MycelCliError) {
+      console.error(error.message);
+      process.exitCode = 1;
+      return;
     }
-  };
+    throw error;
+  }
+}
+
+/** Every operator command needs the store, and they all reach it the same way. */
+function withDatabase(command: Command): Command {
+  return command.option(
+    "--database <url>",
+    "Postgres connection string (or MYCEL_DATABASE_URL)",
+  );
 }
 
 export const mycelCommand = new Command("mycel")
@@ -121,8 +136,8 @@ mycelCommand
   .option("--port <port>", "Port to listen on", String(DEFAULT_PORT))
   .option("--database <url>", "Postgres connection string (or MYCEL_DATABASE_URL)")
   .option("--ephemeral", "Run against memory — loses every balance on exit")
-  .action(
-    action(async (opts) => {
+  .action(async (opts: CliOptions) => {
+    await guard(async () => {
       const store = openStore(opts);
       const port = Number(opts.port ?? DEFAULT_PORT);
 
@@ -138,41 +153,37 @@ mycelCommand
       };
       process.once("SIGINT", () => void stop());
       process.once("SIGTERM", () => void stop());
-    }),
-  );
+    });
+  });
 
 // ── Demand ───────────────────────────────────────────────────────────────────
 
 const client = mycelCommand.command("client").description("Clients you invoice");
 
-client
-  .command("create <id>")
+withDatabase(client.command("create <id>"))
   .description("Record a commercial relationship that already exists")
   .option("--name <name>", "Display name")
-  .option("--database <url>")
   .action(async (id: string, opts: CliOptions) => {
-    await action(async () => {
+    await guard(async () => {
       const operator = new Operator(openStore(opts));
       const created = await operator.createClient(id, opts.name ?? id);
       console.log(`Created client ${created.id} (${created.name}).`);
       console.log("There is no signup — a Client is onboarded by contract (ADR 0012).");
-    })(opts);
+    });
   });
 
 const application = mycelCommand
   .command("application")
   .description("Products built on the Exchange");
 
-application
-  .command("create <id>")
+withDatabase(application.command("create <id>"))
   .description("Create an Application and issue its credential")
   .option("--client <id>", "Owning Client")
   .option("--jwks-url <url>", "Publish keys instead of holding a static credential")
   .option("--guarantees <names>", "Required on every request from this Application")
   .option("--models <names>", "Restrict to these Models")
-  .option("--database <url>")
   .action(async (id: string, opts: CliOptions) => {
-    await action(async () => {
+    await guard(async () => {
       if (!opts.client) throw new MycelCliError("Which Client owns it? Pass --client.");
       const operator = new Operator(openStore(opts));
       const { application: app, credential } = await operator.createApplication({
@@ -198,32 +209,28 @@ application
       console.log("Callers send it as a bearer token, with the End User in a header:");
       console.log("  Authorization: Bearer <credential>");
       console.log("  X-Mycel-End-User: <your user id>");
-    })(opts);
+    });
   });
 
-application
-  .command("rotate <id>")
+withDatabase(application.command("rotate <id>"))
   .description("Issue a new credential, invalidating the old one")
-  .option("--database <url>")
   .action(async (id: string, opts: CliOptions) => {
-    await action(async () => {
+    await guard(async () => {
       const operator = new Operator(openStore(opts));
       const credential = await operator.rotateApplicationCredential(id);
       console.log(`\n  ${credential}\n`);
       console.log("The previous credential stopped working the moment this was issued.");
-    })(opts);
+    });
   });
 
 // ── Money ────────────────────────────────────────────────────────────────────
 
-mycelCommand
-  .command("grant <owner> <microDollars>")
+withDatabase(mycelCommand.command("grant <owner> <microDollars>"))
   .description("Add credit to a Client or Application balance")
   .option("--application", "Treat <owner> as an Application rather than a Client")
   .option("--reason <text>", "Recorded on the ledger entry", "grant")
-  .option("--database <url>")
   .action(async (owner: string, amount: string, opts: CliOptions & { application?: boolean }) => {
-    await action(async () => {
+    await guard(async () => {
       const operator = new Operator(openStore(opts));
       const micro = parseMicroDollars(amount);
       const balance = opts.application
@@ -232,16 +239,14 @@ mycelCommand
 
       console.log(`Granted ${dollars(micro)} to ${balance.ownerKind} ${balance.ownerKey}.`);
       console.log(`Balance is now ${dollars(balance.microDollars)}.`);
-    })(opts as CliOptions);
+    });
   });
 
-mycelCommand
-  .command("balance <owner>")
+withDatabase(mycelCommand.command("balance <owner>"))
   .description("Show a balance and the entries that make it up")
   .option("--application", "Treat <owner> as an Application rather than a Client")
-  .option("--database <url>")
   .action(async (owner: string, opts: CliOptions & { application?: boolean }) => {
-    await action(async () => {
+    await guard(async () => {
       const balances = new Balances(openStore(opts));
       const which = opts.application ? applicationOwner(owner) : clientOwner(owner);
       const [balance, entries] = await Promise.all([
@@ -258,15 +263,14 @@ mycelCommand
             `${entry.reason}${entry.requestId ? ` (${entry.requestId})` : ""}`,
         );
       }
-    })(opts as CliOptions);
+    });
   });
 
 // ── Supply ───────────────────────────────────────────────────────────────────
 
 const supplier = mycelCommand.command("supplier").description("Parties that produce tokens");
 
-supplier
-  .command("register <id>")
+withDatabase(supplier.command("register <id>"))
   .description("Register a Supplier and issue its publishing credential")
   .option("--display-name <name>")
   .option("--base-url <url>", "Where the Exchange sends work (OpenAI-compatible)")
@@ -275,9 +279,8 @@ supplier
     "Name of the env var holding the key we present upstream — the NAME, never the key",
   )
   .option("--guarantees <names>", "Guarantees this Supplier may publish under")
-  .option("--database <url>")
   .action(async (id: string, opts: CliOptions) => {
-    await action(async () => {
+    await guard(async () => {
       if (!opts.baseUrl) throw new MycelCliError("Where does work go? Pass --base-url.");
       const operator = new Operator(openStore(opts));
       const { supplier: created, credential } = await operator.registerSupplier({
@@ -295,7 +298,7 @@ supplier
       );
       console.log(`\n  ${credential}\n`);
       console.log("Shown once. The agent presents it when publishing Offers.");
-    })(opts);
+    });
   });
 
 const offers = mycelCommand.command("offers").description("What a Supplier is selling");
@@ -311,8 +314,7 @@ const offers = mycelCommand.command("offers").description("What a Supplier is se
  */
 const DEFAULT_VENDOR_CAPABILITIES = ["chat", "streaming"];
 
-offers
-  .command("sync <supplierId>")
+withDatabase(offers.command("sync <supplierId>"))
   .description("Publish a vendor's Models as Offers, on its behalf")
   .option("--models <names>", "Models to resell, comma-separated")
   .option("--capabilities <names>", "Applied to every Model", DEFAULT_VENDOR_CAPABILITIES.join(","))
@@ -320,9 +322,8 @@ offers
     "--watch <minutes>",
     "Keep republishing. A vendor runs no agent, so this IS its heartbeat",
   )
-  .option("--database <url>")
   .action(async (supplierId: string, opts: CliOptions & { capabilities?: string; watch?: string }) => {
-    await action(async () => {
+    await guard(async () => {
       const models = list(opts.models);
       if (models.length === 0) {
         throw new MycelCliError(
@@ -380,5 +381,58 @@ offers
         process.once("SIGINT", stop);
         process.once("SIGTERM", stop);
       });
-    })(opts);
+    });
+  });
+
+withDatabase(mycelCommand.command("price <supplierId> <model>"))
+  .description("Set what an Offer costs us and what it charges")
+  .option("--wholesale-prompt <microDollars>", "Per million prompt tokens, what we owe")
+  .option("--wholesale-completion <microDollars>", "Per million completion tokens, what we owe")
+  .option("--retail-prompt <microDollars>", "Per million prompt tokens, what we charge")
+  .option("--retail-completion <microDollars>", "Per million completion tokens, what we charge")
+  .action(async (supplierId: string, model: string, opts: CliOptions) => {
+    await guard(async () => {
+      const required = {
+        "--wholesale-prompt": opts.wholesalePrompt,
+        "--wholesale-completion": opts.wholesaleCompletion,
+        "--retail-prompt": opts.retailPrompt,
+        "--retail-completion": opts.retailCompletion,
+      };
+      const missing = Object.entries(required)
+        .filter(([, value]) => value === undefined)
+        .map(([flag]) => flag);
+      if (missing.length) {
+        // All four or none. Setting two would leave the others at whatever they
+        // were, which for a price is the kind of half-change nobody notices
+        // until an invoice.
+        throw new MycelCliError(`Missing ${missing.join(", ")}. Set all four together.`);
+      }
+
+      const operator = new Operator(openStore(opts));
+      const pricing = {
+        wholesalePromptPerMillion: parseMicroDollars(opts.wholesalePrompt!),
+        wholesaleCompletionPerMillion: parseMicroDollars(opts.wholesaleCompletion!),
+        retailPromptPerMillion: parseMicroDollars(opts.retailPrompt!),
+        retailCompletionPerMillion: parseMicroDollars(opts.retailCompletion!),
+      };
+      await operator.setPricing(supplierId, model, pricing);
+
+      console.log(`${supplierId} / ${model}`);
+      console.log(
+        `  wholesale  ${dollars(pricing.wholesalePromptPerMillion)} prompt / ` +
+          `${dollars(pricing.wholesaleCompletionPerMillion)} completion, per million`,
+      );
+      console.log(
+        `  retail     ${dollars(pricing.retailPromptPerMillion)} prompt / ` +
+          `${dollars(pricing.retailCompletionPerMillion)} completion, per million`,
+      );
+
+      // Not a warning — retail is deliberately independent of wholesale
+      // (ADR 0013), and selling below cost can be a deliberate choice. But it
+      // should never be an accident.
+      if (pricing.retailPromptPerMillion < pricing.wholesalePromptPerMillion ||
+          pricing.retailCompletionPerMillion < pricing.wholesaleCompletionPerMillion) {
+        console.log("\n  note: retail is below wholesale — this Offer loses money per token.");
+      }
+    });
   });

--- a/packages/mycel/src/operator.ts
+++ b/packages/mycel/src/operator.ts
@@ -13,7 +13,14 @@
 
 import { hashCredential, issueCredential } from "./auth/credentials.js";
 import { Balances, applicationOwner, clientOwner } from "./metering/balances.js";
-import type { Application, Client, MicroDollars, OfferPricing, Supplier } from "./types.js";
+import type {
+  Application,
+  Client,
+  MicroDollars,
+  OfferPricing,
+  PublishedOffer,
+  Supplier,
+} from "./types.js";
 import type { ExchangeStore } from "./store/types.js";
 
 export interface RegisterSupplierInput {
@@ -195,5 +202,30 @@ export class Operator {
 
   async setPricing(supplierId: string, model: string, pricing: OfferPricing): Promise<void> {
     await this.store.setOfferPricing(supplierId, model, pricing);
+  }
+
+  /**
+   * Publish a Supplier's Offers on its behalf.
+   *
+   * For a machine, the agent publishes what it probed. A commercial vendor runs
+   * no agent, so the operator lists what it is willing to resell.
+   *
+   * **These Capabilities are declared, not probed**, which is the one place
+   * ADR 0015 bends. A vendor's catalogue is somebody else's claim about
+   * somebody else's serving path, so the honest treatment is to keep the list
+   * short enough to stand behind and to mark every Offer `adapted` — which is
+   * exactly what reselling a runtime you do not control means (ADR 0016).
+   *
+   * Publishing is total, as it is for an agent: this replaces the Supplier's
+   * whole Offer set, so a Model dropped from the list stops being advertised
+   * without anyone deleting anything.
+   */
+  async publishOffersFor(supplierId: string, offers: PublishedOffer[]): Promise<void> {
+    const supplier = await this.store.getSupplier(supplierId);
+    if (!supplier) throw new Error(`Unknown supplier "${supplierId}".`);
+    await this.store.replaceOffers(
+      supplierId,
+      offers.map((offer) => ({ ...offer, servingMode: "adapted" as const })),
+    );
   }
 }

--- a/packages/mycel/src/server.ts
+++ b/packages/mycel/src/server.ts
@@ -15,6 +15,15 @@ import { createBuyerHandler, type BuyerHandlerOptions } from "./buyer/handler.js
 import { createModelsHandler } from "./buyer/models.js";
 import type { ExchangeStore } from "./store/types.js";
 
+/**
+ * Mycel's port.
+ *
+ * In umwelten's 74xx block but **below 7440**, where Gaia begins assigning
+ * ports sequentially to the habitat containers it manages. A fixed service
+ * inside that range gets its port taken by whichever child Gaia starts next.
+ */
+export const DEFAULT_PORT = 7438;
+
 export interface ExchangeServerOptions {
   store: ExchangeStore;
   port?: number;
@@ -93,10 +102,10 @@ export async function createExchangeServer(
   });
 
   const host = opts.host ?? "0.0.0.0";
-  await new Promise<void>((resolve) => server.listen(opts.port ?? 7450, host, resolve));
+  await new Promise<void>((resolve) => server.listen(opts.port ?? DEFAULT_PORT, host, resolve));
 
   const address = server.address();
-  const port = typeof address === "object" && address ? address.port : (opts.port ?? 0);
+  const port = typeof address === "object" && address ? address.port : (opts.port ?? DEFAULT_PORT);
 
   return {
     server,

--- a/packages/supplier/src/command.ts
+++ b/packages/supplier/src/command.ts
@@ -84,7 +84,14 @@ interface CliOptions {
  */
 const AGENT_VERSION = "1";
 
-const DEFAULT_MANAGED_PORT = 7450;
+/**
+ * The port the agent's own runtime listens on.
+ *
+ * Below 7440, where Gaia starts handing out ports to managed containers, and
+ * clear of Mycel's 7438,
+ * so an operator can run the Exchange and a supplier agent on one box.
+ */
+const DEFAULT_MANAGED_PORT = 7439;
 const DEFAULT_MANAGED_CONFIG = path.join(os.homedir(), ".umwelten", "supplier", "llama-swap.yaml");
 
 function resolveMode(opts: CliOptions): ServingMode {

--- a/packages/supplier/src/managed.test.ts
+++ b/packages/supplier/src/managed.test.ts
@@ -43,7 +43,7 @@ const managed = (overrides: Partial<ManagedOptions> = {}): ManagedOptions => ({
   models: ["gemma-4-26b-a4b"],
   contextTokens: 32_768,
   parallel: 4,
-  port: 7450,
+  port: 7439,
   configPath: "/tmp/llama-swap.yaml",
   ...overrides,
 });

--- a/packages/supplier/src/runtime.test.ts
+++ b/packages/supplier/src/runtime.test.ts
@@ -21,7 +21,7 @@ const PLAN = planManagedRuntime({
     models: ["gemma-4-26b"],
     contextTokens: 32_768,
     parallel: 4,
-    port: 7450,
+    port: 7439,
     configPath: "/tmp/umwelten-test/llama-swap.yaml",
   },
   available: DISK,
@@ -94,7 +94,7 @@ describe("ManagedRuntime.start", () => {
     // serving path that is not serving, and the first Dispatch would find out.
     const fake = fakeEffects({ readyAfter: 5 });
     const runtime = await ManagedRuntime.start(PLAN, fake.effects);
-    expect(runtime.baseUrl).toBe("http://127.0.0.1:7450/v1");
+    expect(runtime.baseUrl).toBe("http://127.0.0.1:7439/v1");
     await runtime.stop();
   });
 

--- a/packages/supplier/src/state.test.ts
+++ b/packages/supplier/src/state.test.ts
@@ -33,7 +33,7 @@ const CONFIG: PersistedConfig = {
     models: ["gemma-4-26b"],
     contextTokens: 32_768,
     parallel: 4,
-    port: 7450,
+    port: 7439,
     configPath: "/tmp/llama-swap.yaml",
   },
 };


### PR DESCRIPTION
The last three gaps from the deployment runbook. **Stage 1 is now blocked only on the Neon project.**

## Ports — including a mistake I made and corrected

Mycel defaulted to **7450**, and so did the supplier agent's managed runtime. 7450 is inside **7440–7499**, which Gaia hands out sequentially to the containers it manages. So both collided with each other *and* with whichever habitat Gaia started next.

Mycel is now **7438**, supplier runtime **7439** — both below where Gaia begins.

I got this wrong once on the way: the first fix moved them to 7460/7461, which is *also* inside Gaia's range, and shipped a comment claiming otherwise. Numbers and reasoning are both corrected here, and CLAUDE.md's table now lists the fixed services **above** the dynamic block so the boundary is visible rather than something you have to notice.

## Catalogue sync

```
umwelten mycel offers sync openrouter --models a,b --watch 5
```

A machine publishes what its agent probed; a commercial vendor runs no agent, so the operator publishes for it. Two consequences, both stated in the code rather than left implicit:

**These Capabilities are declared, not probed** — the one place ADR 0015 bends. So the default set is the two things every hosted model does (`chat`, `streaming`), and tool-calling, structured output and reasoning are opt-in per model. Over-claiming would have Dispatch route a tool-calling request somewhere that can't serve it, which is the exact failure that ADR exists to prevent.

**The sync IS the vendor's heartbeat**, so `--watch` isn't a convenience. Without it the Offers expire fifteen minutes later — the first thing that will look like a bug. A failed republish logs and keeps beating; giving up would expire the Offers of a vendor that is probably fine.

## Container

Deliberately **not** built on `packages/habitat/Dockerfile`. That image carries the Docker CLI, mise, git and ripgrep because a habitat clones repos and runs toolchains. Mycel is an HTTP service over Postgres that clones nothing, spawns nothing, and needs no volume — every one of those tools would be attack surface on the one service holding the money ledger.

Non-root user, and a healthcheck that asks the **store** rather than the process: a service answering while its database is gone is worse than one that doesn't answer, because Dispatch keeps sending it traffic.

## Compose

`deploy/mycel/` — its own file beside Gaia's, not a service inside it. The whole argument for Mycel being a peer rather than a Gaia child is separate deploy cadence, and sharing a compose file means `docker compose up -d` for a Gaia change cycles the money service.

Plus `deploy/mycel/README.md`: start, stop, roll back, and a "failures that will look like bugs first" section — stale vendor Offers, a 402 from a user who was capped rather than unfunded, a 401 from a missing `X-Mycel-End-User`, and a zero Cost with a non-zero Charge (which is correct).

## Verification

2711 unit tests, typecheck clean, lint clean (0 errors). CLI exercised by hand — `offers sync` refuses an empty model list with the reason, `--help` renders, and `examples/mycel-e2e` still runs both auth paths end to end after the port move.

Not verified: the Docker build itself, which needs a daemon this container doesn't have. Worth a `docker build` locally before the first deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG)_