### PR TITLE
Install the buildx CLI plugin in the habitat image

### DIFF
--- a/packages/habitat/Dockerfile
+++ b/packages/habitat/Dockerfile
@@ -30,6 +30,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN curl -fsSL "https://download.docker.com/linux/static/stable/$(uname -m)/docker-27.3.1.tgz" | \
     tar xz -C /usr/local/bin --strip-components=1 docker/docker
 
+# Install the buildx CLI plugin.
+#
+# The static tarball above ships only the `docker` binary — no CLI plugins —
+# and buildx is distributed separately. Gaia's own `build_image` builds THIS
+# Dockerfile, which mounts a pnpm store cache (`RUN --mount=type=cache`); that
+# needs BuildKit, and BuildKit needs buildx. Without the plugin the build fails
+# either way round: the legacy builder cannot parse `--mount`, and asking for
+# BuildKit gets "the buildx component is missing or broken".
+#
+# Release asset names use amd64/arm64, while `uname -m` says x86_64/aarch64,
+# so the two have to be mapped rather than substituted.
+RUN BUILDX_VERSION=v0.36.1 && \
+    BUILDX_ARCH="$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')" && \
+    mkdir -p /usr/local/lib/docker/cli-plugins && \
+    curl -fsSL \
+      "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${BUILDX_ARCH}" \
+      -o /usr/local/lib/docker/cli-plugins/docker-buildx && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx && \
+    docker buildx version
+
 # Install mise (universal runtime/package manager)
 RUN curl https://mise.run | sh && \
     ln -s /root/.local/bin/mise /usr/local/bin/mise


### PR DESCRIPTION
With #363 asking for BuildKit, `build_image` now fails one layer further in:

```
ERROR: BuildKit is enabled but the buildx component is missing or broken.
```

Confirmed on the live host: `docker buildx version` → `docker: 'buildx' is not a docker command.`

## Why it was never there

The image installs the Docker CLI from the static tarball, which ships **only** the `docker` binary — no CLI plugins:

```dockerfile
RUN curl -fsSL "https://download.docker.com/linux/static/stable/$(uname -m)/docker-27.3.1.tgz" | \
    tar xz -C /usr/local/bin --strip-components=1 docker/docker
```

buildx is distributed separately, so it was simply absent.

That left the build unwinnable either way round: the legacy builder can't parse the `RUN --mount=type=cache` **this same Dockerfile** uses, and asking for BuildKit finds no buildx. Gaia builds this Dockerfile, so the image has to carry the tool needed to build itself.

## The fix

Installs buildx v0.36.1 into `/usr/local/lib/docker/cli-plugins`.

Release assets are named `amd64`/`arm64` while `uname -m` says `x86_64`/`aarch64`, so the two are **mapped rather than substituted** — the same trap the docker CLI line above already documents. The `RUN` ends with `docker buildx version`, so a bad download fails the build loudly instead of producing an image that can't build the next one.

## Verification

Both checked from the Gaia host — whose network isn't proxy-restricted — rather than assumed:

- `v0.36.1` is the current release (`api.github.com/repos/docker/buildx/releases/latest`)
- The exact URL this Dockerfile fetches returns **HTTP 200**

`pnpm test:run` green. The image build itself is unverified here (no docker daemon in this environment).

## Bootstrap note

This fixes builds **after** an image containing it exists. The first build still has to come from a host that already has buildx — which is how the current image got built. Once one image carries the plugin, `build_image` becomes self-sustaining.

## The full chain

Four separate things stood between a merged fix and a running habitat:

1. `refresh_habitat` pulls content repos, never rebuilds images
2. `build_image` pointed at a nonexistent Dockerfile path — #357
3. …then invoked a builder that can't read that Dockerfile — #363
4. …and the builder it asks for isn't installed — this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_