### PR TITLE
Supervise the vendor sync — and ADR 0023, which deletes it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,15 @@ jobs:
         # left to manual runs.
         run: pnpm test:run
 
+      - name: Build every package
+        # Not optional, and not merely an optimisation. Node refuses to strip
+        # types under node_modules (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING),
+        # so a package that ships src/*.ts installs cleanly and then crashes on
+        # first import. Each package's publishConfig points main/types/exports/bin
+        # at dist/, and pnpm applies it at publish time — if this step is skipped,
+        # those paths resolve to files that were never emitted.
+        run: pnpm -r build
+
       - name: Publish workspace packages to npm
         # `pnpm -r publish` walks every workspace package, skips the ones
         # marked `private: true`, and rewrites `workspace:*` deps into the

--- a/docs/adr/0022-when-a-probe-goes-stale.md
+++ b/docs/adr/0022-when-a-probe-goes-stale.md
@@ -95,6 +95,14 @@ into a process that is not running.
 
 ## The heartbeat, and why silence has to mean something
 
+> **Superseded in part by ADR 0023 — machine Suppliers dial in.** Everything
+> below infers liveness from silence, which is only necessary because the
+> Exchange could not observe it. Once a machine Supplier holds an open
+> connection, connected *is* available and disconnected *is* withdrawn, and the
+> heartbeat, the window, and the sync service all delete. What remains below
+> applies to vendor Suppliers, where it is also probably unnecessary.
+
+
 Withdrawal has two halves, and they are meant to overlap so that neither is a
 single point of failure:
 

--- a/docs/adr/0023-suppliers-dial-in.md
+++ b/docs/adr/0023-suppliers-dial-in.md
@@ -1,0 +1,121 @@
+# 0023 — Machine Suppliers dial in; the Exchange never dials a machine
+
+Status: Accepted
+Date: 2026-08-08
+
+A Supplier that is a **machine** — a DGX on a desk, a laptop, anything someone
+owns — opens a persistent connection *to* Mycel and receives work over it. Mycel
+never connects to it, and it accepts no inbound connections at all.
+
+A Supplier that is a **commercial vendor** is still dialed out to, because a
+public API is reachable by definition.
+
+So there are two supplier transports. That asymmetry is the correction: the
+previous design pretended a vendor and a box on a desk were the same kind of
+thing, and every problem below came from that.
+
+## What was wrong
+
+The original model gave every Supplier a `baseUrl` that Mycel connects to. For
+OpenRouter that is right. For a machine behind NAT it is a requirement that
+someone stand up a tunnel, register a stable address, and hand it over before
+they can contribute a single token.
+
+Two consequences followed, and neither was noticed as a consequence:
+
+**Onboarding became a network project.** "Install Tailscale, get an ACL, get an
+address, tell the operator" is not something a person with a spare Mac Studio
+does on a whim. For a pool whose entire premise is other people's idle hardware,
+that is the difference between the idea working and not.
+
+**Liveness became unobservable, so it got inferred.** Mycel could not tell
+whether a machine was still there, so it inferred it from silence — and that
+inference is where a whole subsystem came from:
+
+- a 15-minute staleness window on every Offer (ADR 0022)
+- a 5-minute heartbeat republish in the supplier agent
+- a `--watch` mode on `offers sync`
+- a `mycel-offers` compose service to run that mode for vendors, which have no
+  agent to heartbeat for them
+
+Four mechanisms, all answering *"is this supplier alive?"* — a question a held
+connection answers by existing. **Connected is available; disconnected is
+withdrawn.** Exactly, instantly, with no window to tune and nothing to schedule.
+
+That accumulation was the signal the premise deserved re-examining, and it was
+missed for long enough to ship all four.
+
+## Why dial-out is the standard answer
+
+Wherever workers sit behind NAT and the coordinator is public, the workers dial
+the coordinator: GitHub's self-hosted runners dial GitHub, `cloudflared` dials
+Cloudflare, kubelet dials the API server. None of them ask the operator to make
+the worker reachable, because making a worker reachable is the hard part and it
+is avoidable.
+
+## What it buys beyond reachability
+
+**Onboarding is one command.** No tunnel, no ACL, no DNS, no firewall rule:
+
+```
+umwelten supplier serve --mycel https://mycel.thefocus.ai --credential sk-mycel-…
+```
+
+That works from a coffee shop and from behind a corporate proxy, because it is
+an outbound WebSocket over 443.
+
+**The privacy guarantee gets stronger.** Under the tunnel design the machine sits
+on a private network but still runs a listening service. Under dial-out it
+accepts no inbound connections at all — there is nothing to reach, from
+anywhere. An on-premise Guarantee (ADR 0012, which the operator is liable for)
+is easier to defend when the honest description is "that machine is not
+addressable."
+
+**Four mechanisms delete.** Staleness window, heartbeat, `--watch`, sidecar. The
+Offer expiry that ADR 0022 specifies remains meaningful only for vendor
+Suppliers, where it is also unnecessary — a vendor with an SLA and a status page
+does not vanish the way a NAT'd box does.
+
+## What it costs
+
+**Protocol work.** WebSocket: request framing, response streaming back
+token-by-token, multiplexing concurrent requests over one connection, reconnect
+with backoff, half-open detection. Days, not hours, and all of it is code we own
+rather than configuration we describe.
+
+**Mycel becomes connection-stateful.** It must know which Suppliers are
+connected right now, and Dispatch must consult that rather than a database
+column. At this scale — a handful of machines — that is a map in memory, and it
+replaces a database round trip rather than adding one.
+
+**Two transports to maintain.** Accepted, and named: `Supplier.kind` is `agent`
+or `vendor`, and the difference is real rather than incidental.
+
+## Sequencing, and a reversal
+
+The first recommendation here was: Tailscale for stage 2 now, dial-out later,
+on the reasoning that Tailscale is zero code and running it would teach us what
+the protocol needs to carry.
+
+**That was wrong, and it was wrong in the same way the original design was.**
+
+What Tailscale would prove — that Mycel can relay to a remote GPU — is not
+seriously in doubt; it is the same relay path that already works for a
+commercial vendor. What is unproven is the protocol, and a tunnel derisks none
+of it. Meanwhile the staged version means building stage 2 twice and keeping
+four pieces of doomed machinery alive in between.
+
+So: **dial-out first.** Tailscale remains a legitimate fallback for a machine
+that cannot run the agent, and nothing here forbids it.
+
+## Consequences
+
+- `Supplier` gains a `kind`. `baseUrl` becomes meaningful only for vendors.
+- Dispatch consults live connections for agent Suppliers.
+- ADR 0022's staleness window narrows to vendors, and should probably be
+  dropped there too — a separate decision.
+- The supplier agent's heartbeat, `offers sync --watch`, and the `mycel-offers`
+  compose service are removed once dial-out lands.
+- `packages/supplier` still must not depend on `packages/mycel`: the wire
+  protocol is a shared shape, and a shared *type* at most, never a shared
+  database driver.

--- a/docs/adr/0023-suppliers-dial-in.md
+++ b/docs/adr/0023-suppliers-dial-in.md
@@ -76,12 +76,44 @@ Offer expiry that ADR 0022 specifies remains meaningful only for vendor
 Suppliers, where it is also unnecessary — a vendor with an SLA and a status page
 does not vanish the way a NAT'd box does.
 
+## The connection is a request channel, not a work queue
+
+Mycel **pushes**. A request frame goes down the socket, token frames come back
+up, correlated by request id. The machine does not ask for work.
+
+The alternative was a pull model — the machine reports "I can take two more" and
+Mycel hands work down as slots free. It was rejected despite being the better
+answer to backpressure, because a queue is a component and not a detail: depth,
+timeouts, an ordering policy, and a buyer's request that can now sit waiting on
+a machine that never asks. Push keeps the relay doing what it already does —
+dispatch picks an Offer and forwards — and leaves one hop between buyer and
+tokens.
+
+**The cost is precise, and it is not small.** Mycel must decide for itself what
+a machine can take, and the only thing it knows is Headroom, which is a
+measurement from probe time rather than a reading of now (ADR 0027 says this
+about scoring; it applies with more force here, because a wrong score picks a
+slower Offer while a wrong capacity estimate pushes a fifth request at a box
+that serves four). Nothing in this ADR closes that gap. What the held connection
+does give us is the *ability* to close it later — in-flight requests per machine
+are countable by Mycel because Mycel issued every one of them, which is strictly
+more than the probe-time inference available today.
+
 ## What it costs
 
 **Protocol work.** WebSocket: request framing, response streaming back
 token-by-token, multiplexing concurrent requests over one connection, reconnect
 with backoff, half-open detection. Days, not hours, and all of it is code we own
 rather than configuration we describe.
+
+**A dropped connection mid-stream is a truncated response, and nothing more.**
+No buffering, no replay, no re-dispatch: the buyer's stream ends where the
+tokens stopped and the request is recorded `supply-failed` (ADR 0025). This is
+the routine case rather than the exceptional one — the machine is a laptop and
+laptops close — and it is accepted rather than engineered around, because both
+alternatives cost more than the failure does. Re-serving from the top pays for
+one sale twice; resuming from a prefix seams at the join and is not supported
+across runtimes at all.
 
 **Mycel becomes connection-stateful.** It must know which Suppliers are
 connected right now, and Dispatch must consult that rather than a database
@@ -116,6 +148,10 @@ that cannot run the agent, and nothing here forbids it.
   dropped there too — a separate decision.
 - The supplier agent's heartbeat, `offers sync --watch`, and the `mycel-offers`
   compose service are removed once dial-out lands.
+- Mycel tracks in-flight requests per connected machine, because under push it
+  is the only party that can. Whether it *refuses* to exceed a number, and what
+  that number is, is left open — probe-time Headroom is a poor basis for it and
+  a live count is the better one, once there is a live count.
 - `packages/supplier` still must not depend on `packages/mycel`: the wire
   protocol is a shared shape, and a shared *type* at most, never a shared
   database driver.

--- a/docs/adr/0024-suppliers-are-paid-from-a-balance.md
+++ b/docs/adr/0024-suppliers-are-paid-from-a-balance.md
@@ -1,0 +1,72 @@
+# 0024 — A Supplier is paid from a Balance, like everyone else
+
+Status: Accepted — designed, not built
+Date: 2026-08-08
+
+A Supplier accrues earnings in a **Balance**, using the same append-only ledger
+that already tracks what buyers owe. Every served request credits the Supplier's
+Balance by its `Cost`. A payout is a debit against that Balance.
+
+Nothing here is built. It is designed now so that the dial-in protocol
+(ADR 0023) and the ledger are shaped for it, rather than being retrofitted
+around a payout mechanism invented later.
+
+## Why a Balance rather than a payouts table
+
+The ledger already does exactly this job on the demand side: append-only, never
+a stored total, every entry traceable to the request that caused it (ADR 0013,
+and the Balance definition in `packages/mycel/CONTEXT.md`). A Supplier's
+earnings have the same requirements — reconstructable, disputable, and
+auditable — so a second mechanism would be a second thing to get wrong.
+
+Concretely: `BalanceOwnerKind` gains `"supplier"`. Everything else already
+exists.
+
+The symmetry is the point. "What are we owed" and "what do we owe" become the
+same query against the same table, which is what makes a margin number
+believable.
+
+## What we owe is what we measured
+
+ADR 0017 has the Exchange meter at its own boundary rather than trusting an
+upstream's usage report. The same argument runs the other way: **a Supplier is
+owed for what we measured it produce**, not for what it claims.
+
+That is not distrust so much as arithmetic hygiene. We already record
+`upstreamPromptTokens` / `upstreamCompletionTokens` alongside our own count
+precisely so the two can be compared. A persistent divergence on one Supplier is
+a conversation; letting the Supplier's number set the payment would make it an
+unnoticed one.
+
+A disputed Cost resolves against the `RequestRecord`, which the ledger entry
+references by id.
+
+## What this ADR does not decide
+
+**How dollars actually move.** Bank transfer, Stripe Connect, or a spreadsheet
+and an invoice are all compatible with the above, and for a closed pool of a
+handful of Suppliers the answer is probably the boring one. The Balance says
+what is owed; the rail is an operational choice that can change without the
+ledger noticing.
+
+**Cadence.** Monthly, on request, or above a threshold — all expressible as
+"when someone runs the payout command." Deferring this costs nothing because the
+Balance accrues continuously either way.
+
+**Tax and reporting.** Real, and out of scope until there is a Supplier who is
+not us.
+
+## Consequences
+
+- `BalanceOwnerKind` gains `"supplier"`; `supplierOwner(id)` joins the existing
+  owner helpers.
+- The request path credits the Supplier as part of the same transaction that
+  debits the buyer. One request, two entries, one place.
+- A payout is `debit(supplierOwner(id), amount, "payout")` — visible in the same
+  history as everything else.
+- **A Supplier is credited even when the buyer is not charged** (ADR 0025). The
+  work was done; who eats the failure is a separate question from who did the
+  work.
+- Until this is built, `Cost` on a `RequestRecord` is the only record of what is
+  owed. That is sufficient to reconstruct every Balance retroactively, which is
+  why deferring the build is safe and deferring the *design* was not.

