### PR TITLE
Refresh with a freshly minted GitHub token, and stop guessing why a pull failed

### DIFF
--- a/packages/habitat/src/provision/execute.test.ts
+++ b/packages/habitat/src/provision/execute.test.ts
@@ -356,16 +356,34 @@ describe("executeProvisionPlan", () => {
     expect(rec.logs).toContain("[entrypoint] Updating agent web (git pull --ff-only)...");
   });
 
-  it("reports a non-fast-forward pull as a warning, not a failure", async () => {
+  it("reports a failed pull as a warning, not a failure", async () => {
     const rec = recorder({ fails: (c) => c.includes("git pull") });
     const result: ProvisionResult = await executeProvisionPlan(
       planFor(fullConfig, { ownedRepoCloned: true }),
       rec.deps,
     );
     expect(result.aborted).toBeUndefined();
-    expect(rec.logs).toContain(
-      "[entrypoint] Pull skipped (non-fast-forward or offline; keeping current checkout).",
-    );
+    expect(rec.logs.some((l) => l.includes("Pull FAILED for /data/project"))).toBe(true);
+  });
+
+  /**
+   * The message must not name a cause. It named two — "non-fast-forward or
+   * offline" — while the live failure was an expired credential, so a habitat
+   * whose checkout had silently stopped moving looked like a habitat with
+   * nothing new to report.
+   */
+  it("does not guess why a pull failed", async () => {
+    const rec = recorder({ fails: (c) => c.includes("git pull") });
+    await executeProvisionPlan(planFor(fullConfig, { ownedRepoCloned: true }), rec.deps);
+
+    const warnings = rec.logs.filter((l) => l.includes("Pull FAILED"));
+    expect(warnings.length).toBeGreaterThan(0);
+    for (const w of warnings) {
+      expect(w).not.toMatch(/non-fast-forward|offline/);
+      // Says the checkout is now stale, and points at git's own error.
+      expect(w).toMatch(/STALE/);
+      expect(w).toMatch(/git error above/);
+    }
   });
 
   it("does nothing at all without a config.json", async () => {

--- a/packages/habitat/src/provision/plan.ts
+++ b/packages/habitat/src/provision/plan.ts
@@ -156,7 +156,11 @@ export function planProvision(input: PlanProvisionInput): ProvisionPlan {
       branch: config.gitBranch,
       announce: `${LOG} Updating ${ownedRepoDir} (git pull --ff-only)...`,
       onFailure: "warn",
-      warning: `${LOG} Pull skipped (non-fast-forward or offline; keeping current checkout).`,
+      // Names no cause. The step cannot tell a diverged branch from an expired
+      // credential, and guessing produced a message that read as "nothing
+      // changed" while auth had been failing for hours — git's own error is
+      // already on stdout, so point at it instead of paraphrasing it wrong.
+      warning: `${LOG} Pull FAILED for ${ownedRepoDir} — keeping current checkout, which is now STALE. See the git error above.`,
     });
   }
 
@@ -264,7 +268,7 @@ export function planProvision(input: PlanProvisionInput): ProvisionPlan {
         envNames: agent.envNames,
         announce: `${LOG} Updating agent ${agent.id} (git pull --ff-only)...`,
         onFailure: "warn",
-        warning: `${LOG} Pull skipped for agent ${agent.id} (non-fast-forward or offline).`,
+        warning: `${LOG} Pull FAILED for agent ${agent.id} — keeping current checkout, which is now STALE. See the git error above.`,
       });
     }
 

