### PR TITLE
Gaia: build the habitat image with BuildKit

### DIFF
--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -237,7 +237,20 @@ export class DockerManager {
     const { stdout, stderr } = await execFile(
       "docker",
       ["build", "-f", HABITAT_DOCKERFILE, "-t", DEFAULT_IMAGE_NAME, "."],
-      { cwd: this.projectRoot, maxBuffer: 10 * 1024 * 1024 },
+      {
+        cwd: this.projectRoot,
+        maxBuffer: 10 * 1024 * 1024,
+        // The Dockerfile mounts a pnpm store cache (`RUN --mount=type=cache`),
+        // which the legacy builder cannot parse:
+        //
+        //   the --mount option requires BuildKit
+        //
+        // Daemons still defaulting to the legacy builder therefore fail every
+        // build. Asking for BuildKit here rather than relying on the host's
+        // default keeps the build a property of this repo — the Dockerfile and
+        // the command that runs it agree, on any daemon.
+        env: { ...process.env, DOCKER_BUILDKIT: "1" },
+      },
     );
     return stdout + stderr;
   }


### PR DESCRIPTION
With #357 in place, `build_image` now reaches docker — and fails on the daemon's default builder:

```
docker build -f packages/habitat/Dockerfile -t habitat .
the --mount option requires BuildKit
```

The Dockerfile mounts a pnpm store cache (line 54, `RUN --mount=type=cache,id=pnpm-habitat,...`), which the legacy builder can't parse. `buildImage` passed no environment, so on any daemon still defaulting to the legacy builder, **every build fails**.

Sets `DOCKER_BUILDKIT=1` for the build rather than relying on the host default, so the Dockerfile and the command that runs it agree on any daemon.

## Context

This is the third thing standing between a merged fix and a running habitat:

1. `refresh_habitat` pulls content repos but never rebuilds images
2. `build_image` pointed at a nonexistent Dockerfile path (#357)
3. …and once pointed correctly, invoked a builder that can't read it — this PR

Found by calling `build_image` against production once #357 went live.

## Verification

- `tsc --noEmit` clean on `@umwelten/habitat`; `pnpm test:run` green (2723 tests)
- The failing command and its exact error came from the live daemon, so the diagnosis isn't inferred

The successful build is still unverified — that needs this merged and Gaia restarted. If the daemon also lacks the buildx component entirely, the error will change to a missing-plugin message and want `apt-get install docker-buildx-plugin` on the host; the deprecation warning in the output suggests buildx may not be installed at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_