### PR TITLE
Buyer relay resolves its transport through a seam (#376)

### DIFF
--- a/packages/mycel/src/buyer/handler.ts
+++ b/packages/mycel/src/buyer/handler.ts
@@ -44,6 +44,7 @@ import {
   resolveChargeOwner,
   type BalanceOwner,
 } from "../metering/balances.js";
+import { createHttpTransport, type ResolveTransport } from "./transport.js";
 import type { ExchangeStore } from "../store/types.js";
 
 export const CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
@@ -64,6 +65,11 @@ export interface BuyerHandlerOptions {
    */
   readCredential?: (envName: string | undefined) => string | undefined;
   fetchImpl?: typeof fetch;
+  /**
+   * How to reach a Supplier. Defaults to an OpenAI-compatible POST at its
+   * `baseUrl`; a machine Supplier's Connection will supply its own (ADR 0023).
+   */
+  resolveTransport?: ResolveTransport;
   /** Offers not republished within this window stop being dispatched to. */
   staleAfterMs?: number;
   /** Injectable so tests need not stand up a real JWKS endpoint. */
@@ -144,9 +150,10 @@ function sendJson(res: ServerResponse, status: number, payload: unknown): void {
 
 export function createBuyerHandler(opts: BuyerHandlerOptions) {
   const { store } = opts;
-  const doFetch = opts.fetchImpl ?? fetch;
   const readCredential =
     opts.readCredential ?? ((envName?: string) => (envName ? process.env[envName] : undefined));
+  const resolveTransport =
+    opts.resolveTransport ?? createHttpTransport({ fetchImpl: opts.fetchImpl, readCredential });
   const verifyCaller = opts.verifyCaller ?? createIdentityVerifier({ store });
   const balances = new Balances(store);
 
@@ -328,20 +335,14 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
       if (!res.writableEnded) clientGone();
     });
 
-    const credential = readCredential(supplier.upstreamCredentialEnv);
     const streaming = body.stream === true;
 
     let upstreamRes: Response;
     try {
-      upstreamRes = await doFetch(`${supplier.baseUrl.replace(/\/$/, "")}/chat/completions`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          ...(credential ? { authorization: `Bearer ${credential}` } : {}),
-        },
-        body: JSON.stringify(body),
-        signal: upstream.signal,
-      });
+      // One call reaches the Supplier, and everything below operates on what it
+      // returns. That is what lets a Connection later satisfy this without the
+      // relay — or its metering — changing (ADR 0023).
+      upstreamRes = await resolveTransport(supplier)(body, upstream.signal);
     } catch (error) {
       if (upstream.signal.aborted) {
         // The caller left before the upstream answered. The prompt was still

--- a/packages/mycel/src/buyer/transport.test.ts
+++ b/packages/mycel/src/buyer/transport.test.ts
@@ -1,0 +1,184 @@
+/**
+ * The relay reaches a Supplier through one seam.
+ *
+ * These tests inject a transport that never touches the network and assert the
+ * money path behaves identically to the HTTP one — because that is the property
+ * dial-in depends on. A machine Supplier's Connection will satisfy this same
+ * shape (ADR 0023), and if metering only works for transports that happen to be
+ * HTTP, it will be discovered by charging someone wrongly.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { MemoryStore } from "../store/memory-store.js";
+import { supplierFixture } from "../store/conformance.js";
+import { makeTestApplication, type TestApplicationKeys } from "../testing/application-keys.js";
+import { createIdentityVerifier } from "../auth/identity.js";
+import { createExchangeServer, type RunningExchange } from "../server.js";
+import { Balances, endUserOwner } from "../metering/balances.js";
+import type { SupplierTransport } from "./transport.js";
+
+const MODEL = "gemma-4-26b";
+const FUNDED = 1_000_000_000;
+
+/**
+ * An SSE body of the shape the relay counts, produced without a socket.
+ *
+ * Chunks are produced on `pull` rather than queued up front, because
+ * `controller.error()` discards anything still queued — so a stream that
+ * enqueued everything and then failed would deliver nothing at all, and a test
+ * asserting "we charge for what arrived" would pass for the wrong reason.
+ * Pulling one at a time means the tokens genuinely arrive before the drop.
+ */
+function streamingResponse(chunks: string[], opts: { stallAfter?: number } = {}): Response {
+  const encoder = new TextEncoder();
+  let sent = 0;
+
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (opts.stallAfter !== undefined && sent >= opts.stallAfter) {
+        // A Connection dropping mid-stream is a truncated response and nothing
+        // more — no buffering, no replay, no re-dispatch (ADR 0023).
+        controller.error(new Error("connection lost"));
+        return;
+      }
+      if (sent >= chunks.length) {
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+        return;
+      }
+      controller.enqueue(
+        encoder.encode(
+          `data: ${JSON.stringify({ choices: [{ delta: { content: chunks[sent] } }] })}\n\n`,
+        ),
+      );
+      sent += 1;
+    },
+  });
+
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+describe("the Supplier transport seam", () => {
+  let store: MemoryStore;
+  let exchange: RunningExchange;
+  let app: TestApplicationKeys;
+  let balances: Balances;
+  let seen: { body: Record<string, unknown> } | undefined;
+
+  /**
+   * Accepts a sync producer too — a Connection hands back a Response as soon as
+   * it has framed the request, and making every test wrap that in a Promise
+   * would be noise.
+   */
+  async function boot(
+    transport: (
+      ...args: Parameters<SupplierTransport>
+    ) => Response | Promise<Response>,
+  ) {
+    seen = undefined;
+    store = new MemoryStore();
+    // No baseUrl at all: nothing here reaches the network, which is the point.
+    await store.createSupplier(supplierFixture({ baseUrl: "" }));
+    await store.replaceOffers("office-spark", [
+      { model: MODEL, capabilities: ["chat", "streaming"], servingMode: "managed" },
+    ]);
+    app = await makeTestApplication();
+    await store.createClient({ id: "acme", name: "Acme" });
+    await store.createApplication(app.application);
+
+    exchange = await createExchangeServer({
+      store,
+      port: 0,
+      host: "127.0.0.1",
+      verifyCaller: createIdentityVerifier({ store, makeKeySet: () => app.keySet }),
+      resolveTransport: () => async (body, signal) => {
+        seen = { body };
+        return transport(body, signal);
+      },
+    });
+
+    balances = new Balances(store);
+    await balances.grant(
+      endUserOwner({ application: app.application, subject: "user-1" }),
+      FUNDED,
+      "test-grant",
+    );
+  }
+
+  async function chat(body: Record<string, unknown> = {}) {
+    return fetch(`${exchange.url}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${await app.sign("user-1")}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        messages: [{ role: "user", content: "hello" }],
+        ...body,
+      }),
+    });
+  }
+
+  afterEach(async () => {
+    await exchange?.close();
+  });
+
+  it("serves a request through an injected transport", async () => {
+    await boot(() => streamingResponse(["one ", "two ", "three"]));
+
+    const res = await chat({ stream: true });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("three");
+  });
+
+  it("forwards the buyer's payload unmodified", async () => {
+    await boot(() => streamingResponse(["ok"]));
+
+    await (await chat({ stream: true, temperature: 0.2 })).text();
+
+    expect(seen?.body.model).toBe(MODEL);
+    expect(seen?.body.temperature).toBe(0.2);
+  });
+
+  it("meters and charges a transport that never touched the network", async () => {
+    await boot(() => streamingResponse(["one ", "two ", "three"]));
+
+    await (await chat({ stream: true })).text();
+
+    const [record] = await store.listRequests();
+    expect(record.outcome).toBe("completed");
+    expect(record.promptTokens).toBeGreaterThan(0);
+    expect(record.completionTokens).toBeGreaterThan(0);
+    expect(record.charge).toBeGreaterThan(0);
+
+    const owner = endUserOwner({ application: app.application, subject: "user-1" });
+    expect((await balances.get(owner)).microDollars).toBe(FUNDED - record.charge);
+  });
+
+  it("records a transport dying mid-stream as a supply failure, and still charges", async () => {
+    await boot(() => streamingResponse(["one ", "two ", "three"], { stallAfter: 2 }));
+
+    // Headers are long gone by then, so the buyer's stream simply ends short.
+    await (await chat({ stream: true })).text();
+
+    const [record] = await store.listRequests();
+    expect(record.outcome).toBe("supply-failed");
+    // The tokens that did arrive were produced and are owed, whoever's fault
+    // the drop was — the Exchange bears the failure, not the buyer's balance
+    // going unreconciled (ADR 0025).
+    expect(record.completionTokens).toBeGreaterThan(0);
+    expect(record.charge).toBeGreaterThan(0);
+  });
+
+  it("reports a transport that refuses to open as an upstream error", async () => {
+    await boot(() => Promise.reject(new Error("no connection for that Supplier")));
+
+    const res = await chat({ stream: true });
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).toBe("upstream_error");
+  });
+});

--- a/packages/mycel/src/buyer/transport.ts
+++ b/packages/mycel/src/buyer/transport.ts
@@ -1,0 +1,63 @@
+/**
+ * How the Exchange reaches one Supplier for one request.
+ *
+ * The relay calls a transport and gets a `Response`. Everything downstream —
+ * prompt counting at admission, per-chunk completion counting, Balance
+ * enforcement mid-flight, buyer-abort handling, and recording on every exit
+ * path — operates on that `Response` and does not know what produced it.
+ *
+ * Today there is one transport: an HTTP request to a vendor's `baseUrl`. A
+ * machine Supplier's will be a frame pushed down its held Connection (ADR
+ * 0023), returning a `Response` whose body streams the token frames back. The
+ * point of this seam is that the money path does not change to accommodate
+ * that — a dropped Connection mid-stream becomes a body that ends, which the
+ * relay already records as `supply-failed`.
+ */
+
+import type { Supplier } from "../types.js";
+
+/**
+ * A request, already validated and metered at admission, on its way to a
+ * Supplier. The body is the buyer's own OpenAI-shaped payload, forwarded
+ * unmodified — the Exchange adds nothing to it.
+ */
+export type SupplierTransport = (
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) => Promise<Response>;
+
+/**
+ * Resolve the transport for a Supplier. Injectable so a test — or a Connection
+ * — can supply its own without the relay knowing the difference.
+ */
+export type ResolveTransport = (supplier: Supplier) => SupplierTransport;
+
+/**
+ * The vendor transport: an OpenAI-compatible POST to the Supplier's `baseUrl`.
+ *
+ * The credential is resolved by name from the environment at request time, so
+ * a database compromise hands over nothing that can spend — a Supplier record
+ * stores the *name* of an environment variable, never the key.
+ */
+export function createHttpTransport(opts: {
+  fetchImpl?: typeof fetch;
+  readCredential: (envName: string | undefined) => string | undefined;
+}): ResolveTransport {
+  const doFetch = opts.fetchImpl ?? fetch;
+
+  return (supplier: Supplier): SupplierTransport => {
+    const credential = opts.readCredential(supplier.upstreamCredentialEnv);
+    const url = `${supplier.baseUrl.replace(/\/$/, "")}/chat/completions`;
+
+    return (body, signal) =>
+      doFetch(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(credential ? { authorization: `Bearer ${credential}` } : {}),
+        },
+        body: JSON.stringify(body),
+        signal,
+      });
+  };
+}

--- a/packages/mycel/src/server.ts
+++ b/packages/mycel/src/server.ts
@@ -31,6 +31,11 @@ export interface ExchangeServerOptions {
   /** Injectable identity verification, so tests need no JWKS endpoint. */
   verifyCaller?: BuyerHandlerOptions["verifyCaller"];
   staleAfterMs?: number;
+  /**
+   * How the relay reaches a Supplier. Defaults to an OpenAI-compatible POST at
+   * its `baseUrl`; a machine Supplier's Connection supplies its own (ADR 0023).
+   */
+  resolveTransport?: BuyerHandlerOptions["resolveTransport"];
 }
 
 export interface RunningExchange {
@@ -42,12 +47,17 @@ export interface RunningExchange {
 
 export function createExchangeApp(
   store: ExchangeStore,
-  opts: Pick<ExchangeServerOptions, "verifyCaller" | "staleAfterMs"> = {},
+  opts: Pick<ExchangeServerOptions, "verifyCaller" | "staleAfterMs" | "resolveTransport"> = {},
 ) {
   const handlers = [
     createSupplyHandler({ store }),
     createModelsHandler({ store }),
-    createBuyerHandler({ store, verifyCaller: opts.verifyCaller, staleAfterMs: opts.staleAfterMs }),
+    createBuyerHandler({
+      store,
+      verifyCaller: opts.verifyCaller,
+      staleAfterMs: opts.staleAfterMs,
+      resolveTransport: opts.resolveTransport,
+    }),
   ];
 
   return async function handle(
@@ -89,6 +99,7 @@ export async function createExchangeServer(
   const app = createExchangeApp(opts.store, {
     verifyCaller: opts.verifyCaller,
     staleAfterMs: opts.staleAfterMs,
+    resolveTransport: opts.resolveTransport,
   });
   await opts.store.setup();
 


### PR DESCRIPTION
Closes #376. Prefactor for dial-in — "make the change easy, then make the easy change."

## What changes

The relay reached a Supplier by constructing an HTTP request inline. It now asks for a transport and calls that. Today the answer is always the same POST to the Supplier's `baseUrl`, so **behaviour is identical and no existing test changed**.

## Why this is the whole trick

Everything downstream of that one call — prompt counting at admission, per-chunk completion counting, Balance enforcement mid-flight, buyer-abort handling, and recording on every exit path — operates on the `Response` it returns and does not know what produced it.

So a machine Supplier's Connection (ADR 0023) can satisfy the same shape without the money path changing to accommodate it. A Connection dropping mid-stream becomes a body that ends, which the relay already records as `supply-failed`. That is what keeps "the money path changes last" true for the rest of #374.

`resolveTransport` is threaded through `createExchangeServer` too, so #380 can test a Connection-backed Supplier through the real server rather than around it.

## Tests

Five new, all driving a Supplier with **no `baseUrl` at all** over a transport that never touches the network:

```
✓ serves a request through an injected transport
✓ forwards the buyer's payload unmodified
✓ meters and charges a transport that never touched the network
✓ records a transport dying mid-stream as a supply failure, and still charges
✓ reports a transport that refuses to open as an upstream error
```

One of those passed for the wrong reason first, and the fix is worth knowing about if you ever write a similar test: `controller.error()` **discards anything still queued** on a `ReadableStream`, so a stream that enqueued every chunk and then failed delivered nothing at all — the "we charge for what arrived" assertion was checking zero against zero. Chunks are now pulled one at a time so the tokens genuinely arrive before the drop.

## Verification

2770 tests passing (2765 + 5), typecheck clean, lint 0 errors. The existing metering, credit-limit, charge-owner and buyer-handler suites pass untouched, which is the actual acceptance criterion for a prefactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG)_