### PR TITLE
Pass the SaaS registry env through to the Gaia container

### DIFF
--- a/deploy/gaia/.env.example
+++ b/deploy/gaia/.env.example
@@ -68,3 +68,15 @@ OPENROUTER_API_KEY=
 # Per-user token delivery (#56): enable the narrow POST /api/secrets receiver on
 # spawned habitats so the SaaS can push per-user X tokens (TWITTER_REFRESH_TOKEN:<sub>).
 # GAIA_SECRET_WRITE_PREFIXES=TWITTER_REFRESH_TOKEN:
+
+# Dynamic registry (#358) — announce habitats to the Habitats SaaS so they show
+# up there as agents instead of being pasted in by hand. Gaia announces on every
+# habitat start; `register_in_saas` backfills ones that have not restarted since.
+#
+# Inert unless BOTH the URL and the secret are set. The secret must match
+# UMWELTEN_REGISTRY_SECRET in the SaaS's own environment (Vercel), and the
+# workspace is the SaaS habitat slug new agents attach to — attaching is an
+# access grant, so nothing here is guessed on your behalf.
+# HABITATS_SAAS_REGISTRY_URL=https://habitats.thefocus.ai/api/admin/umwelten/register
+# HABITATS_SAAS_REGISTRY_SECRET=
+# HABITATS_SAAS_REGISTRY_WORKSPACE=

--- a/deploy/gaia/docker-compose.yml
+++ b/deploy/gaia/docker-compose.yml
@@ -73,6 +73,16 @@ services:
       GITHUB_APP_ID: ${GITHUB_APP_ID:-}
       GITHUB_APP_INSTALLATION_ID: ${GITHUB_APP_INSTALLATION_ID:-}
       GITHUB_APP_PRIVATE_KEY_FILE: ${GITHUB_APP_PRIVATE_KEY_FILE:-}
+
+      # Dynamic registry (#358): Gaia announces each habitat it starts to the
+      # Habitats SaaS, so the product's view of the fleet stops being a snapshot
+      # of whoever last pasted a URL into the attach form. Announcing is inert
+      # unless BOTH the URL and the secret are set — either alone is a
+      # half-configured integration that could only produce failing calls.
+      # The secret must match UMWELTEN_REGISTRY_SECRET on the SaaS.
+      HABITATS_SAAS_REGISTRY_URL: ${HABITATS_SAAS_REGISTRY_URL:-}
+      HABITATS_SAAS_REGISTRY_SECRET: ${HABITATS_SAAS_REGISTRY_SECRET:-}
+      HABITATS_SAAS_REGISTRY_WORKSPACE: ${HABITATS_SAAS_REGISTRY_WORKSPACE:-}
     labels:
       # Gaia is itself a caddy-fronted habitat: control plane over TLS + auth at
       # GAIA_HOSTNAME, reached by caddy over the network ({{upstreams 7420}}).


### PR DESCRIPTION
#358 reads `HABITATS_SAAS_REGISTRY_URL` / `_SECRET` / `_WORKSPACE`, but nothing put them in front of the process.

`deploy/gaia/docker-compose.yml` has **no `env_file` directive** — it enumerates every variable the `gaia` service receives. So setting these in `deploy/gaia/.env` would have had no effect, and the registry could never have been switched on. I only caught it because the question "where do these keys go?" made me check instead of assume.

Adds the three to the gaia service's `environment:` block, and documents them in `.env.example` beside the GitHub App settings they sit next to operationally.

Defaulted to empty like every other optional setting here, which preserves the opt-in: `resolveSaasRegistryConfig` returns `null` unless **both** the URL and the secret are non-empty, so an unconfigured deploy announces nothing.

Verified the compose still parses and all three resolve to `${VAR:-}`. `pnpm test:run` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M55pLXs6W57tL3kEaP2E22)_