### PR TITLE
The published binary crashed on every command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,17 @@ jobs:
         run: pnpm typecheck
       - name: Run lint
         run: pnpm lint
+
+      # The unit suite runs against `src/`, so it cannot see the published
+      # artifact at all. The one thing every user does first — run the binary —
+      # went untested until a workspace dependency that no manifest declared got
+      # inlined into the ESM bundle and `umwelten --help` began throwing
+      # "Dynamic require of \"events\" is not supported". Green tests, broken
+      # release.
+      #
+      # So: build what ships, then run it. `--help` exercises the whole import
+      # graph, which is where a bundling fault lands.
+      - name: Build the published package
+        run: pnpm -r build
+      - name: Smoke-test the published binary
+        run: node packages/umwelten/dist/cli/entry.js --help

--- a/packages/umwelten/package.json
+++ b/packages/umwelten/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umwelten",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
@@ -62,6 +62,7 @@
     "streammark": "^1.0.4",
     "turndown": "^7.2.4",
     "undici": "^8.9.0",
+    "ws": "^8.21.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/umwelten/src/manifest.test.ts
+++ b/packages/umwelten/src/manifest.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The published manifest has to list what the bundle leaves out.
+ *
+ * `umwelten` ships as one package: tsup inlines every `@umwelten/*` workspace
+ * package and leaves every third-party import external, resolved at runtime
+ * from `dependencies`. That arrangement has one failure mode, and it is silent
+ * — a workspace package adds a third-party dependency, nobody adds it here, and
+ * tsup has no external declaration to honour so it inlines that too.
+ *
+ * Inlining a CJS package into an ESM bundle is where it bites: esbuild replaces
+ * its `require()` calls with a stub that throws, so the crash is
+ * `Dynamic require of "events" is not supported` at import time. Not on some
+ * unusual path — on `umwelten --help`, because the fault is in the import
+ * graph. `ws` did exactly this, and every test still passed, because the suite
+ * runs against `src/` and never loads the artifact.
+ *
+ * Comparing the manifests catches it at the point the dependency is added,
+ * rather than after a release.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packagesDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function manifest(name: string): { name: string; dependencies?: Record<string, string> } {
+  return JSON.parse(readFileSync(join(packagesDir, name, "package.json"), "utf8"));
+}
+
+describe("the published manifest", () => {
+  it("declares every third-party dependency the workspace packages import", () => {
+    const published = manifest("umwelten");
+    const declared = new Set(Object.keys(published.dependencies ?? {}));
+
+    const undeclared: string[] = [];
+    for (const dir of readdirSync(packagesDir)) {
+      if (dir === "umwelten") continue;
+      let pkg;
+      try {
+        pkg = manifest(dir);
+      } catch {
+        continue; // not a package directory
+      }
+      for (const dep of Object.keys(pkg.dependencies ?? {})) {
+        // Workspace packages are inlined by tsup, so they are the one thing
+        // that must *not* appear in the published manifest.
+        if (dep.startsWith("@umwelten/")) continue;
+        if (!declared.has(dep)) undeclared.push(`${dep} (from ${pkg.name})`);
+      }
+    }
+
+    expect(
+      undeclared,
+      "Add these to packages/umwelten/package.json dependencies, or tsup will " +
+        "inline them and the published binary will throw on import.",
+    ).toEqual([]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,6 +590,9 @@ importers:
       undici:
         specifier: ^8.9.0
         version: 8.9.0
+      ws:
+        specifier: ^8.21.3
+        version: 8.21.3
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
Found while building `main` to install on thor. `node dist/cli/entry.js --help` throws:

```
Error: Dynamic require of "events" is not supported
    at ws/lib/websocket.js
```

Not one command — every command, because the fault is in the import graph.

## Cause

`ws` is a dependency of `@umwelten/mycel` and `@umwelten/supplier`, and was declared in neither the published manifest. `tsup.config.ts` treats `dependencies` as its externals list, so with nothing to honour it inlined a CJS package into the ESM bundle, and esbuild replaced its `require()` calls with a stub that throws.

The whole suite passed throughout. It runs against `src/`; nothing loaded the artifact. Green tests, broken release.

## Fix, in three parts

1. **Declare `ws` in `packages/umwelten/package.json`.** Fixes the build.
2. **A manifest test** comparing every workspace package's third-party dependencies against the published one. Catches this when the dependency is added rather than after a release. Verified to fail without the fix — it names `ws (from @umwelten/mycel)` and `ws (from @umwelten/supplier)`.
3. **CI builds the published package and runs the binary.** `--help` exercises the whole import graph, which is where a bundling fault lands.

The single-package shape has this failure mode by construction: the workspace split is real for writing the code and erased at publish time, so anything the bundler must leave external has to be stated twice. Now one of those statements is checked against the other.

## Release

Bumped to `0.4.14`. `0.4.13` predates the `ws` dependency and is unaffected — this never reached npm.

## Verification

2804 tests, typecheck clean, 0 lint errors. Built the artifact and ran it:

```
$ node packages/umwelten/dist/cli/entry.js --help
Usage: umwelten [options] [command]
$ node packages/umwelten/dist/cli/entry.js supplier dial --help
Hold a Connection open to the Exchange (ADR 0023)
$ node packages/umwelten/dist/cli/entry.js mycel supplier connections --help
Show the history of machine Suppliers dialling in and out
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG)_