--- a/docs/adr/0025-the-exchange-bears-its-own-supply-failures.md
+++ b/docs/adr/0025-the-exchange-bears-its-own-supply-failures.md
@@ -37,18 +37,28 @@ the ones you want.
 **A buyer who cancels is charged for what was delivered. A Supplier that drops
 is not billed to the buyer at all.**
 
-Both produce a truncated stream and, today, look identical in the code: the
-`aborted` flag on a `RequestRecord` is set only by `req.on("aborted")` and
-`res.on("close")` — buyer disconnect. There is no signal for "upstream died
-mid-stream", so that path currently records a normal completion and charges for
-it.
+Both produce a truncated stream, and when this was written they looked identical
+in the code: the `aborted` flag on a `RequestRecord` was set only by
+`req.on("aborted")` and `res.on("close")` — buyer disconnect. There was no
+signal for "upstream died mid-stream", so that path recorded a normal completion
+and charged for it.
 
 So this ADR creates work rather than describing behaviour:
 
-1. The relay must distinguish a buyer-initiated abort from a supply-side
-   failure, and record which.
-2. The charge path must skip the debit on the second.
+1. ~~The relay must distinguish a buyer-initiated abort from a supply-side
+   failure, and record which.~~ **Done.** `RequestRecord.aborted` is replaced by
+   `outcome`: `completed`, `buyer-aborted`, `supply-failed`, `credit-exhausted`,
+   settled first-cause-wins so a caller who hangs up and then trips the read
+   loop is not recorded as a supply failure.
+2. The charge path must skip the debit on the second. **Not done, deliberately.**
+   Every outcome is still debited. The distinction is recorded before it is
+   acted on, so the numbers exist to say what this rule will cost before it
+   starts costing it.
 3. The credit to the Supplier (ADR 0024) must happen regardless.
+
+Splitting 1 from 2 is the point rather than a shortcut: a rule that moves money
+should be turned on against a population of real records, not on the same day
+the records start being kept.
 
 The asymmetry is deliberate and worth stating plainly: **the party who made the
 choice bears its consequences.** A buyer who hangs up chose to; we who picked

--- a/docs/adr/0025-the-exchange-bears-its-own-supply-failures.md
+++ b/docs/adr/0025-the-exchange-bears-its-own-supply-failures.md
@@ -1,0 +1,77 @@
+# 0025 — The Exchange bears the cost of its own supply failures
+
+Status: Accepted
+Date: 2026-08-08
+
+When a response is truncated because a **Supplier** failed — the connection
+dropped mid-stream, the runtime died, the upstream returned an error partway —
+the buyer is **charged nothing** for that request.
+
+The Supplier is still credited its `Cost` for the tokens it produced. The
+difference is the Exchange's loss.
+
+## Why the buyer does not pay
+
+**The buyer did not choose the Supplier. We did.** Dispatch is the Exchange's
+decision — it weighs Guarantees, Capabilities and price and picks one (see
+`dispatch.ts`). Charging the buyer when that choice fails is charging them for a
+decision they were not party to and cannot inspect.
+
+It also produces the wrong incentive on our side. If a flaky Supplier's failures
+are billed to buyers, the flakiness is invisible in our own numbers — it shows
+up as slightly unhappy customers and unchanged margin. If we absorb it, a
+Supplier that drops streams becomes **directly expensive**, visible in the gap
+between Charge and Cost, and the pressure to stop routing there lands where the
+routing decision is made.
+
+## Why the Supplier is still paid
+
+It produced the tokens. Whether the buyer received them is a question about our
+transport and our Dispatch, not about whether work happened. Docking a Supplier
+for a network failure between us and the buyer would make earnings depend on
+conditions the Supplier cannot see or control, which is the fastest way to lose
+the ones you want.
+
+## The distinction that carries the weight
+
+**A buyer who cancels is charged for what was delivered. A Supplier that drops
+is not billed to the buyer at all.**
+
+Both produce a truncated stream and, today, look identical in the code: the
+`aborted` flag on a `RequestRecord` is set only by `req.on("aborted")` and
+`res.on("close")` — buyer disconnect. There is no signal for "upstream died
+mid-stream", so that path currently records a normal completion and charges for
+it.
+
+So this ADR creates work rather than describing behaviour:
+
+1. The relay must distinguish a buyer-initiated abort from a supply-side
+   failure, and record which.
+2. The charge path must skip the debit on the second.
+3. The credit to the Supplier (ADR 0024) must happen regardless.
+
+The asymmetry is deliberate and worth stating plainly: **the party who made the
+choice bears its consequences.** A buyer who hangs up chose to; we who picked
+the Supplier chose that.
+
+## Scope
+
+This covers failures *of supply*. It does not cover:
+
+- **A buyer sending a bad request.** A 400 is charged nothing because nothing
+  was produced, not because of this rule.
+- **A model producing a bad answer.** Quality is not a failure mode the Exchange
+  can detect, and pretending otherwise would make every refund a judgement call.
+- **An Offer that was slow but completed.** Headroom is published so a buyer can
+  see what it is dispatching into (ADR 0021); slowness is information, not a
+  fault.
+
+## Consequences
+
+- Margin becomes an honest number: it already excludes what we chose to eat.
+- A Supplier with a high drop rate is visible as a widening Cost-without-Charge
+  line, which is a better signal than a support ticket.
+- Retrying elsewhere before the first token reaches the buyer stays open as a
+  future improvement — it converts a loss into a slower success. After the first
+  token it is impossible, and this rule is what makes that case survivable
+  rather than contentious.

--- a/docs/adr/0026-mycel-hosts-its-own-client-surface.md
+++ b/docs/adr/0026-mycel-hosts-its-own-client-surface.md
@@ -1,0 +1,79 @@
+# 0026 — Mycel hosts its own Client surface
+
+Status: Accepted
+Date: 2026-08-08
+
+A Client can see its own usage, spend, per-End-User breakdown and Balance, on a
+surface **Mycel serves itself** — not in the habitats SaaS.
+
+## Why not the SaaS
+
+It was proposed, and it was wrong for the same reason every other Mycel boundary
+is drawn where it is.
+
+Mycel already has its own Neon project, its own deploy cadence, its own fnox
+scope, its own hostname, and its own bounded context with its own glossary. Each
+of those was argued on the grounds that Mycel is a different thing from the
+habitat fleet — a different business, a different blast radius, a different set
+of people. Then hanging its customer-facing surface off the SaaS would have
+undone all of it in one move.
+
+More concretely: **a Client is not a habitat user.** A company building a
+hairstyle app has no relationship with the habitats fleet, no reason to hold an
+account in its identity system, and no business appearing in its user table.
+Putting them there couples two products that should be sellable, priceable and
+retirable independently — and puts Mycel's customers inside the identity system
+that fronts our own infrastructure.
+
+## This is not the admin API that was refused
+
+`packages/mycel/src/command.ts` records why there is no HTTP admin API: those
+operations move money and grant eligibility for traffic the operator is liable
+for, so a CLI on the box is a smaller surface than a route.
+
+None of that applies here. The Client surface is **read-only**. It moves no
+money, grants no eligibility, and changes no configuration. The argument that
+killed the admin routes was about consequence, not about HTTP.
+
+## A third kind of identity, and why it does not contradict ADR 0014
+
+ADR 0014 says the Exchange never authenticates **End Users** — no login, no
+password reset, no account recovery — because owning that for every Application
+forever is a business nobody wants.
+
+A Client operator logging in to see an invoice is a different party. There are a
+handful of them, they are onboarded by contract (ADR 0012), and they are exactly
+the people we already have a commercial relationship with. So Mycel now has
+three identities and they should not be confused:
+
+| Who | How they authenticate | Count |
+|---|---|---|
+| **End User** | never — asserted by the Application | unbounded |
+| **Application** | JWKS, or a hashed static credential | a few per Client |
+| **Client operator** | logs in to the Client surface | a handful, total |
+
+The bound on the third row is what makes it safe. If it ever stops being a
+handful, this ADR needs revisiting rather than scaling.
+
+## What it shows
+
+Usage by Application and by End User, spend against Balance, the ledger entries
+that sum to it, and which Models were served by which Supplier — everything
+`mycel balance` and the `RequestRecord` table already hold, rendered for someone
+who is not going to ssh anywhere.
+
+Deliberately not shown: **which Supplier served a request**, unless a Guarantee
+made it relevant. A Client buys tokens meeting a specification; our supply
+arrangements are ours, and exposing them invites a conversation about paying
+wholesale.
+
+## Consequences
+
+- Mycel grows a read-only, Client-scoped HTTP surface. Scoped means a Client can
+  only ever see its own Applications — the enforcement is not a UI concern.
+- Client operator login is a new mechanism to choose and build. Its own auth,
+  not the SaaS's.
+- The read surface can be added before the UI, and the UI can be as small as a
+  single page. Neither blocks stage 1.
+- `mycel balance` stays. The CLI is still the operator's tool; this is the
+  Client's.