--- a/packages/habitat/src/tools/gaia/docker.ts
+++ b/packages/habitat/src/tools/gaia/docker.ts
@@ -434,16 +434,28 @@ export class DockerManager {
    * with `--refresh`, so the decision about what needs updating stays in the
    * habitat rather than being second-guessed from outside.
    */
+  /**
+   * Run a command inside a running habitat.
+   *
+   * `env` overrides the container's own environment for this exec only. A
+   * long-running container still holds whatever was injected at start, and
+   * some of that expires — GitHub boot tokens live about an hour — so a caller
+   * that needs a credential to still be valid has to supply a fresh one rather
+   * than inherit a stale one. Passed via `docker exec -e`, so the values never
+   * appear in the command string.
+   */
   async execInContainer(
     id: string,
     command: string,
     timeout = 600000,
+    env?: Record<string, string>,
   ): Promise<{ ok: boolean; output: string }> {
     const name = containerName(id);
+    const envArgs = Object.entries(env ?? {}).flatMap(([k, v]) => ["-e", `${k}=${v}`]);
     try {
       const { stdout, stderr } = await execFile(
         "docker",
-        ["exec", name, "sh", "-c", command],
+        ["exec", ...envArgs, name, "sh", "-c", command],
         { timeout, maxBuffer: 10 * 1024 * 1024 },
       );
       return { ok: true, output: `${stdout}${stderr}`.trim() };

--- a/packages/habitat/src/tools/gaia/gaia-tools/refresh.test.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/refresh.test.ts
@@ -7,8 +7,9 @@ const NOW = new Date("2026-07-26T00:00:00.000Z");
 
 interface Fake {
   ctx: RefreshContext;
-  execs: { id: string; command: string }[];
+  execs: { id: string; command: string; env?: Record<string, string> }[];
   writes: { id: string; path: string; content: string }[];
+  mints: number;
 }
 
 function fake(options: {
@@ -16,15 +17,39 @@ function fake(options: {
   status?: ContainerStatus;
   execOk?: boolean;
   execOutput?: string;
+  /** Undefined ⇒ no GitHub App wired up at all. */
+  token?: string | null;
+  mintThrows?: boolean;
 }): Fake {
   const known = new Set(options.known ?? ["ops"]);
-  const f: Fake = { execs: [], writes: [], ctx: null as unknown as RefreshContext };
+  const f: Fake = {
+    execs: [],
+    writes: [],
+    mints: 0,
+    ctx: null as unknown as RefreshContext,
+  };
   f.ctx = {
     registry: { get: (id: string) => (known.has(id) ? ({ id } as never) : undefined) },
+    ...(options.token === undefined
+      ? {}
+      : {
+          githubTokens: {
+            bootTokensFor: async () => {
+              f.mints++;
+              if (options.mintThrows) throw new Error("mint failed");
+              return options.token ? { read: options.token } : undefined;
+            },
+          } as never,
+        }),
     docker: {
       getStatus: async () => options.status ?? "running",
-      execInContainer: async (id: string, command: string) => {
-        f.execs.push({ id, command });
+      execInContainer: async (
+        id: string,
+        command: string,
+        _timeout?: number,
+        env?: Record<string, string>,
+      ) => {
+        f.execs.push({ id, command, ...(env ? { env } : {}) });
         return {
           ok: options.execOk ?? true,
           output: options.execOutput ?? "[entrypoint] provision plan: intent=refresh",
@@ -107,5 +132,75 @@ describe("refreshHabitat", () => {
 
     expect(f.execs.map((e) => e.command)).toEqual([REFRESH_COMMAND, REFRESH_COMMAND]);
     expect(f.writes).toEqual([]);
+  });
+});
+
+/**
+ * Refresh runs via `docker exec`, which inherits the environment the container
+ * was STARTED with — including a GitHub boot token that expires in about an
+ * hour. Past that every pull failed authentication, and since git had no TTY
+ * to prompt on it failed as "could not read Username", which the plan reported
+ * as "non-fast-forward or offline". Habitats went on answering from checkouts
+ * that had silently stopped moving — observed live, days stale.
+ */
+describe("github credential", () => {
+  it("mints a fresh token for the refresh instead of inheriting the container's", async () => {
+    const f = fake({ token: "ghs_fresh" });
+    await refreshHabitat(f.ctx, "ops");
+
+    expect(f.mints).toBe(1);
+    const env = f.execs[0]?.env;
+    expect(env?.GIT_CONFIG_COUNT).toBe("1");
+    expect(env?.GIT_CONFIG_KEY_0).toContain("ghs_fresh");
+    expect(env?.GIT_CONFIG_VALUE_0).toBe("https://github.com/");
+  });
+
+  /** The exact form entrypoint.sh exports, so the provisioner needs no change. */
+  it("passes the credential as the insteadOf rewrite the provisioner already reads", async () => {
+    const f = fake({ token: "ghs_abc" });
+    await refreshHabitat(f.ctx, "ops");
+
+    expect(f.execs[0]?.env?.GIT_CONFIG_KEY_0).toBe(
+      "url.https://x-access-token:ghs_abc@github.com/.insteadOf",
+    );
+  });
+
+  /** A deploy without the GitHub App still refreshes — public repos need none. */
+  it("refreshes with no override when there is no token service", async () => {
+    const f = fake({});
+    const out = await refreshHabitat(f.ctx, "ops");
+
+    expect(out.action).toBe("refreshed");
+    expect(f.execs[0]?.env).toBeUndefined();
+  });
+
+  it("refreshes with no override when the service mints nothing", async () => {
+    const f = fake({ token: null });
+    const out = await refreshHabitat(f.ctx, "ops");
+
+    expect(out.action).toBe("refreshed");
+    expect(f.execs[0]?.env).toBeUndefined();
+  });
+
+  /**
+   * Minting is best-effort: a token service outage should degrade to the old
+   * behaviour, not block a refresh that may not need credentials at all.
+   */
+  it("still refreshes when minting throws", async () => {
+    const f = fake({ token: "ghs_x", mintThrows: true });
+    const out = await refreshHabitat(f.ctx, "ops");
+
+    expect(out.action).toBe("refreshed");
+    expect(f.execs).toHaveLength(1);
+    expect(f.execs[0]?.env).toBeUndefined();
+  });
+
+  it("does not mint for a dormant habitat, which is only marked stale", async () => {
+    const f = fake({ token: "ghs_x", status: "not-found" });
+    const out = await refreshHabitat(f.ctx, "ops");
+
+    expect(out.action).toBe("marked-stale");
+    expect(f.mints).toBe(0);
+    expect(f.execs).toHaveLength(0);
   });
 });

--- a/packages/habitat/src/tools/gaia/gaia-tools/refresh.ts
+++ b/packages/habitat/src/tools/gaia/gaia-tools/refresh.ts
@@ -43,8 +43,44 @@ export interface RefreshOutcome {
 export interface RefreshContext {
   registry: Pick<GaiaToolsContext["registry"], "get">;
   docker: Pick<GaiaToolsContext["docker"], "getStatus" | "execInContainer" | "writeVolumeFile">;
+  /**
+   * Mints the habitat's GitHub boot token. Optional so a deploy without the
+   * GitHub App still refreshes — public repos need no credential.
+   */
+  githubTokens?: GaiaToolsContext["githubTokens"];
   /** Injected for deterministic mark timestamps. */
   now?: () => Date;
+}
+
+/**
+ * A fresh github.com credential for this refresh, in the form the provisioner
+ * already reads: the `GIT_CONFIG_*` triple `entrypoint.sh` exports at boot.
+ *
+ * Refresh runs via `docker exec`, which inherits the environment the container
+ * was *started* with — including a boot token that expires in about an hour.
+ * Past that, every pull fails authentication, and because `git` has no TTY to
+ * prompt on it fails as "could not read Username", which the plan then reports
+ * as "non-fast-forward or offline". The habitat goes on answering questions
+ * from a checkout that silently stopped moving.
+ *
+ * Minting per refresh keeps the credential as fresh as the operation needing
+ * it. Returns undefined when there is nothing to mint, leaving the container's
+ * own environment in place rather than blanking it.
+ */
+async function freshGitCredential(
+  ctx: RefreshContext,
+  id: string,
+): Promise<Record<string, string> | undefined> {
+  const entry = ctx.registry.get(id);
+  if (!entry || !ctx.githubTokens) return undefined;
+  const tokens = await ctx.githubTokens.bootTokensFor(entry);
+  const read = tokens?.read;
+  if (!read) return undefined;
+  return {
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: `url.https://x-access-token:${read}@github.com/.insteadOf`,
+    GIT_CONFIG_VALUE_0: "https://github.com/",
+  };
 }
 
 async function markStale(
@@ -74,7 +110,16 @@ export async function refreshHabitat(
     return markStale(ctx, id, `Habitat "${id}" is dormant (${status}).`);
   }
 
-  const result = await ctx.docker.execInContainer(id, REFRESH_COMMAND);
+  // Minted per refresh, never inherited: the container's own token is as old
+  // as the container. Best-effort — a mint failure refreshes with whatever the
+  // container has, which is what happened before this existed.
+  const gitEnv = await freshGitCredential(ctx, id).catch(() => undefined);
+  const result = await ctx.docker.execInContainer(
+    id,
+    REFRESH_COMMAND,
+    undefined,
+    gitEnv,
+  );
   if (!result.ok) {
     // A refresh that could not run is not a refresh. Leaving the mark means
     // the next wake retries it rather than the request being lost.


### PR DESCRIPTION
## The symptom

Habitats were answering questions from checkouts that had silently stopped moving. The `upperhand` habitat confidently reported "no commits since Aug 5" while its mounts were up to three days and **101 commits** behind.

## The cause

`refreshHabitat` runs the provisioner via `docker exec`, which inherits the environment the container was **started** with — including `GIT_CONFIG_KEY_0`, the `insteadOf` rewrite `entrypoint.sh` builds from a GitHub boot token that expires in about an hour.

Past that, every pull fails authentication. Because git has no TTY to prompt on, it fails as:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

…which the plan then reported as:

```
[entrypoint] Pull skipped for agent upperhand-ae (non-fast-forward or offline).
```

So refresh worked for the first hour of a container's life and failed silently forever after — in a way that read as *"nothing new upstream."*

## Two changes

**1. Mint per refresh.** `refreshHabitat` mints a token and passes the `GIT_CONFIG_*` triple through `docker exec -e`, so the credential is as fresh as the operation using it. Values go via `-e` rather than the command string, so no token is written into a shell line.

Best-effort throughout: no token service, nothing minted, or a mint that throws all fall back to the container's own environment — a deploy without the GitHub App still refreshes, since public repos need no credential.

**2. The warning no longer names a cause.** It named two, neither of which was the real one, and that's precisely why this hid for so long. It now says the pull **FAILED** and the checkout is **STALE**, and points at git's own error — already on stdout, since `deps.run` uses `stdio: "inherit"`.

## Verified against the live fleet

- With a valid credential, the identical scoped command fast-forwards: `upperhand-versant` pulled 15 commits to `9e120ad`.
- **Not everything is a credential.** `upperhand-cp` is genuinely 75 ahead / 101 behind — no token fixes that, and `--ff-only` correctly refuses. That one needs a human decision, and the new message will now say so instead of blaming the network.

## Tests

`tsc` clean on `@umwelten/habitat`; `pnpm test:run` green (2718 tests). Six new refresh cases — mints once, emits the exact `insteadOf` form the provisioner reads, three degradation paths, and no mint for a dormant habitat — plus a regression asserting the warning never again names "non-fast-forward or offline".

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_