--- a/docs/adr/0027-dispatch-filters-on-resource-properties-and-scores-on-more-than-price.md
+++ b/docs/adr/0027-dispatch-filters-on-resource-properties-and-scores-on-more-than-price.md
@@ -1,0 +1,107 @@
+# 0027 — Dispatch filters on resource properties, and scores on more than price
+
+Status: Accepted
+Date: 2026-08-08
+
+Two changes to how one Offer is chosen, both correcting things that were built
+on assumptions nobody agreed to.
+
+1. **Quantization and context length are requirable**, the same way Guarantees
+   already are. A buyer who cares says so; one who does not gets whatever wins.
+2. **Ranking is a weighted score**, not the cheapest price. Price is one term
+   alongside measured throughput, time-to-first-token, and whether the Offer
+   batches at all.
+
+## Why resource properties had to become requirable
+
+Dispatch matched a Model on exact string equality. So a DGX serving
+`gemma-4-26b` at Q8 with a 128k context and a vendor serving the same name at
+whatever they run were **interchangeable**, and the cheaper one won.
+
+That is wrong on this project's own evidence. Probing sixteen Offers across two
+runtimes on one machine found the same weights exposing *different capability
+sets* depending on how they were served
+(`reports/2026-07-26-supplier-probe-capability-divergence.md`), which is the
+whole reason ADR 0015 has Capabilities probed per Offer rather than looked up
+per Model. Quantization was added to the Offer and then never consulted, so the
+Offer carried the evidence and the selection ignored it.
+
+**Requirable, not mandatory.** Making every buyer specify a quantization would
+make the catalogue an exam. The default stays "give me something that serves
+this Model"; the buyer who knows they need Q8 or 128k of context can now say so
+and get a `no_offer` rather than a quiet downgrade.
+
+Per-request headers, matching the existing shape:
+
+```
+X-Mycel-Require-Quantization: Q8_0
+X-Mycel-Min-Context: 131072
+```
+
+An Offer with no `quantization` recorded does not match a quantization
+requirement. An adapted Offer is reselling a configuration its Supplier does not
+control (ADR 0016) and cannot honestly claim one.
+
+## Why cheapest-wins had to go
+
+`rankingPrice` carried its own confession: *"deliberately crude and deliberately
+in one place: when metering lands (#297) and real token counts are available
+before dispatch, this is what gets replaced."* Metering landed. It was not
+replaced.
+
+The consequence is sharper than it sounds, because owned hardware costs zero.
+**A Supplier we own always beat every vendor, regardless of anything else** — a
+DGX that queues four-deep with a 48-second time-to-first-token still won against
+an idle vendor, because zero is less than any price. Every Headroom number this
+project spent weeks measuring was collected, published, stored, and never read.
+
+## What the score uses, and what it cannot
+
+Four terms, each normalized across the eligible set so a score is only ever
+meaningful *relative to the alternatives for this request*:
+
+| Term | Direction | Source |
+|---|---|---|
+| price | lower better | `retail*PerMillion`, weighted completion-heavy |
+| aggregate throughput | higher better | Headroom sample |
+| time to first token | lower better | Headroom sample |
+| serves concurrent work | boolean | Headroom `saturation` verdict |
+
+**What it cannot do, stated plainly: this is capacity, not utilization.**
+Headroom is a measurement taken at probe time, not a reading of what the machine
+is doing right now. An Offer that batches beautifully and is currently serving
+six other requests looks identical to an idle one. So the score prefers an
+Offer that is *characteristically* fast and concurrent — it does not avoid a
+busy one.
+
+Live load is knowable later: under ADR 0023 the Exchange holds an open
+connection to every machine Supplier, so in-flight request counts become
+observable rather than inferred. That is when this becomes true load balancing.
+Until then the honest claim is "better-informed than price alone."
+
+**An Offer with no Headroom scores on price alone**, neither rewarded nor
+punished for the gap. A vendor catalogue is published without probes and would
+otherwise be uniformly penalised for a measurement we never asked it for.
+
+## Explicability is a requirement, not a nicety
+
+Every eligible Offer's score and its component terms are recorded on the
+`considered` list, alongside the rejection reasons that were already there.
+"Why did this request go there" has to stay answerable after the fact, and a
+weighted function is exactly the kind of thing that stops being answerable when
+nobody writes the terms down.
+
+Weights are constants in one place, tunable per deployment. They are not
+per-Application: a buyer expressing a preference does it through a *requirement*,
+which is a filter and therefore explicable, rather than by nudging a scoring
+function.
+
+## Consequences
+
+- `DispatchRequirements` gains `quantization` and `minContextTokens`.
+- Two rejection reasons: `missing-quantization`, `insufficient-context`.
+- `rankingPrice` is replaced by `scoreOffer`. Price-only behaviour remains
+  reachable by zeroing the other weights, which is also how the existing tests
+  stay meaningful.
+- Ties break deterministically on `supplierId`, as before. Production routing
+  that flaps under a tie is worse than a slightly wrong preference.

--- a/docs/adr/0028-a-client-may-be-postpaid-to-a-limit.md
+++ b/docs/adr/0028-a-client-may-be-postpaid-to-a-limit.md
@@ -1,0 +1,66 @@
+# 0028 — A Client may be postpaid, to a limit it was given
+
+Status: Accepted
+Date: 2026-08-08
+
+A Client has a **credit limit**. Its Balance may go negative down to that limit,
+and what it owes is what you invoice. A limit of zero is prepaid — the behaviour
+that exists today.
+
+## Why prepaid alone was wrong
+
+The built behaviour refuses a request the moment a Balance reaches zero. That is
+how a prepaid card works, and it contradicts everything else about how a Client
+comes to exist here: onboarded by contract, not signup (ADR 0012), a commercial
+relationship that already exists, invoiced monthly.
+
+A contracted Client that forgets to top up going dark mid-afternoon is not
+prudent, it is a support incident of our own making.
+
+Prepaid was never chosen. It fell out of "a Balance is a sum of ledger entries,
+refuse when it cannot cover the charge", which is correct arithmetic and an
+unexamined policy.
+
+## Where the limit applies, and where it does not
+
+Only to a **Client's own** Balance.
+
+A charge falls through End User → Application → Client, stopping at the first
+owner that has ever had a ledger entry. That chain already carries a meaning:
+**granting an End User anything opts it into being capped at that amount**, and
+it stays capped once spent rather than falling back to the pool.
+
+The credit limit must not undo that. So:
+
+- Resolved to an **End User** or **Application** balance → hard stop at zero.
+  That is a cap, and a cap that can be exceeded is not one.
+- Resolved to the **Client** → may go negative to the limit.
+
+Which reads correctly in both directions: caps are ceilings you set for someone
+else; the limit is trust you extend to the party you have a contract with.
+
+## What it does not do
+
+**It is not a line of credit that grows.** The limit is set by the operator, per
+Client, and changing it is a deliberate act — the same posture as granting a
+Guarantee, and for the same reason: the operator is the one carrying the risk.
+
+**It does not remove the refusal.** A Client past its limit is refused exactly
+as before. The limit moves where the wall is; it does not remove the wall.
+
+**It does not decide when you invoice.** Cadence is an operational choice; the
+Balance accrues continuously and a negative Balance is the amount owed at any
+moment you care to look.
+
+## Consequences
+
+- `Client` gains `creditLimitMicroDollars`, defaulting to 0 — so existing
+  Clients keep exactly the behaviour they have.
+- `Balances.canCover` takes the applicable floor rather than assuming zero.
+- The floor is derived from the resolved owner, not from the caller, which is
+  what keeps a capped End User capped.
+- A negative Balance is a normal state for a postpaid Client, so anything
+  reporting balances has to render one without looking like a bug — including
+  `mycel balance` and the Client surface (ADR 0026).
+- Collections is a business problem this makes possible. A limit set larger than
+  you are willing to lose is a decision, and the ADR cannot make it for you.

--- a/docs/adr/0029-mycel-sells-as-principal.md
+++ b/docs/adr/0029-mycel-sells-as-principal.md
@@ -1,0 +1,97 @@
+# 0029 — Mycel sells as principal, and warrants Guarantees on contract
+
+Status: Accepted
+Date: 2026-08-08
+
+Mycel buys tokens from Suppliers and resells them **as its own**. A buyer's
+counterparty is always Mycel, never the Supplier that happened to serve the
+request. Mycel is a principal, not a broker.
+
+A **Guarantee** on a third-party machine is warranted on the strength of a
+contract with that Supplier, enforced commercially — audit rights, indemnity,
+removal on breach — and not by any technical control.
+
+## Why this needed writing down
+
+It was already built this way, four times over, and never stated:
+
+- **ADR 0013** — Charge is set independently of Cost. Only a principal can do
+  that. A broker's fee is a commission on a price the buyer can see.
+- **ADR 0016** — a Guarantee is "asserted by the operator, who is liable for
+  it." Liable to whom, backed by what, was left open.
+- **ADR 0025** — the Exchange bears the cost of its own supply failures. That is
+  a principal absorbing a supplier problem; a broker would pass the breach
+  through to the party that breached.
+- **ADR 0028** — the operator extends credit to a Client. You do that with your
+  own counterparty, not with someone else's.
+
+Four decisions resting on an unstated premise is how the premise ends up being
+discovered by contradiction later. The alternative was live: a broker Mycel that
+introduces and meters, takes a disclosed commission, and names the serving
+Supplier to the buyer. That was rejected, and rejecting it is what makes the four
+above coherent rather than merely consistent.
+
+## What being the principal costs
+
+**You are liable for machines you do not own and cannot inspect.** A partner's
+box in a partner's office serves a request under your warranty. This is the
+whole cost of the position, and it is not reduced by the fact that pooling
+third-party hardware is the point of the project.
+
+Three ways to back a Guarantee were on the table:
+
+| Backing | Detection of a breach | Rejected because |
+|---|---|---|
+| Only your own hardware carries Guarantees | n/a — never at risk | Guaranteed demand is the valuable demand; pooling would scale only the cheap traffic |
+| **Contract, enforced commercially** | after the fact, if ever | — chosen |
+| The serving path proves it | at serving time | Real work, blocked on ADR 0023, and no Guarantee that isn't network-shaped can be proven this way |
+
+The middle one is chosen with its weakness stated rather than argued away: **a
+breach is discovered after the fact, if at all, and the buyer is exposed for the
+whole window before it is found.** Nothing in the system detects a Supplier
+copying a prompt off a machine it controls.
+
+"Not trained on" makes this plainest. It has no network-level evidence and never
+will, so even the strongest technical option would fall back to contract for
+that Guarantee. Contract is not a placeholder for a mechanism we intend to
+build; for some Guarantees it is the only thing there is.
+
+## What follows for what a Supplier sees
+
+A Supplier sees **what it earned** — its Cost, per request and in aggregate,
+which is what it needs to check a Settlement. It does not see the retail price
+or the margin. That is not secrecy for its own sake: under a principal model the
+retail price is Mycel's own price for its own product, and the Supplier is not a
+party to that sale. A broker would have to disclose the commission; a principal
+does not have a commission to disclose.
+
+This settles the shape of the parked "Suppliers cannot see their earnings"
+problem. The surface is Cost, Settlement, and a served-request history. It is
+not a smaller copy of the Client surface (ADR 0026).
+
+## What this does not decide
+
+**It is not a statement about how much risk to accept.** Which Suppliers to
+admit, what a Guarantee costs to warrant, and whether a given partner is worth
+the exposure are commercial judgements made per Supplier. This ADR fixes who is
+answerable, not how brave to be.
+
+**It does not close the door on proof.** When ADR 0023 lands, a machine whose
+only route out is its dial-in connection makes "stays on-premise" observable
+rather than asserted. That would strengthen a Guarantee already sold on
+contract; it is an upgrade to the evidence, not a change of counterparty.
+
+## Consequences
+
+- Guarantee eligibility is not restricted by ownership. A third-party Offer can
+  carry Guarantees, so `Supplier.kind` does not gate them and dispatch needs no
+  new filter.
+- Supplier onboarding acquires a contractual step that the software does not
+  model and must not pretend to: nothing in the schema should imply a signed
+  agreement exists.
+- Audit rights and removal-on-breach need somewhere to live. Withdrawing a
+  Supplier's Offers already exists (`OfferSupervisor.withdrawAll`); an operator
+  action that disables a Supplier outright does not.
+- The buyer-facing surface never names the serving Supplier. Dispatch records
+  which Offer served a request for our own answerability (ADR 0027), and that
+  record is internal.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,9 @@
 | [0021](0021-headroom-sampling-policy.md) | Headroom is sampled to a fixed policy, published with the numbers |
 | [0022](0022-when-a-probe-goes-stale.md) | A probe goes stale when the serving path moves, and our own code counts |
 | [0023](0023-suppliers-dial-in.md) | Machine Suppliers dial in; the Exchange never dials a machine |
+| [0024](0024-suppliers-are-paid-from-a-balance.md) | A Supplier is paid from a Balance, like everyone else |
+| [0025](0025-the-exchange-bears-its-own-supply-failures.md) | The Exchange bears the cost of its own supply failures |
+| [0026](0026-mycel-hosts-its-own-client-surface.md) | Mycel hosts its own Client surface |
 
 0011 is unused — see below.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@
 | [0020](0020-client-identity-is-hosted-per-product.md) | OAuth client identity is hosted per product |
 | [0021](0021-headroom-sampling-policy.md) | Headroom is sampled to a fixed policy, published with the numbers |
 | [0022](0022-when-a-probe-goes-stale.md) | A probe goes stale when the serving path moves, and our own code counts |
+| [0023](0023-suppliers-dial-in.md) | Machine Suppliers dial in; the Exchange never dials a machine |
 
 0011 is unused — see below.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,6 +29,7 @@
 | [0026](0026-mycel-hosts-its-own-client-surface.md) | Mycel hosts its own Client surface |
 | [0027](0027-dispatch-filters-on-resource-properties-and-scores-on-more-than-price.md) | Dispatch filters on resource properties, and scores on more than price |
 | [0028](0028-a-client-may-be-postpaid-to-a-limit.md) | A Client may be postpaid, to a limit it was given |
+| [0029](0029-mycel-sells-as-principal.md) | Mycel sells as principal, and warrants Guarantees on contract |
 
 0011 is unused — see below.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,8 @@
 | [0024](0024-suppliers-are-paid-from-a-balance.md) | A Supplier is paid from a Balance, like everyone else |
 | [0025](0025-the-exchange-bears-its-own-supply-failures.md) | The Exchange bears the cost of its own supply failures |
 | [0026](0026-mycel-hosts-its-own-client-surface.md) | Mycel hosts its own Client surface |
+| [0027](0027-dispatch-filters-on-resource-properties-and-scores-on-more-than-price.md) | Dispatch filters on resource properties, and scores on more than price |
+| [0028](0028-a-client-may-be-postpaid-to-a-limit.md) | A Client may be postpaid, to a limit it was given |
 
 0011 is unused — see below.
 

--- a/docs/architecture/mycel-deployment.md
+++ b/docs/architecture/mycel-deployment.md
@@ -17,7 +17,7 @@ Each later stage adds exactly one unproven thing:
 | Stage | Adds | Blocked on |
 |---|---|---|
 | **1** | Mycel + OpenRouter Supplier + one habitat buying | Neon project |
-| **2** | a local box as a second Supplier | Tailscale + the box |
+| **2** | a local box as a second Supplier, dialling in | the dial-in protocol (ADR 0023) |
 | **3** | the habitats SaaS as an Application (per-user balances) | stage 1 |
 | **4** | a third-party client app in its own repo | stage 3 |
 
@@ -338,7 +338,8 @@ filtered on the container name. Then the `considered` list on a failed dispatch,
 which records every Offer weighed and why each was rejected — "why did this
 request go there" is otherwise unanswerable after the fact.
 
-**Watch for:** Offers expiring. Dispatch drops an Offer not republished within 15
+**Watch for:** Offers expiring. (Doomed — see ADR 0023. Until dial-in lands,
+this is still how it behaves.) Dispatch drops an Offer not republished within 15
 minutes (`DEFAULT_STALE_AFTER_MS`). A vendor's synced catalogue has no agent
 heartbeating for it, so **a synced Offer set needs re-syncing on that cadence or
 its Offers will expire** — the first thing that will surprise you in stage 1, and
@@ -366,8 +367,12 @@ To cap a user at $5, grant them $5. To leave them uncapped, grant them nothing.
 ## Open decisions
 
 - **The Neon project** — create it, hand over the connection string.
-- **Reachability for a local box** (stage 2). Mycel dials `Supplier.baseUrl`; a
-  machine behind NAT has no URL. Tailscale is the recommendation — outbound-only
-  from both ends, and ACLs mean the box is never on the public internet, which is
-  what makes an on-premise Guarantee defensible rather than decorative.
+- ~~**Reachability for a local box.**~~ **Decided: ADR 0023 — machine Suppliers
+  dial in.** Mycel never connects to a machine; the machine holds an outbound
+  connection and receives work over it. No tunnel, no ACL, no address to
+  register, and the box accepts no inbound connections at all.
+
+  This also deletes the vendor-catalogue heartbeat below once it lands, because
+  the whole staleness apparatus exists only to infer a liveness that a held
+  connection makes observable.
 - **Which local box, and which model on it** — pending.

--- a/docs/architecture/mycel-deployment.md
+++ b/docs/architecture/mycel-deployment.md
@@ -66,6 +66,11 @@ operations run rarely, by one person, and each can move money or grant
 eligibility for traffic the operator is liable for (ADR 0012) — a route is a
 larger surface than a command, and the convenience is not worth securing.
 
+This does **not** forbid a read-only surface. ADR 0026 gives Clients their own
+view of their own usage, served by Mycel rather than by the habitats SaaS. The
+argument above is about consequence, not about HTTP: a route that moves no money
+and grants no eligibility is not the thing that was refused.
+
 ---
 
 ## Part 1 — The database

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "cli": "NODE_OPTIONS='--no-deprecation' tsx src/entry.ts",
     "test": "vitest --reporter=verbose",
     "test:run": "vitest run --reporter=verbose"
@@ -41,5 +42,15 @@
     "tsx": "^4.23.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "main": "./dist/cli.js",
+    "types": "./dist/cli.d.ts",
+    "bin": {
+      "umwelten": "dist/entry.js"
+    }
   }
 }

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  // Emit for publishing. The checked-in tsconfig.json stays noEmit because it
+  // is what `pnpm typecheck` and the editor use; this is the only place that
+  // writes anything.
+  //
+  // outDir mirrors rootDir exactly, so a module's depth from the package root
+  // is identical in dist/ and src/. Several files resolve assets by walking up
+  // from import.meta.url (habitat's templates/ and public/, the CLI's
+  // package.json), and that is what keeps them correct in both layouts.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    // Tests are excluded below, so the build does not need vitest's globals.
+    "types": ["node"]
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.integration.test.ts",
+    "**/__fixtures__/**"
+  ]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,12 +25,15 @@
     "node": ">=20.0.0"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest --reporter=verbose",
     "test:run": "vitest run --reporter=verbose"
   },
   "dependencies": {
     "@ai-sdk/google": "^4.0.27",
     "@ai-sdk/openai-compatible": "^3.0.16",
+    "@ai-sdk/provider": "^4.0.4",
+    "@ai-sdk/provider-utils": "^5.0.14",
     "@json-render/core": "^0.19.0",
     "@openrouter/ai-sdk-provider": "^3.0.0",
     "ai": "^7.0.41",
@@ -50,5 +53,22 @@
     "@types/node": "^26.1.2",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./*.js": {
+        "types": "./dist/*.d.ts",
+        "import": "./dist/*.js"
+      }
+    }
   }
 }

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  // Emit for publishing. The checked-in tsconfig.json stays noEmit because it
+  // is what `pnpm typecheck` and the editor use; this is the only place that
+  // writes anything.
+  //
+  // outDir mirrors rootDir exactly, so a module's depth from the package root
+  // is identical in dist/ and src/. Several files resolve assets by walking up
+  // from import.meta.url (habitat's templates/ and public/, the CLI's
+  // package.json), and that is what keeps them correct in both layouts.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    // Tests are excluded below, so the build does not need vitest's globals.
+    "types": ["node"]
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.integration.test.ts",
+    "**/__fixtures__/**"
+  ]
+}

--- a/packages/evaluation/package.json
+++ b/packages/evaluation/package.json
@@ -25,10 +25,13 @@
     "node": ">=20.0.0"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest --reporter=verbose",
     "test:run": "vitest run --reporter=verbose"
   },
   "dependencies": {
+    "@ai-sdk/provider": "^4.0.4",
+    "@ai-sdk/provider-utils": "^5.0.14",
     "@umwelten/core": "workspace:*",
     "@umwelten/sessions": "workspace:*",
     "ai": "^7.0.41",
@@ -39,5 +42,22 @@
     "@types/node": "^26.1.2",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./*.js": {
+        "types": "./dist/*.d.ts",
+        "import": "./dist/*.js"
+      }
+    }
   }
 }

--- a/packages/evaluation/tsconfig.build.json
+++ b/packages/evaluation/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  // Emit for publishing. The checked-in tsconfig.json stays noEmit because it
+  // is what `pnpm typecheck` and the editor use; this is the only place that
+  // writes anything.
+  //
+  // outDir mirrors rootDir exactly, so a module's depth from the package root
+  // is identical in dist/ and src/. Several files resolve assets by walking up
+  // from import.meta.url (habitat's templates/ and public/, the CLI's
+  // package.json), and that is what keeps them correct in both layouts.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    // Tests are excluded below, so the build does not need vitest's globals.
+    "types": ["node"]
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.integration.test.ts",
+    "**/__fixtures__/**"
+  ]
+}

--- a/packages/habitat/package.json
+++ b/packages/habitat/package.json
@@ -25,12 +25,14 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest --reporter=verbose",
     "test:run": "vitest run --reporter=verbose"
   },
   "dependencies": {
     "@a2a-js/sdk": "^1.0.1",
+    "@ai-sdk/provider": "^4.0.4",
+    "@ai-sdk/provider-utils": "^5.0.14",
     "@mcp-ui/server": "^6.1.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@umwelten/core": "workspace:*",
@@ -57,6 +59,26 @@
     },
     "@tavily/core": {
       "optional": true
+    }
+  },
+  "files": [
+    "dist",
+    "public",
+    "templates",
+    "entrypoint.sh"
+  ],
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./*.js": {
+        "types": "./dist/*.d.ts",
+        "import": "./dist/*.js"
+      }
     }
   }
 }

--- a/packages/habitat/tsconfig.build.json
+++ b/packages/habitat/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  // Emit for publishing. The checked-in tsconfig.json stays noEmit because it
+  // is what `pnpm typecheck` and the editor use; this is the only place that
+  // writes anything.
+  //
+  // outDir mirrors rootDir exactly, so a module's depth from the package root
+  // is identical in dist/ and src/. Several files resolve assets by walking up
+  // from import.meta.url (habitat's templates/ and public/, the CLI's
+  // package.json), and that is what keeps them correct in both layouts.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    // Tests are excluded below, so the build does not need vitest's globals.
+    "types": ["node"]
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.integration.test.ts",
+    "**/__fixtures__/**"
+  ]
+}

--- a/packages/mycel/CONTEXT.md
+++ b/packages/mycel/CONTEXT.md
@@ -16,7 +16,9 @@ _Avoid_: Provider (means an Umwelten vendor integration), factory, host, node, w
 **Guarantee**:
 A promise about the conditions under which a Supplier produces tokens, such as
 staying on-premise or not being trained on. Asserted by the operator, who is
-liable for it, rather than self-declared by the Supplier.
+liable for it, rather than self-declared by the Supplier. On hardware the
+operator does not own it rests on a contract with that Supplier, enforced after
+the fact rather than prevented (ADR 0029 — Mycel sells as principal).
 _Avoid_: Capability, policy, SLA, tag
 
 **Headroom**:
@@ -72,8 +74,17 @@ _Avoid_: user, customer, account, subject
 ### Money
 
 **Balance**:
-Money available to be spent, held by a Client, an Application, or an End User.
+What a Client, an Application, or an End User has left to spend — negative when
+it has spent more than it holds, which only a Credit Limit permits. Always the
+sum of its ledger entries, never a stored total.
 _Avoid_: credits, wallet, quota
+
+**Credit Limit**:
+How far a Client's Balance may go negative before the exchange refuses it. Set
+by the operator, per Client; zero means prepaid. Applies only to a Client's own
+Balance, never to an Application's or an End User's, because granting one of
+those an amount is how you cap it (ADR 0028 — a Client may be postpaid).
+_Avoid_: credit line, overdraft, allowance, quota
 
 **Cost**:
 What a Supplier is owed for a request. Zero when the operator owns the hardware.

--- a/packages/mycel/CONTEXT.md
+++ b/packages/mycel/CONTEXT.md
@@ -97,3 +97,55 @@ _Avoid_: Cost, price, rate
 **Settlement**:
 Periodic reconciliation of what each Supplier is owed for the requests it served.
 _Avoid_: payout, invoice, billing
+
+## Relationships
+
+- A **Client** owns one or more **Applications**; only a Client is invoiced
+- An **Application** knows an **End User** only through a claim it signs
+- A **Supplier** publishes zero or more **Offers**; an **Offer** serves exactly
+  one **Model**, and one Model is served by many Offers
+- A **Guarantee** belongs to a **Supplier**; a **Capability** belongs to an
+  **Offer** — which is why two Offers for one Model are not interchangeable
+- **Dispatch** chooses exactly one **Offer** per request
+- One request produces exactly one **Cost** and one **Charge**, and neither is
+  computed from the other
+- A **Balance** is held by a Client, an Application, or an End User; a Charge
+  falls to the first of those three that has ever had an entry
+- A **Credit Limit** belongs to a **Client** and applies only to that Client's
+  own Balance
+- **Settlement** aggregates **Costs** by Supplier, never **Charges**
+
+## Example dialogue
+
+> **Dev:** "An **End User** with an empty **Balance** makes a request. Do we
+> refuse it?"
+>
+> **Domain expert:** "Depends why it's empty. If you granted them $5 and they
+> spent it, yes — granting is how you cap someone. If they were never granted
+> anything, they have no Balance at all and the **Charge** falls through to the
+> **Application**, then to the **Client**."
+>
+> **Dev:** "And the Client is out of money too?"
+>
+> **Domain expert:** "Then it depends on its **Credit Limit**. A Client can go
+> negative, because we have a contract with it. The End User can't, because a
+> cap you can exceed isn't a cap."
+>
+> **Dev:** "The Supplier's **Offer** costs us nothing — it's our own hardware.
+> So the Charge is zero?"
+>
+> **Domain expert:** "No. **Cost** is what the Supplier is owed; **Charge** is
+> what we debit. Ours being free is our margin, not the buyer's discount."
+
+## Flagged ambiguities
+
+- "user" was used for both the operator and the person using an **Application**
+  — resolved: the latter is an **End User**, and "user" is never used bare.
+- "**Guarantee**" was ambiguous between a promise the Supplier makes and one we
+  make — resolved: the operator asserts it and is liable for it, backed by
+  contract on hardware we do not own (ADR 0029).
+- "aborted" was used for any truncated stream, which conflated a buyer hanging
+  up with a Supplier dropping — resolved: four distinct outcomes, because only
+  one of them is the buyer's own doing and only one of them is our fault.
+- "**Headroom**" is capacity measured at probe time, never current utilization.
+  Nothing in the system reads what a machine is doing right now.

--- a/packages/mycel/package.json
+++ b/packages/mycel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@umwelten/mycel",
-  "version": "0.1.0",
-  "description": "Mycel \u2014 the Exchange: buys model tokens wholesale from Suppliers and resells them retail to Applications",
+  "version": "0.4.13",
+  "description": "Mycel — the Exchange: buys model tokens wholesale from Suppliers and resells them retail to Applications",
   "type": "module",
   "exports": {
     ".": {
@@ -14,6 +14,7 @@
     }
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
@@ -26,5 +27,20 @@
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./*.js": {
+        "types": "./dist/*.d.ts",
+        "import": "./dist/*.js"
+      }
+    }
+  }
 }

--- a/packages/mycel/src/buyer/handler.ts
+++ b/packages/mycel/src/buyer/handler.ts
@@ -24,7 +24,7 @@
 
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { CapabilityName } from "../types.js";
+import type { CapabilityName, RequestOutcome } from "../types.js";
 import { dispatch, type DispatchRequirements } from "../dispatch.js";
 import {
   AuthError,
@@ -250,7 +250,13 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
     const startedAt = new Date();
     const promptTokens = estimatePromptTokens(body);
     const counter = new StreamCounter();
-    let aborted = false;
+    // First cause wins. A caller who hangs up and *then* trips the read loop
+    // would otherwise be recorded as a supply failure, which inverts the whole
+    // point of separating them.
+    let outcome: RequestOutcome | undefined;
+    const settle = (cause: RequestOutcome) => {
+      outcome ??= cause;
+    };
     let recorded = false;
     let upstreamUsage: { prompt?: number; completion?: number } = {};
     // End User → Application → Client, stopping at the first that has ever
@@ -288,7 +294,7 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
         completionTokens,
         cost,
         charge,
-        aborted,
+        outcome: outcome ?? "completed",
         upstreamPromptTokens: upstreamUsage.prompt,
         upstreamCompletionTokens: upstreamUsage.completion,
         startedAt,
@@ -309,7 +315,7 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
     const upstream = new AbortController();
     let cancelBody: (() => void) | undefined;
     const clientGone = () => {
-      aborted = true;
+      settle("buyer-aborted");
       upstream.abort();
       cancelBody?.();
     };
@@ -409,6 +415,7 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
           // that never started.
           if (!(await balances.canCover(owner, running, floor))) {
             creditExhausted = true;
+            settle("credit-exhausted");
             upstream.abort();
             cancelBody?.();
             break;
@@ -418,6 +425,11 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
     } catch {
       // An upstream that dies mid-stream leaves the caller with a truncated
       // response and no way to signal an error — headers are already sent.
+      //
+      // So the only place it can be said is the record. Under ADR 0023 this
+      // stops being an exception: a dial-in Supplier is a laptop whose lid
+      // closes, and this is the path that fires when it does.
+      settle("supply-failed");
     } finally {
       // Runs on every path out of the relay — normal completion, an upstream
       // that died mid-stream, and a caller that hung up. That is the point:

--- a/packages/mycel/src/buyer/handler.ts
+++ b/packages/mycel/src/buyer/handler.ts
@@ -38,7 +38,12 @@ import {
   estimatePromptTokens,
   priceRequest,
 } from "../metering/counter.js";
-import { Balances, resolveChargeOwner, type BalanceOwner } from "../metering/balances.js";
+import {
+  Balances,
+  creditFloorFor,
+  resolveChargeOwner,
+  type BalanceOwner,
+} from "../metering/balances.js";
 import type { ExchangeStore } from "../store/types.js";
 
 export const CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
@@ -252,12 +257,15 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
     // had a ledger entry. Resolved once and then both checked and debited, so
     // an unfunded user never accidentally acquires an entry of its own.
     const owner: BalanceOwner = await resolveChargeOwner(caller, balances);
+    // Only a Client's own Balance may go negative, and only to the limit the
+    // operator gave it (ADR 0028). A capped End User still stops at zero.
+    const floor = await creditFloorFor(owner, caller.application.clientId, store);
 
     // Refuse before forwarding when the prompt alone cannot be covered. There
     // is no point buying tokens the buyer cannot pay for, and this is the only
     // moment nothing has been consumed yet.
     const promptCharge = priceRequest(offer, promptTokens, 0).charge;
-    if (!(await balances.canCover(owner, promptCharge))) {
+    if (!(await balances.canCover(owner, promptCharge, floor))) {
       sendJson(res, 402, {
         error: BuyerError.INSUFFICIENT_BALANCE,
         message: "Balance does not cover this request.",
@@ -396,7 +404,10 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
         if (chunksSinceCheck >= BALANCE_CHECK_INTERVAL) {
           chunksSinceCheck = 0;
           const running = priceRequest(offer, promptTokens, counter.completionTokens).charge;
-          if (!(await balances.canCover(owner, running))) {
+          // Same floor as the pre-flight check. Cutting a postpaid Client off
+          // at zero mid-response would make its limit apply only to requests
+          // that never started.
+          if (!(await balances.canCover(owner, running, floor))) {
             creditExhausted = true;
             upstream.abort();
             cancelBody?.();

--- a/packages/mycel/src/buyer/handler.ts
+++ b/packages/mycel/src/buyer/handler.ts
@@ -254,7 +254,7 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
     // would otherwise be recorded as a supply failure, which inverts the whole
     // point of separating them.
     let outcome: RequestOutcome | undefined;
-    const settle = (cause: RequestOutcome) => {
+    const endedBecause = (cause: RequestOutcome) => {
       outcome ??= cause;
     };
     let recorded = false;
@@ -315,7 +315,7 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
     const upstream = new AbortController();
     let cancelBody: (() => void) | undefined;
     const clientGone = () => {
-      settle("buyer-aborted");
+      endedBecause("buyer-aborted");
       upstream.abort();
       cancelBody?.();
     };
@@ -415,7 +415,7 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
           // that never started.
           if (!(await balances.canCover(owner, running, floor))) {
             creditExhausted = true;
-            settle("credit-exhausted");
+            endedBecause("credit-exhausted");
             upstream.abort();
             cancelBody?.();
             break;
@@ -429,7 +429,7 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
       // So the only place it can be said is the record. Under ADR 0023 this
       // stops being an exception: a dial-in Supplier is a laptop whose lid
       // closes, and this is the path that fires when it does.
-      settle("supply-failed");
+      endedBecause("supply-failed");
     } finally {
       // Runs on every path out of the relay — normal completion, an upstream
       // that died mid-stream, and a caller that hung up. That is the point:

--- a/packages/mycel/src/dispatch-selection.test.ts
+++ b/packages/mycel/src/dispatch-selection.test.ts
@@ -1,0 +1,202 @@
+/**
+ * The two selection changes from ADR 0027.
+ *
+ * Both correct things that were built on assumptions: that two Offers sharing a
+ * Model name are interchangeable, and that the cheapest eligible one always
+ * wins. The second mattered more than it sounds — owned hardware costs zero, so
+ * it beat every vendor regardless of how slow or how serialized it was.
+ */
+
+import { describe, it, expect } from "vitest";
+import { DEFAULT_WEIGHTS, dispatch, scoreOffers } from "./dispatch.js";
+import type { HeadroomSample, Offer } from "./types.js";
+
+const MODEL = "gemma-4-26b";
+
+const sample = (o: Partial<HeadroomSample> = {}): HeadroomSample => ({
+  concurrency: 4,
+  ttftMs: 400,
+  tokensPerSecond: 300,
+  decodeTokensPerSecond: 90,
+  ...o,
+});
+
+function offer(overrides: Partial<Offer> = {}): Offer {
+  return {
+    supplierId: "a",
+    model: MODEL,
+    capabilities: ["chat", "streaming"],
+    guarantees: [],
+    servingMode: "managed",
+    headroom: [],
+    wholesalePromptPerMillion: 0,
+    wholesaleCompletionPerMillion: 0,
+    retailPromptPerMillion: 100,
+    retailCompletionPerMillion: 100,
+    enabled: true,
+    publishedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("resource properties are requirable", () => {
+  it("refuses an Offer at the wrong quantization", () => {
+    // The same weights served two ways expose different capabilities — the
+    // finding this whole project rests on. A buyer who needs Q8 gets a refusal
+    // rather than a quiet downgrade to Q4.
+    const result = dispatch([offer({ quantization: "Q4_K_M" })], {
+      model: MODEL,
+      quantization: "Q8_0",
+    });
+
+    expect(result.offer).toBeUndefined();
+    expect(result.considered[0].reason).toBe("wrong-quantization");
+  });
+
+  it("refuses an Offer that never said which quantization it serves", () => {
+    // An adapted Offer resells a configuration its Supplier does not control,
+    // so it cannot honestly claim one — and silence must not pass as a match.
+    const result = dispatch([offer({ servingMode: "adapted" })], {
+      model: MODEL,
+      quantization: "Q8_0",
+    });
+    expect(result.considered[0].reason).toBe("wrong-quantization");
+  });
+
+  it("takes the matching quantization over the cheaper one", () => {
+    const cheapWrongQuant = offer({
+      supplierId: "vendor",
+      quantization: "Q4_K_M",
+      retailPromptPerMillion: 1,
+      retailCompletionPerMillion: 1,
+    });
+    const pricierRightQuant = offer({
+      supplierId: "office",
+      quantization: "Q8_0",
+      retailPromptPerMillion: 9_000,
+      retailCompletionPerMillion: 9_000,
+    });
+
+    const result = dispatch([cheapWrongQuant, pricierRightQuant], {
+      model: MODEL,
+      quantization: "Q8_0",
+    });
+    expect(result.offer?.supplierId).toBe("office");
+  });
+
+  it("refuses an Offer whose context is too small", () => {
+    const result = dispatch([offer({ contextTokens: 8_192 })], {
+      model: MODEL,
+      minContextTokens: 131_072,
+    });
+    expect(result.considered[0].reason).toBe("insufficient-context");
+  });
+
+  it("ignores both when the buyer does not ask", () => {
+    // Requirable, not mandatory. Making everyone specify a quantization would
+    // turn the catalogue into an exam.
+    const result = dispatch([offer({ quantization: "Q4_K_M", contextTokens: 4_096 })], {
+      model: MODEL,
+    });
+    expect(result.offer).toBeDefined();
+  });
+});
+
+describe("scoring", () => {
+  it("no longer hands every request to the cheapest Offer", () => {
+    // The case that motivated this. Owned hardware costs zero, so under
+    // price-only ranking a DGX that queues four-deep beat an idle vendor every
+    // single time.
+    const freeButSerializing = offer({
+      supplierId: "office",
+      retailPromptPerMillion: 0,
+      retailCompletionPerMillion: 0,
+      headroom: [sample({ tokensPerSecond: 95, ttftMs: 48_000 })],
+      headroomMeta: { sampledAt: "x", saturation: "queues" },
+    });
+    const pricierButFast = offer({
+      supplierId: "vendor",
+      retailPromptPerMillion: 3_000,
+      retailCompletionPerMillion: 3_000,
+      headroom: [sample({ tokensPerSecond: 900, ttftMs: 300 })],
+      headroomMeta: { sampledAt: "x", saturation: "batches" },
+    });
+
+    const result = dispatch([freeButSerializing, pricierButFast], { model: MODEL });
+    expect(result.offer?.supplierId).toBe("vendor");
+  });
+
+  it("still prefers cheap when nothing else separates them", () => {
+    // Price remains the dominant term. Owned hardware being cheap is a real
+    // advantage, not an accident to correct away.
+    const cheap = offer({ supplierId: "cheap", retailCompletionPerMillion: 10 });
+    const pricey = offer({ supplierId: "pricey", retailCompletionPerMillion: 5_000 });
+
+    expect(dispatch([pricey, cheap], { model: MODEL }).offer?.supplierId).toBe("cheap");
+  });
+
+  it("does not punish an Offer for having no Headroom", () => {
+    // A vendor catalogue is published without probes. Scoring the gap as slow
+    // would make every vendor lose to any probed Offer on grounds nobody
+    // established.
+    const unmeasured = offer({ supplierId: "vendor", retailCompletionPerMillion: 10 });
+    const measured = offer({
+      supplierId: "office",
+      retailCompletionPerMillion: 5_000,
+      headroom: [sample()],
+      headroomMeta: { sampledAt: "x", saturation: "batches" },
+    });
+
+    expect(dispatch([measured, unmeasured], { model: MODEL }).offer?.supplierId).toBe("vendor");
+  });
+
+  it("records the terms, so the choice stays explicable", () => {
+    // A weighted function stops being answerable the moment nobody writes down
+    // what went into it.
+    const result = dispatch([offer({ headroom: [sample()] })], { model: MODEL });
+    const [entry] = result.considered;
+
+    expect(entry.score).toBeGreaterThan(0);
+    expect(entry.terms).toMatchObject({
+      price: expect.any(Number),
+      throughput: expect.any(Number),
+      timeToFirstToken: expect.any(Number),
+      concurrency: expect.any(Number),
+    });
+  });
+
+  it("scores a lone Offer at full marks on every term", () => {
+    // Nothing to prefer it over, so nothing should count against it.
+    const [only] = scoreOffers([offer({ headroom: [sample()] })]);
+    expect(only.terms.price).toBe(1);
+    expect(only.terms.throughput).toBe(1);
+  });
+
+  it("is deterministic under a tie", () => {
+    const offers = [offer({ supplierId: "b" }), offer({ supplierId: "a" })];
+    expect(dispatch(offers, { model: MODEL }).offer?.supplierId).toBe("a");
+    expect(dispatch([...offers].reverse(), { model: MODEL }).offer?.supplierId).toBe("a");
+  });
+
+  it("collapses to price-only when the other weights are zeroed", () => {
+    // The escape hatch, and the reason the old behaviour is still reachable.
+    const free = offer({
+      supplierId: "office",
+      retailPromptPerMillion: 0,
+      retailCompletionPerMillion: 0,
+      headroomMeta: { sampledAt: "x", saturation: "queues" },
+      headroom: [sample({ ttftMs: 48_000 })],
+    });
+    const fast = offer({
+      supplierId: "vendor",
+      retailCompletionPerMillion: 3_000,
+      headroom: [sample({ ttftMs: 300 })],
+      headroomMeta: { sampledAt: "x", saturation: "batches" },
+    });
+
+    const result = dispatch([free, fast], { model: MODEL }, {
+      weights: { ...DEFAULT_WEIGHTS, throughput: 0, timeToFirstToken: 0, concurrency: 0 },
+    });
+    expect(result.offer?.supplierId).toBe("office");
+  });
+});

--- a/packages/mycel/src/dispatch.ts
+++ b/packages/mycel/src/dispatch.ts
@@ -27,6 +27,15 @@ export interface DispatchRequirements {
   capabilities?: CapabilityName[];
   /** When set, an Offer for a Model outside this list is never selected. */
   allowedModels?: string[];
+  /**
+   * Requirable, not mandatory (ADR 0027). A buyer who knows they need Q8 says
+   * so and gets a refusal rather than a quiet downgrade; one who does not care
+   * gets whatever wins. The same weights served two ways expose different
+   * capabilities, which is why the Offer carries this at all.
+   */
+  quantization?: string;
+  /** Smallest context this request needs the Offer to actually accept. */
+  minContextTokens?: number;
 }
 
 export type RejectionReason =
@@ -35,7 +44,17 @@ export type RejectionReason =
   | "offer-disabled"
   | "offer-stale"
   | "missing-guarantee"
-  | "missing-capability";
+  | "missing-capability"
+  | "wrong-quantization"
+  | "insufficient-context";
+
+/** Why an eligible Offer scored the way it did. */
+export interface ScoreTerms {
+  price: number;
+  throughput: number;
+  timeToFirstToken: number;
+  concurrency: number;
+}
 
 export interface Considered {
   supplierId: string;
@@ -44,6 +63,14 @@ export interface Considered {
   reason?: RejectionReason;
   /** What this Offer would have charged, for the ones that were eligible. */
   rankingPrice?: MicroDollars;
+  /** Higher wins. Only meaningful relative to the others in this request. */
+  score?: number;
+  /**
+   * The terms that produced it. A weighted function stops being explicable the
+   * moment nobody writes down what went into it, and "why did this request go
+   * there" has to stay answerable (ADR 0027).
+   */
+  terms?: ScoreTerms;
 }
 
 export interface DispatchResult {
@@ -57,16 +84,117 @@ export interface DispatchResult {
 }
 
 /**
- * A single number to rank an Offer by.
+ * What a request would cost, as one number.
  *
  * Prompt and completion are priced separately but a request has to be ranked
  * before either token count is known, so this weights them by a rough
- * completion-heavy mix. Deliberately crude and deliberately in one place: when
- * metering lands (#297) and real token counts are available before dispatch,
- * this is what gets replaced.
+ * completion-heavy mix. Still crude, still in one place — but it is now one
+ * term in a score rather than the whole decision (ADR 0027).
  */
 export function rankingPrice(offer: Offer): MicroDollars {
   return offer.retailPromptPerMillion + offer.retailCompletionPerMillion * 3;
+}
+
+/**
+ * How much each term moves the score. Constants in one place, tunable per
+ * deployment, and deliberately *not* per-Application: a buyer expressing a
+ * preference does it through a requirement, which is a filter and therefore
+ * explicable, rather than by nudging a scoring function.
+ */
+export interface ScoreWeights {
+  price: number;
+  throughput: number;
+  timeToFirstToken: number;
+  concurrency: number;
+}
+
+export const DEFAULT_WEIGHTS: ScoreWeights = {
+  // Price still dominates — the Exchange exists to buy tokens well, and owned
+  // hardware being cheap is a real advantage rather than an accident to correct.
+  price: 1,
+  throughput: 0.4,
+  timeToFirstToken: 0.4,
+  // A binary, and worth its own weight: an Offer that serves requests one at a
+  // time cannot take a second customer, which is a different kind of fact from
+  // being somewhat slower.
+  concurrency: 0.3,
+};
+
+/** The best sample an Offer published, by concurrency level. */
+function bestSample(offer: Offer) {
+  return [...offer.headroom].sort((a, b) => b.concurrency - a.concurrency)[0];
+}
+
+/**
+ * Map a value into 0..1 across the range present in this request's eligible
+ * set, so a score only ever means "compared to the alternatives here".
+ *
+ * A single eligible Offer scores 1 on every term, which is correct: there is
+ * nothing to prefer it over.
+ */
+function normalize(value: number, min: number, max: number, higherIsBetter: boolean): number {
+  if (!Number.isFinite(value) || max === min) return 1;
+  const scaled = (value - min) / (max - min);
+  return higherIsBetter ? scaled : 1 - scaled;
+}
+
+/**
+ * Score every eligible Offer against the others.
+ *
+ * **This is capacity, not utilization.** Headroom was measured at probe time,
+ * not read from the machine now, so an Offer that batches well and is currently
+ * serving six requests looks exactly like an idle one. The score prefers an
+ * Offer that is characteristically fast and concurrent; it does not avoid a
+ * busy one. Live load becomes observable under ADR 0023, and that is when this
+ * becomes real load balancing.
+ *
+ * An Offer with no Headroom scores on price alone — neither rewarded nor
+ * punished for a measurement nobody asked it for, which is the normal case for
+ * a vendor catalogue.
+ */
+export function scoreOffers(
+  offers: Offer[],
+  weights: ScoreWeights = DEFAULT_WEIGHTS,
+): { offer: Offer; score: number; terms: ScoreTerms }[] {
+  const prices = offers.map(rankingPrice);
+  const samples = offers.map(bestSample);
+  const throughputs = samples.map((s) => s?.tokensPerSecond ?? 0).filter((n) => n > 0);
+  const ttfts = samples.map((s) => s?.ttftMs ?? 0).filter((n) => n > 0);
+
+  const range = (values: number[]) => ({
+    min: values.length ? Math.min(...values) : 0,
+    max: values.length ? Math.max(...values) : 0,
+  });
+  const priceRange = range(prices);
+  const throughputRange = range(throughputs);
+  const ttftRange = range(ttfts);
+
+  return offers.map((offer, index) => {
+    const sample = samples[index];
+    const measured = sample !== undefined;
+
+    const terms: ScoreTerms = {
+      price: normalize(prices[index], priceRange.min, priceRange.max, false),
+      // Unmeasured terms score 1 rather than 0: a missing measurement is not
+      // evidence of being slow, and scoring it as such would make every vendor
+      // Offer lose to any probed one on grounds nobody established.
+      throughput: measured
+        ? normalize(sample.tokensPerSecond, throughputRange.min, throughputRange.max, true)
+        : 1,
+      timeToFirstToken: measured
+        ? normalize(sample.ttftMs, ttftRange.min, ttftRange.max, false)
+        : 1,
+      concurrency: offer.headroomMeta?.saturation === "batches" ? 1 : measured ? 0 : 1,
+    };
+
+    const score =
+      terms.price * weights.price +
+      terms.throughput * weights.throughput +
+      terms.timeToFirstToken * weights.timeToFirstToken +
+      terms.concurrency * weights.concurrency;
+
+    return { offer, score: Number(score.toFixed(4)), terms };
+  });
 }
 
 /**
@@ -90,7 +218,7 @@ export const DEFAULT_STALE_AFTER_MS = 15 * 60_000;
 export function dispatch(
   offers: Offer[],
   requirements: DispatchRequirements,
-  opts: { staleAfterMs?: number; now?: Date } = {},
+  opts: { staleAfterMs?: number; now?: Date; weights?: ScoreWeights } = {},
 ): DispatchResult {
   const now = opts.now ?? new Date();
   const considered: Considered[] = [];
@@ -137,20 +265,43 @@ export function dispatch(
       continue;
     }
 
+    // An Offer with no recorded quantization does not satisfy a quantization
+    // requirement. An adapted Offer resells a configuration its Supplier does
+    // not control (ADR 0016) and cannot honestly claim one.
+    if (requirements.quantization && offer.quantization !== requirements.quantization) {
+      note("wrong-quantization");
+      continue;
+    }
+
+    if (
+      requirements.minContextTokens !== undefined &&
+      (offer.contextTokens ?? 0) < requirements.minContextTokens
+    ) {
+      note("insufficient-context");
+      continue;
+    }
+
+    eligible.push(offer);
+  }
+
+  // Scored against each other, not in isolation — a term only means anything
+  // relative to the alternatives for this request (ADR 0027).
+  const scored = scoreOffers(eligible, opts.weights);
+  for (const { offer, score, terms } of scored) {
     considered.push({
       supplierId: offer.supplierId,
       model: offer.model,
       eligible: true,
       rankingPrice: rankingPrice(offer),
+      score,
+      terms,
     });
-    eligible.push(offer);
   }
 
-  // Ties broken by supplier id so the choice is deterministic — otherwise the
-  // tests are flaky and, worse, so is production behaviour under a price tie.
-  eligible.sort(
-    (a, b) => rankingPrice(a) - rankingPrice(b) || a.supplierId.localeCompare(b.supplierId),
-  );
+  // Highest score wins. Ties broken by supplier id so the choice is
+  // deterministic — otherwise the tests are flaky and, worse, so is production
+  // routing under a tie.
+  scored.sort((a, b) => b.score - a.score || a.offer.supplierId.localeCompare(b.offer.supplierId));
 
-  return { offer: eligible[0], considered };
+  return { offer: scored[0]?.offer, considered };
 }

--- a/packages/mycel/src/metering/balances.ts
+++ b/packages/mycel/src/metering/balances.ts
@@ -123,9 +123,18 @@ export class Balances {
   }
 
   /** Whether there is enough to cover an amount before committing to it. */
-  async canCover(owner: BalanceOwner, microDollars: MicroDollars): Promise<boolean> {
+  /**
+   * @param floor  How far below zero this owner may go. Zero is prepaid.
+   *               Derived from the *resolved* owner rather than the caller,
+   *               which is what keeps a capped End User capped (ADR 0028).
+   */
+  async canCover(
+    owner: BalanceOwner,
+    microDollars: MicroDollars,
+    floor: MicroDollars = 0,
+  ): Promise<boolean> {
     const balance = await this.get(owner);
-    return balance.microDollars >= microDollars;
+    return balance.microDollars - microDollars >= -floor;
   }
 }
 
@@ -138,4 +147,21 @@ function entry(owner: BalanceOwner, microDollars: MicroDollars, reason: string):
     reason,
     createdAt: new Date(),
   };
+}
+
+/**
+ * How far the resolved owner may go negative.
+ *
+ * Only a Client gets a limit. A charge resolving to an End User or Application
+ * balance stops at zero — granting one of those is how you cap it, and a cap
+ * that can be exceeded is not a cap (ADR 0028).
+ */
+export async function creditFloorFor(
+  owner: BalanceOwner,
+  clientId: string,
+  store: ExchangeStore,
+): Promise<MicroDollars> {
+  if (owner.kind !== "client") return 0;
+  const client = await store.getClient(clientId);
+  return client?.creditLimitMicroDollars ?? 0;
 }

--- a/packages/mycel/src/metering/credit-limit.test.ts
+++ b/packages/mycel/src/metering/credit-limit.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Postpaid Clients (ADR 0028).
+ *
+ * The load-bearing part is *where* the limit applies. A Client may go negative
+ * because you have a contract with it; an End User granted an allowance may
+ * not, because granting one is how you cap it and a cap that can be exceeded is
+ * not a cap.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemoryStore } from "../store/memory-store.js";
+import {
+  Balances,
+  applicationOwner,
+  clientOwner,
+  creditFloorFor,
+  endUserOwner,
+  resolveChargeOwner,
+} from "./balances.js";
+import { Operator } from "../operator.js";
+import type { Caller } from "../auth/identity.js";
+
+describe("credit limits", () => {
+  let store: MemoryStore;
+  let balances: Balances;
+  let operator: Operator;
+  let caller: Caller;
+
+  beforeEach(async () => {
+    store = new MemoryStore();
+    await store.setup();
+    balances = new Balances(store);
+    operator = new Operator(store);
+
+    await operator.createClient("acme", "Acme");
+    const { application } = await operator.createApplication({
+      id: "hairstyle-app",
+      clientId: "acme",
+    });
+    caller = { application, subject: "user-1" };
+  });
+
+  it("defaults to prepaid, so existing Clients are unchanged", async () => {
+    const floor = await creditFloorFor(clientOwner("acme"), "acme", store);
+    expect(floor).toBe(0);
+    expect(await balances.canCover(clientOwner("acme"), 1, floor)).toBe(false);
+  });
+
+  it("lets a Client with a limit go negative", async () => {
+    await store.createClient({ id: "acme", name: "Acme", creditLimitMicroDollars: 10_000_000 });
+
+    const floor = await creditFloorFor(clientOwner("acme"), "acme", store);
+    expect(await balances.canCover(clientOwner("acme"), 5_000_000, floor)).toBe(true);
+  });
+
+  it("still refuses past the limit", async () => {
+    // The limit moves where the wall is; it does not remove the wall.
+    await store.createClient({ id: "acme", name: "Acme", creditLimitMicroDollars: 10_000_000 });
+    const floor = await creditFloorFor(clientOwner("acme"), "acme", store);
+
+    expect(await balances.canCover(clientOwner("acme"), 10_000_000, floor)).toBe(true);
+    expect(await balances.canCover(clientOwner("acme"), 10_000_001, floor)).toBe(false);
+  });
+
+  it("does not extend the limit to a capped End User", async () => {
+    // The whole reason the floor comes from the resolved owner. Granting a user
+    // $5 caps them at $5; the Client's credit line must not quietly lift it.
+    await store.createClient({ id: "acme", name: "Acme", creditLimitMicroDollars: 10_000_000 });
+    await balances.grant(endUserOwner(caller), 5_000);
+
+    const owner = await resolveChargeOwner(caller, balances);
+    expect(owner).toEqual(endUserOwner(caller));
+
+    const floor = await creditFloorFor(owner, "acme", store);
+    expect(floor).toBe(0);
+    expect(await balances.canCover(owner, 5_001, floor)).toBe(false);
+  });
+
+  it("does not extend the limit to an Application balance either", async () => {
+    await store.createClient({ id: "acme", name: "Acme", creditLimitMicroDollars: 10_000_000 });
+    await balances.grant(applicationOwner("hairstyle-app"), 1_000);
+
+    const owner = await resolveChargeOwner(caller, balances);
+    expect(owner).toEqual(applicationOwner("hairstyle-app"));
+    expect(await creditFloorFor(owner, "acme", store)).toBe(0);
+  });
+
+  it("applies the limit when the charge falls through to the Client", async () => {
+    // An unfunded End User draws from the pool behind it, and the pool is the
+    // thing that may float.
+    await store.createClient({ id: "acme", name: "Acme", creditLimitMicroDollars: 10_000_000 });
+
+    const owner = await resolveChargeOwner(caller, balances);
+    expect(owner).toEqual(clientOwner("acme"));
+
+    const floor = await creditFloorFor(owner, "acme", store);
+    expect(await balances.canCover(owner, 1_000_000, floor)).toBe(true);
+  });
+
+  it("treats a negative Balance as a normal amount owed", async () => {
+    await store.createClient({ id: "acme", name: "Acme", creditLimitMicroDollars: 10_000_000 });
+    await balances.debit(clientOwner("acme"), 2_000_000, "a month of requests");
+
+    const balance = await balances.get(clientOwner("acme"));
+    expect(balance.microDollars).toBe(-2_000_000);
+    // Still a sum of entries, never a stored total — which is what makes an
+    // invoice reconstructable.
+    const entries = await balances.entries(clientOwner("acme"));
+    expect(entries.reduce((sum, e) => sum + e.microDollars, 0)).toBe(-2_000_000);
+  });
+});

--- a/packages/mycel/src/metering/metering.test.ts
+++ b/packages/mycel/src/metering/metering.test.ts
@@ -84,7 +84,32 @@ describe("metering", () => {
       const record = await onlyRecord();
       expect(record.promptTokens).toBeGreaterThan(0);
       expect(record.completionTokens).toBeGreaterThan(0);
-      expect(record.aborted).toBe(false);
+      expect(record.outcome).toBe("completed");
+    });
+
+    it("tells a Supplier dropping apart from a buyer hanging up", async () => {
+      // The distinction ADR 0025 turns on, and the one the old `aborted` flag
+      // could not express: both truncate a stream, and only one is the buyer's
+      // doing. Under ADR 0023 the supply side of it stops being rare — a
+      // dial-in Supplier is a laptop, and laptops close.
+      await boot("dies-mid-stream");
+
+      const res = await chat({
+        model: MODEL,
+        messages: [{ role: "user", content: "hello there" }],
+        stream: true,
+      });
+      // Drain rather than abort: an abort here would be the buyer's doing and
+      // would mask exactly what this test is about.
+      await res.text().catch(() => {});
+      await new Promise((r) => setTimeout(r, 100));
+
+      const record = await onlyRecord();
+      expect(record.outcome).toBe("supply-failed");
+      expect(record.completionTokens).toBeGreaterThan(0);
+      // Recorded, not yet acted on. When the second half of ADR 0025 lands this
+      // becomes 0, and this line is where that change announces itself.
+      expect(record.charge).toBeGreaterThan(0);
     });
 
     it("attributes to the asserted End User of the Application", async () => {
@@ -163,7 +188,9 @@ describe("metering", () => {
 
       const record = await onlyRecord();
       expect(record).toBeDefined();
-      expect(record.aborted).toBe(true);
+      // Not merely "truncated" — the buyer's own doing, which is what makes it
+      // chargeable while a supply failure is not (ADR 0025).
+      expect(record.outcome).toBe("buyer-aborted");
       expect(record.promptTokens).toBeGreaterThan(1000);
       expect(record.charge).toBeGreaterThan(0);
     });

--- a/packages/mycel/src/store/neon-store.ts
+++ b/packages/mycel/src/store/neon-store.ts
@@ -24,6 +24,7 @@ import type {
   Offer,
   OfferPricing,
   PublishedOffer,
+  RequestOutcome,
   RequestRecord,
   ServingMode,
   Supplier,
@@ -139,7 +140,7 @@ export class NeonStore implements ExchangeStore {
         completion_tokens INTEGER NOT NULL,
         cost BIGINT NOT NULL,
         charge BIGINT NOT NULL,
-        aborted BOOLEAN NOT NULL DEFAULT false,
+        outcome TEXT NOT NULL DEFAULT 'completed',
         upstream_prompt_tokens INTEGER,
         upstream_completion_tokens INTEGER,
         started_at TIMESTAMPTZ NOT NULL,
@@ -247,12 +248,12 @@ export class NeonStore implements ExchangeStore {
     await this.sql`
       INSERT INTO exchange_request
         (id, application_id, subject, supplier_id, model, prompt_tokens,
-         completion_tokens, cost, charge, aborted, upstream_prompt_tokens,
+         completion_tokens, cost, charge, outcome, upstream_prompt_tokens,
          upstream_completion_tokens, started_at, finished_at)
       VALUES (
         ${record.id}, ${record.applicationId}, ${record.subject}, ${record.supplierId},
         ${record.model}, ${record.promptTokens}, ${record.completionTokens},
-        ${record.cost}, ${record.charge}, ${record.aborted},
+        ${record.cost}, ${record.charge}, ${record.outcome},
         ${record.upstreamPromptTokens ?? null}, ${record.upstreamCompletionTokens ?? null},
         ${record.startedAt.toISOString()}, ${record.finishedAt.toISOString()}
       )
@@ -486,7 +487,7 @@ function toRequestRecord(row: Row): RequestRecord {
     completionTokens: Number(row.completion_tokens),
     cost: Number(row.cost),
     charge: Number(row.charge),
-    aborted: Boolean(row.aborted),
+    outcome: String(row.outcome) as RequestOutcome,
     upstreamPromptTokens:
       row.upstream_prompt_tokens === null ? undefined : Number(row.upstream_prompt_tokens),
     upstreamCompletionTokens:

--- a/packages/mycel/src/testing/mock-upstream.ts
+++ b/packages/mycel/src/testing/mock-upstream.ts
@@ -19,7 +19,13 @@ export type UpstreamMode =
   /** Streams slowly and forever, so the caller must abort. */
   | "never-finishes"
   /** Refuses with a 500 and an error body. */
-  | "error";
+  | "error"
+  /**
+   * Streams a few tokens and then drops the socket without a terminator. What
+   * a runtime crash or a dial-in machine going to sleep looks like from here —
+   * indistinguishable from a buyer hanging up unless the relay says which.
+   */
+  | "dies-mid-stream";
 
 export interface MockUpstream {
   baseUrl: string;
@@ -116,9 +122,17 @@ export async function startMockUpstream(mode: UpstreamMode = "ok"): Promise<Mock
     res.on("close", disconnected);
     res.on("error", disconnected);
 
+    let written = 0;
     for (const word of WORDS) {
       if (closed) return;
       res.write(`data: ${JSON.stringify(chunk(model, word))}\n\n`);
+      written += 1;
+      // Mid-stream, deliberately: enough tokens relayed that the buyer has a
+      // partial answer, and no [DONE] so the relay cannot mistake it for an end.
+      if (mode === "dies-mid-stream" && written >= 3) {
+        res.destroy();
+        return;
+      }
       await new Promise((r) => setTimeout(r, 15));
     }
 

--- a/packages/mycel/src/types.ts
+++ b/packages/mycel/src/types.ts
@@ -180,6 +180,15 @@ export interface PublishedOffer {
 export interface Client {
   id: string;
   name: string;
+  /**
+   * How far this Client's own Balance may go negative before requests are
+   * refused (ADR 0028). Zero is prepaid — a hard stop at nothing left.
+   *
+   * Applies **only** to the Client's own Balance. A charge that resolves to an
+   * End User or Application balance still stops at zero, because granting one
+   * of those is how you cap it and a cap that can be exceeded is not one.
+   */
+  creditLimitMicroDollars?: MicroDollars;
 }
 
 /**

--- a/packages/mycel/src/types.ts
+++ b/packages/mycel/src/types.ts
@@ -272,6 +272,23 @@ export interface LedgerEntry {
  * Cost, End User balances read Charge, and every report must say which. Getting
  * that backwards bills a customer for GPU time we never paid for.
  */
+/**
+ * Why a request stopped producing tokens.
+ *
+ * The distinction that matters is *who chose*: a buyer who hangs up chose to,
+ * and we who picked the Supplier chose that. Both leave a truncated stream and
+ * before this they were indistinguishable after the fact.
+ */
+export type RequestOutcome =
+  /** The upstream finished the response. */
+  | "completed"
+  /** The caller hung up. The prompt was still submitted, so it is still owed. */
+  | "buyer-aborted"
+  /** The Supplier dropped, died, or errored partway. Our choice, our problem. */
+  | "supply-failed"
+  /** We cut the stream off because the Balance ran out mid-flight. */
+  | "credit-exhausted";
+
 export interface RequestRecord {
   id: string;
   applicationId: string;
@@ -285,8 +302,17 @@ export interface RequestRecord {
   completionTokens: number;
   cost: MicroDollars;
   charge: MicroDollars;
-  /** True when the caller hung up. The prompt is charged regardless. */
-  aborted: boolean;
+  /**
+   * How the request ended. A truncated stream has more than one cause and they
+   * are not each other's fault (ADR 0025 — the Exchange bears its own supply
+   * failures), so the cause is recorded rather than inferred from the fact of
+   * truncation.
+   *
+   * Recorded, not yet acted on: every outcome is still debited. Skipping the
+   * debit on `supply-failed` is the second half of ADR 0025 and is deliberately
+   * not done here.
+   */
+  outcome: RequestOutcome;
   /**
    * What the upstream said it used, when it said anything. Recorded for
    * reconciliation against our own count, never used to compute a Charge.

--- a/packages/mycel/tsconfig.build.json
+++ b/packages/mycel/tsconfig.build.json
@@ -1,0 +1,29 @@
+{
+  // Emit for publishing. The checked-in tsconfig.json stays noEmit because it
+  // is what `pnpm typecheck` and the editor use; this is the only place that
+  // writes anything.
+  //
+  // outDir mirrors rootDir exactly, so a module's depth from the package root
+  // is identical in dist/ and src/. Several files resolve assets by walking up
+  // from import.meta.url (habitat's templates/ and public/, the CLI's
+  // package.json), and that is what keeps them correct in both layouts.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    // Tests are excluded below, so the build does not need vitest's globals.
+    "types": ["node"]
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.integration.test.ts",
+    "**/__fixtures__/**",
+    "src/store/conformance.ts"
+  ]
+}

--- a/packages/protocols/package.json
+++ b/packages/protocols/package.json
@@ -25,15 +25,18 @@
     "node": ">=20.0.0"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest --reporter=verbose",
     "test:run": "vitest run --reporter=verbose",
     "conformance": "tsx src/a2a/conformance/run.ts"
   },
   "dependencies": {
-    "@umwelten/core": "workspace:*",
     "@a2a-js/sdk": "^1.0.1",
+    "@ai-sdk/provider": "^4.0.4",
+    "@ai-sdk/provider-utils": "^5.0.14",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@neondatabase/serverless": "^1.1.0",
+    "@umwelten/core": "workspace:*",
     "ai": "^7.0.41",
     "chalk": "^5.6.2",
     "zod": "^4.4.3"
@@ -42,5 +45,22 @@
     "@types/node": "^26.1.2",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./*.js": {
+        "types": "./dist/*.d.ts",
+        "import": "./dist/*.js"
+      }
+    }
   }
 }

--- a/packages/protocols/tsconfig.build.json
+++ b/packages/protocols/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  // Emit for publishing. The checked-in tsconfig.json stays noEmit because it
+  // is what `pnpm typecheck` and the editor use; this is the only place that
+  // writes anything.
+  //
+  // outDir mirrors rootDir exactly, so a module's depth from the package root
+  // is identical in dist/ and src/. Several files resolve assets by walking up
+  // from import.meta.url (habitat's templates/ and public/, the CLI's
+  // package.json), and that is what keeps them correct in both layouts.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    // Tests are excluded below, so the build does not need vitest's globals.
+    "types": ["node"]
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.integration.test.ts",
+    "**/__fixtures__/**"
+  ]
+}

--- a/packages/sessions/package.json
+++ b/packages/sessions/package.json
@@ -25,6 +25,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest --reporter=verbose",
     "test:run": "vitest run --reporter=verbose"
   },
@@ -39,5 +40,22 @@
     "@types/node": "^26.1.2",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./*.js": {
+        "types": "./dist/*.d.ts",
+        "import": "./dist/*.js"
+      }
+    }
   }
 }

--- a/packages/sessions/tsconfig.build.json
+++ b/packages/sessions/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  // Emit for publishing. The checked-in tsconfig.json stays noEmit because it
+  // is what `pnpm typecheck` and the editor use; this is the only place that
+  // writes anything.
+  //
+  // outDir mirrors rootDir exactly, so a module's depth from the package root
+  // is identical in dist/ and src/. Several files resolve assets by walking up
+  // from import.meta.url (habitat's templates/ and public/, the CLI's
+  // package.json), and that is what keeps them correct in both layouts.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    // Tests are excluded below, so the build does not need vitest's globals.
+    "types": ["node"]
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.integration.test.ts",
+    "**/__fixtures__/**"
+  ]
+}

--- a/packages/supplier/package.json
+++ b/packages/supplier/package.json
@@ -1,13 +1,22 @@
 {
   "name": "@umwelten/supplier",
-  "version": "0.1.0",
+  "version": "0.4.13",
   "description": "Turns a machine into a Supplier the Exchange can dispatch to",
   "type": "module",
   "exports": {
-    ".": { "types": "./src/index.ts", "import": "./src/index.ts" },
-    "./*.js": { "types": "./src/*.ts", "import": "./src/*.ts" }
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./*.js": {
+      "types": "./src/*.ts",
+      "import": "./src/*.ts"
+    }
   },
-  "scripts": { "typecheck": "tsc --noEmit -p tsconfig.json" },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
   "dependencies": {
     "@umwelten/core": "workspace:*",
     "commander": "^15.0.0"
@@ -17,5 +26,20 @@
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./*.js": {
+        "types": "./dist/*.d.ts",
+        "import": "./dist/*.js"
+      }
+    }
+  }
 }

--- a/packages/supplier/tsconfig.build.json
+++ b/packages/supplier/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  // Emit for publishing. The checked-in tsconfig.json stays noEmit because it
+  // is what `pnpm typecheck` and the editor use; this is the only place that
+  // writes anything.
+  //
+  // outDir mirrors rootDir exactly, so a module's depth from the package root
+  // is identical in dist/ and src/. Several files resolve assets by walking up
+  // from import.meta.url (habitat's templates/ and public/, the CLI's
+  // package.json), and that is what keeps them correct in both layouts.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    // Tests are excluded below, so the build does not need vitest's globals.
+    "types": ["node"]
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.integration.test.ts",
+    "**/__fixtures__/**"
+  ]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,10 +33,13 @@
     "node": ">=20.0.0"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest --reporter=verbose",
     "test:run": "vitest run --reporter=verbose"
   },
   "dependencies": {
+    "@ai-sdk/provider": "^4.0.4",
+    "@ai-sdk/provider-utils": "^5.0.14",
     "@grammyjs/files": "^1.2.0",
     "@types/react": "^19.2.17",
     "@umwelten/core": "workspace:*",
@@ -57,5 +60,38 @@
     "react-dom": "^19.2.8",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./cli/CLIInterface.js": {
+        "types": "./dist/cli/CLIInterface.d.ts",
+        "import": "./dist/cli/CLIInterface.js"
+      },
+      "./cli/DefaultCommands.js": {
+        "types": "./dist/cli/DefaultCommands.d.ts",
+        "import": "./dist/cli/DefaultCommands.js"
+      },
+      "./cli/repl.js": {
+        "types": "./dist/cli/repl.d.ts",
+        "import": "./dist/cli/repl.js"
+      },
+      "./discord/discord-backfill-sessions.js": {
+        "types": "./dist/discord/discord-backfill-sessions.d.ts",
+        "import": "./dist/discord/discord-backfill-sessions.js"
+      },
+      "./*.js": {
+        "types": "./dist/*.d.ts",
+        "import": "./dist/*.js"
+      }
+    }
   }
 }

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  // Emit for publishing. The checked-in tsconfig.json stays noEmit because it
+  // is what `pnpm typecheck` and the editor use; this is the only place that
+  // writes anything.
+  //
+  // outDir mirrors rootDir exactly, so a module's depth from the package root
+  // is identical in dist/ and src/. Several files resolve assets by walking up
+  // from import.meta.url (habitat's templates/ and public/, the CLI's
+  // package.json), and that is what keeps them correct in both layouts.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    // Tests are excluded below, so the build does not need vitest's globals.
+    "types": ["node"]
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.integration.test.ts",
+    "**/__fixtures__/**"
+  ]
+}

--- a/packages/umwelten/package.json
+++ b/packages/umwelten/package.json
@@ -27,7 +27,9 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "scripts": {},
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json"
+  },
   "dependencies": {
     "@umwelten/core": "workspace:*",
     "@umwelten/protocols": "workspace:*",
@@ -38,5 +40,25 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./mcp-serve": {
+        "types": "./dist/mcp-serve.d.ts",
+        "import": "./dist/mcp-serve.js"
+      }
+    },
+    "bin": {
+      "umwelten": "dist/entry.js"
+    }
   }
 }

--- a/packages/umwelten/tsconfig.build.json
+++ b/packages/umwelten/tsconfig.build.json
@@ -1,0 +1,28 @@
+{
+  // Emit for publishing. The checked-in tsconfig.json stays noEmit because it
+  // is what `pnpm typecheck` and the editor use; this is the only place that
+  // writes anything.
+  //
+  // outDir mirrors rootDir exactly, so a module's depth from the package root
+  // is identical in dist/ and src/. Several files resolve assets by walking up
+  // from import.meta.url (habitat's templates/ and public/, the CLI's
+  // package.json), and that is what keeps them correct in both layouts.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    // Tests are excluded below, so the build does not need vitest's globals.
+    "types": ["node"]
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.integration.test.ts",
+    "**/__fixtures__/**"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,12 @@ importers:
       '@ai-sdk/openai-compatible':
         specifier: ^3.0.16
         version: 3.0.16(zod@4.4.3)
+      '@ai-sdk/provider':
+        specifier: ^4.0.4
+        version: 4.0.4
+      '@ai-sdk/provider-utils':
+        specifier: ^5.0.14
+        version: 5.0.14(zod@4.4.3)
       '@json-render/core':
         specifier: ^0.19.0
         version: 0.19.0(zod@4.4.3)
@@ -208,6 +214,12 @@ importers:
 
   packages/evaluation:
     dependencies:
+      '@ai-sdk/provider':
+        specifier: ^4.0.4
+        version: 4.0.4
+      '@ai-sdk/provider-utils':
+        specifier: ^5.0.14
+        version: 5.0.14(zod@4.4.3)
       '@umwelten/core':
         specifier: workspace:*
         version: link:../core
@@ -239,6 +251,12 @@ importers:
       '@a2a-js/sdk':
         specifier: ^1.0.1
         version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1)
+      '@ai-sdk/provider':
+        specifier: ^4.0.4
+        version: 4.0.4
+      '@ai-sdk/provider-utils':
+        specifier: ^5.0.14
+        version: 5.0.14(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.220
         version: 0.3.220(@anthropic-ai/sdk@0.90.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)
@@ -313,6 +331,12 @@ importers:
       '@a2a-js/sdk':
         specifier: ^1.0.1
         version: 1.0.1(@grpc/grpc-js@1.14.4)(express@5.2.1)
+      '@ai-sdk/provider':
+        specifier: ^4.0.4
+        version: 4.0.4
+      '@ai-sdk/provider-utils':
+        specifier: ^5.0.14
+        version: 5.0.14(zod@4.4.3)
       '@modelcontextprotocol/sdk':
         specifier: ^1.30.0
         version: 1.30.0(zod@4.4.3)
@@ -391,6 +415,12 @@ importers:
 
   packages/ui:
     dependencies:
+      '@ai-sdk/provider':
+        specifier: ^4.0.4
+        version: 4.0.4
+      '@ai-sdk/provider-utils':
+        specifier: ^5.0.14
+        version: 5.0.14(zod@4.4.3)
       '@grammyjs/files':
         specifier: ^1.2.0
         version: 1.2.0(grammy@1.45.1)
@@ -512,16 +542,6 @@ packages:
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@5.0.7':
-    resolution: {integrity: sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider@4.0.3':
-    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
-    engines: {node: '>=22'}
 
   '@ai-sdk/provider@4.0.4':
     resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
@@ -3890,18 +3910,6 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.3
-      '@standard-schema/spec': 1.1.0
-      '@workflow/serde': 4.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
-
-  '@ai-sdk/provider@4.0.3':
-    dependencies:
-      json-schema: 0.4.0
-
   '@ai-sdk/provider@4.0.4':
     dependencies:
       json-schema: 0.4.0
@@ -6365,8 +6373,8 @@ snapshots:
 
   ollama-ai-provider-v2@4.0.1(ai@7.0.41(zod@4.4.3))(zod@4.4.3):
     dependencies:
-      '@ai-sdk/provider': 4.0.3
-      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.14(zod@4.4.3)
       ai: 7.0.41(zod@4.4.3)
       zod: 4.4.3
 


### PR DESCRIPTION
Two commits that pull in opposite directions, deliberately: the first makes the current design correct, the second records why the current design is wrong.

## Commit 1 — fixes for what exists

Two things #362's README got wrong about running this for real, found while writing the deployment instructions.

**The catalogue sync was documented as a command you run.** It takes `--watch` and never exits — so that meant holding a terminal open forever, and losing the heartbeat when ssh closed. Now a supervised compose service. **This is the sidecar ADR 0023 deletes**, and it's here anyway because until the protocol lands, this is how the thing behaves and an operator shouldn't be told to babysit a terminal.

**The operator alias hardcoded `/opt/umwelten`,** which isn't where the repo lives on `gaia-host`. Now a `$UMWELTEN` variable. Also documents `mycel price`, which #362 built but the README never mentioned — so the routing lever was undiscoverable.

## Commit 2 — ADR 0023

A Supplier that is a **machine** holds an outbound connection to Mycel and receives work over it. Mycel never connects to it; the box accepts no inbound connections at all. A **vendor** is still dialled out to, because a public API is reachable by definition.

Two transports, named — `Supplier.kind` is `agent` or `vendor`. The asymmetry *is* the correction: the previous design pretended a DGX on a desk and OpenRouter were the same kind of thing.

### What that assumption cost

**Onboarding became a network project.** "Install Tailscale, get an ACL, register an address, hand it to the operator" is not what someone with a spare Mac Studio does on a whim — and this pool's whole premise is other people's idle hardware.

**Liveness became unobservable, so it got inferred** — and the inference grew four mechanisms:

- a 15-minute staleness window on every Offer (ADR 0022)
- a 5-minute heartbeat republish in the supplier agent
- `offers sync --watch`
- the `mycel-offers` service added in commit 1

All four answer *"is this supplier alive?"* — a question a held connection answers by existing. **Connected is available; disconnected is withdrawn.** Nothing to tune, nothing to schedule.

### How this got missed

I raised it in the original grilling as Q10, "tunnel vs dial-out." I got no answer, wrote it into #303's Out of Scope, and then built on the unexamined assumption across #305–#310 — adding a workaround each time rather than noticing what the workarounds had in common. Accumulating machinery around a premise is the signal the premise deserves re-examining, and I kept building.

### A reversal of my own recommendation

I first proposed Tailscale for stage 2 with dial-out later, arguing Tailscale is zero code and would teach us what the protocol needs.

Wrong in the same shape. What Tailscale would prove — Mycel can relay to a remote GPU — is the same relay path a vendor already exercises. What's unproven is the protocol, which a tunnel derisks not at all. Staging it means building stage 2 twice and keeping four doomed mechanisms alive in between.

**Dial-out first.** Tailscale stays a fallback for a machine that can't run the agent.

## Also

ADR 0022's heartbeat section is marked *superseded in part* rather than rewritten — it's an accurate record of why that machinery existed. The deployment runbook's stage 2 row and open-decisions section are updated.

No code removals yet; those land with the protocol.

## Verification

2711 tests, typecheck, lint clean. `docker compose config` validates both services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG