### PR TITLE
A machine that dialled in serves buyer traffic (#380, #381)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -525,8 +525,18 @@ Turns a machine into a Supplier: `umwelten supplier candidates | probe | publish
 **Deliberately does not depend on `@umwelten/mycel`** — it talks HTTP to a
 running Exchange, which keeps a Postgres driver off every GPU box.
 
-Next: machine Suppliers dial in over a held Connection instead of being dialled
-out to (ADR 0023). Specified in `docs/architecture/dial-in-protocol.md`, unbuilt.
+- `dial.ts` / `serve-connection.ts` — `umwelten supplier dial` holds an outbound
+  Connection to the Exchange and serves work pushed down it (ADR 0023). The
+  machine accepts no inbound connections: no tunnel, no ACL, no DNS, no firewall
+  rule. `--runtime` is what makes it a Supplier — without it the Connection is
+  held and pushed work is dropped. Its runtime key never leaves the machine.
+
+Machine Suppliers now dial in rather than being dialled out to (ADR 0023);
+`docs/architecture/dial-in-protocol.md` is the design. Connected is available,
+disconnected is withdrawn, and the staleness window no longer applies to a
+machine at all. Still open: the agent publishing its own Offers over the
+Connection (#379), deleting the inferred-liveness machinery for good (#382), and
+a vLLM runtime so `probe` can reach it (#377).
 
 ### `@umwelten/cli` — Command-Line Interface
 

--- a/docs/guide/local-supplier-vllm.md
+++ b/docs/guide/local-supplier-vllm.md
@@ -6,21 +6,21 @@ that Mycel dispatches to. Written against the deployed stage 1 Exchange at
 
 > **Read this first.**
 >
-> **ADR 0023's dial-in protocol is half built.** `umwelten supplier dial` exists
-> and works: thor opens an outbound WebSocket, the Exchange records it, and the
-> Connection ending withdraws the machine with no staleness window involved.
-> **Nothing is dispatched over it yet** — offers over the Connection (#379), the
-> relay pushing work down it (#380) and Dispatch consulting the live map (#381)
-> are still open. Section 0 is how to exercise what is built; it is a real test
-> of the liveness half and carries no traffic.
+> **The dial-in protocol serves traffic. Section 0 is the whole setup, and you
+> can stop there.** Thor holds an outbound WebSocket, the Exchange pushes work
+> down it, and the Connection ending withdraws the machine instantly — no
+> tunnel, no `GatewayPorts`, no firewall rule, no staleness window.
 >
-> Until #380 and #381 land, **traffic still needs section 1's tunnel.** That
-> satisfies the ADR's transport property — Mycel never connects *to* thor, so a
-> box behind NAT accepts no inbound connections and has no address to register —
-> with ssh instead of a protocol. What it does not give you is liveness: Mycel
-> infers thor is up from whether its Offers were republished recently, and a
-> dead vLLM behind a healthy tunnel looks dispatchable until a request fails.
-> Run both for now, and delete section 1 when #381 lands.
+> Section 1's reverse tunnel is **the old way**, kept only for a machine that
+> cannot run the agent. If that is not you, skip to section 0 and ignore the
+> rest of the ssh setup entirely.
+>
+> **ADR 0015 — Capabilities are probed through the serving path — is still not
+> satisfied.** `umwelten supplier` cannot probe vLLM (#377), so thor's Offers
+> are **declared by the operator**, like a vendor's. Claim narrowly: an
+> over-claimed Capability routes a request somewhere that cannot serve it, which
+> is the failure that ADR exists to prevent. Thor also publishes no Headroom, so
+> Dispatch scores it on price alone and cannot know whether it batches or queues.
 >
 > **ADR 0015 — Capabilities are probed through the serving path — is not
 > satisfied.** `umwelten supplier` cannot probe vLLM: `discoverRuntimes` knows
@@ -52,12 +52,14 @@ mycel supplier register thor-dial \
 
 It prints a credential once. That credential is what thor presents.
 
-**On thor**, hold the Connection:
+**On thor**, hold the Connection and serve from the local runtime:
 
 ```bash
 umwelten supplier dial \
   --mycel https://mycel.thefocus.ai \
-  --credential "$SUPPLIER_CREDENTIAL"
+  --credential "$SUPPLIER_CREDENTIAL" \
+  --runtime http://localhost:4000/v1 \
+  --runtime-key "$VLLM_API_KEY"
 ```
 
 You should see:
@@ -66,6 +68,27 @@ You should see:
 dialling https://mycel.thefocus.ai …
 connected — this machine is now dispatchable
 ```
+
+**`--runtime` is what makes it a Supplier.** Without it the Connection is held
+and every pushed request is dropped on the floor — useful for checking
+reachability, useless for selling. The agent says so on start rather than
+letting it look like success.
+
+Thor's vLLM key never leaves thor. The Exchange pushes a request down the
+Connection and the agent adds the key locally, so the Exchange stores no
+credential for this machine and a database compromise yields nothing that can
+spend your GPU.
+
+Then publish thor's catalogue from `mycel-host` — operator-declared, because
+`probe` cannot see vLLM (#377):
+
+```bash
+mycel offers sync thor --models thor-<short-name> --capabilities chat,streaming
+```
+
+**No `--watch` needed.** For a machine, the Connection *is* liveness: a
+connected machine's Offers never go stale, and a disconnected machine's are
+refused whatever their age. The republishing heartbeat is a vendor concern.
 
 Close the lid, kill the process, pull the ethernet — it reconnects, and the
 backoff doubles only while it is failing to connect at all, resetting after any
@@ -96,11 +119,27 @@ Connection was replaced), `shutdown` (the Exchange stopped).
 Caddy proxies the upgrade without configuration — `reverse_proxy` handles
 WebSockets natively, so nothing in `docker-compose.yml` changes for this.
 
-**What this does not yet do:** carry a request. Thor being connected is recorded
-and observable, and Dispatch does not consult it yet (#381). For traffic today,
-also do section 1.
+Now buy from it, and check where it went:
 
-## 1. Thor carries traffic — a reverse tunnel
+```bash
+curl -s https://mycel.thefocus.ai/v1/chat/completions \
+  -H "Authorization: Bearer $APP_CREDENTIAL" \
+  -H "X-Mycel-End-User: you" \
+  -H "content-type: application/json" \
+  -d '{"model":"thor-<short-name>","stream":true,"messages":[{"role":"user","content":"hi"}]}'
+```
+
+Kill the dial and the same request 503s with `supplier-disconnected` in the
+`considered` list — a different diagnosis from `offer-stale`, and the body says
+which. Restart it and the request succeeds again with no operator action.
+
+**That is the end of the setup.** Sections 1–5 below are the older tunnel-based
+path; you need none of them.
+
+## 1. The old way — a reverse tunnel
+
+> Only for a machine that cannot run the supplier agent. Section 0 replaces all
+> of this, and gives you real liveness on top.
 
 vLLM is OpenAI-shaped on `:4000`, and Mycel already speaks that. The only real
 question is who opens the TCP connection, and the answer is **thor**.
@@ -350,14 +389,17 @@ each was rejected — `missing-guarantee` is a different problem from
   behaviour under concurrency, so Dispatch cannot tell whether it batches or
   queues and scores it on price alone. A `queues` box that is cheap wins every
   request and makes the second customer wait.
-- **No liveness *in Dispatch*.** Section 0's Connection is real and recorded,
-  but #381 has not landed, so routing still runs off "Offers republished
-  recently" as a proxy for "thor is up". A dead vLLM with a live sync loop looks
-  dispatchable until a request fails. When #381 lands, the held Connection
-  replaces this and deletes the whole staleness apparatus with it (#382).
-- **No probed Capabilities.** Everything in the Offer is your claim.
+- **No probed Capabilities.** Everything in thor's Offer is your claim, because
+  `probe` cannot reach vLLM (#377). Over-claim and Dispatch routes a request
+  somewhere that cannot serve it.
+- **No Headroom.** Nothing measured thor's throughput or its behaviour under
+  concurrency, so Dispatch scores it on price alone and cannot tell whether it
+  batches or queues. A cheap box that queues wins every request and makes the
+  second customer wait.
+- **The agent does not publish its own catalogue** (#379). The operator declares
+  thor's Offers, which is why they can drift from what vLLM actually has loaded.
 
-Headroom and Capabilities close when a vLLM runtime is added to the supplier
-agent (#377), which lets `umwelten supplier probe` reach thor through its
-serving path as ADR 0015 requires. Liveness closes with #379–#382. Until then,
-this is a real Supplier with a manual seam where the agent should be.
+Both close when a vLLM runtime is added to the supplier agent (#377), which lets
+`probe` reach thor through its serving path as ADR 0015 requires. Liveness is
+done: the Connection is what Dispatch consults, and the staleness window no
+longer applies to a machine at all.

--- a/packages/mycel/src/buyer/handler.ts
+++ b/packages/mycel/src/buyer/handler.ts
@@ -70,6 +70,15 @@ export interface BuyerHandlerOptions {
    * `baseUrl`; a machine Supplier's Connection will supply its own (ADR 0023).
    */
   resolveTransport?: ResolveTransport;
+  /**
+   * Which machine Suppliers are connected, asked fresh per request.
+   *
+   * A function rather than a value because the answer changes between
+   * requests without anything writing to the database — that is the whole
+   * point of ADR 0023, and a snapshot taken at construction would be wrong
+   * within seconds.
+   */
+  connectedSupplierIds?: () => Set<string>;
   /** Offers not republished within this window stop being dispatched to. */
   staleAfterMs?: number;
   /** Injectable so tests need not stand up a real JWKS endpoint. */
@@ -223,8 +232,11 @@ export function createBuyerHandler(opts: BuyerHandlerOptions) {
       allowedModels: caller.application.allowedModels,
     };
 
+    // Read per request, never cached: a machine that dropped between two
+    // requests must not be selected for the second one.
     const decision = dispatch(await store.listOffers(), requirements, {
       staleAfterMs: opts.staleAfterMs,
+      connectedSupplierIds: opts.connectedSupplierIds?.(),
     });
 
     if (!decision.offer) {

--- a/packages/mycel/src/dispatch.test.ts
+++ b/packages/mycel/src/dispatch.test.ts
@@ -224,4 +224,111 @@ describe("dispatch", () => {
       expect(byId["eligible"].rankingPrice).toBeGreaterThan(0);
     });
   });
+
+  describe("a machine's availability is its Connection", () => {
+    const machine = (overrides: Partial<Offer> = {}) =>
+      offer({ supplierId: "thor", supplierKind: "agent", ...overrides });
+
+    it("selects a machine that is holding a Connection", () => {
+      const result = dispatch([machine()], { model: MODEL }, {
+        connectedSupplierIds: new Set(["thor"]),
+      });
+
+      expect(result.offer?.supplierId).toBe("thor");
+    });
+
+    it("will not select one that is disconnected", () => {
+      const result = dispatch([machine()], { model: MODEL }, {
+        connectedSupplierIds: new Set(),
+      });
+
+      expect(result.offer).toBeUndefined();
+    });
+
+    it("says disconnected rather than stale, because they are different problems", () => {
+      // "That machine is switched off" and "nobody republished that catalogue"
+      // have different fixes. An operator who cannot tell them apart debugs the
+      // wrong one.
+      const result = dispatch([machine()], { model: MODEL }, {
+        connectedSupplierIds: new Set(),
+      });
+
+      expect(result.considered[0].reason).toBe("supplier-disconnected");
+    });
+
+    it("serves a connected machine whose Offer has gone stale", () => {
+      // The Connection *is* liveness; staleness only ever inferred it. Taking a
+      // working machine out of the pool because an operator's publish loop died
+      // would keep exactly the apparatus ADR 0023 exists to remove.
+      const result = dispatch(
+        [machine({ publishedAt: new Date(Date.now() - DEFAULT_STALE_AFTER_MS - 60_000) })],
+        { model: MODEL },
+        { connectedSupplierIds: new Set(["thor"]) },
+      );
+
+      expect(result.offer?.supplierId).toBe("thor");
+    });
+
+    it("reconnecting makes the same request succeed again, with no operator action", () => {
+      const offers = [machine()];
+      const gone = dispatch(offers, { model: MODEL }, { connectedSupplierIds: new Set() });
+      const back = dispatch(offers, { model: MODEL }, {
+        connectedSupplierIds: new Set(["thor"]),
+      });
+
+      expect(gone.offer).toBeUndefined();
+      expect(back.offer?.supplierId).toBe("thor");
+    });
+
+    it("leaves vendors alone — a public API has no Connection to hold", () => {
+      const result = dispatch([offer({ supplierId: "openrouter" })], { model: MODEL }, {
+        connectedSupplierIds: new Set(),
+      });
+
+      expect(result.offer?.supplierId).toBe("openrouter");
+    });
+
+    it("judges everything on staleness when the deployment has no registry", () => {
+      // Undefined is not an empty set. A deployment with no Connection registry
+      // must behave exactly as it did before ADR 0023, or every existing
+      // machine Offer silently stops being dispatchable on upgrade.
+      const result = dispatch([machine()], { model: MODEL }, {});
+
+      expect(result.offer?.supplierId).toBe("thor");
+    });
+
+    it("never falls through to an Offer lacking a required Guarantee", () => {
+      // The load-bearing case again, now with a second way to become
+      // unavailable. A disconnected machine must fail the request, not hand it
+      // to a cheaper Supplier the operator cannot warrant.
+      const result = dispatch(
+        [
+          machine({ guarantees: ["on-premise"] }),
+          offer({
+            supplierId: "openrouter",
+            guarantees: [],
+            retailPromptPerMillion: 1,
+            retailCompletionPerMillion: 1,
+          }),
+        ],
+        { model: MODEL, guarantees: ["on-premise"] },
+        { connectedSupplierIds: new Set() },
+      );
+
+      expect(result.offer).toBeUndefined();
+      const byId = Object.fromEntries(result.considered.map((c) => [c.supplierId, c]));
+      expect(byId["thor"].reason).toBe("supplier-disconnected");
+      expect(byId["openrouter"].reason).toBe("missing-guarantee");
+    });
+
+    it("falls through to another eligible Offer when one machine is disconnected", () => {
+      const result = dispatch(
+        [machine(), offer({ supplierId: "openrouter" })],
+        { model: MODEL },
+        { connectedSupplierIds: new Set() },
+      );
+
+      expect(result.offer?.supplierId).toBe("openrouter");
+    });
+  });
 });

--- a/packages/mycel/src/dispatch.ts
+++ b/packages/mycel/src/dispatch.ts
@@ -43,6 +43,13 @@ export type RejectionReason =
   | "model-not-allowed"
   | "offer-disabled"
   | "offer-stale"
+  /**
+   * A machine Supplier that is not holding a Connection. Deliberately distinct
+   * from `offer-stale`: "that machine is switched off" and "nobody has
+   * republished that catalogue" are different diagnoses with different fixes,
+   * and an operator who cannot tell them apart debugs the wrong one.
+   */
+  | "supplier-disconnected"
   | "missing-guarantee"
   | "missing-capability"
   | "wrong-quantization"
@@ -218,7 +225,21 @@ export const DEFAULT_STALE_AFTER_MS = 15 * 60_000;
 export function dispatch(
   offers: Offer[],
   requirements: DispatchRequirements,
-  opts: { staleAfterMs?: number; now?: Date; weights?: ScoreWeights } = {},
+  opts: {
+    staleAfterMs?: number;
+    now?: Date;
+    weights?: ScoreWeights;
+    /**
+     * Which machine Suppliers are holding a Connection right now.
+     *
+     * Passed in, never reached for: Dispatch stays a pure function of Offers,
+     * requirements and injected state, so selection is testable without a
+     * socket. Undefined means "this deployment has no Connection registry", and
+     * every Offer is then judged on staleness alone — the pre-ADR-0023
+     * behaviour, which is what the existing suites assert.
+     */
+    connectedSupplierIds?: Set<string>;
+  } = {},
 ): DispatchResult {
   const now = opts.now ?? new Date();
   const considered: Considered[] = [];
@@ -241,16 +262,34 @@ export function dispatch(
       note("offer-disabled");
       continue;
     }
-    // Defaulted rather than opt-in. An expiry window nobody remembered to
-    // configure is an expiry window that never fires, and then the two
-    // mechanisms that were supposed to overlap are one.
-    const staleAfterMs = opts.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
-    if (staleAfterMs > 0 && now.getTime() - offer.publishedAt.getTime() > staleAfterMs) {
-      // A Supplier that stopped reporting has probably gone. Its last known
-      // capabilities are a guess, and dispatching on a guess is how a buyer
-      // discovers an unplugged machine.
-      note("offer-stale");
-      continue;
+    // A machine's availability is its Connection, and nothing else.
+    //
+    // Checked before staleness, and replacing it, because for a machine the two
+    // answer the same question and only one of them is evidence. Staleness
+    // *infers* liveness from a recent publish; the Connection *is* liveness.
+    // Asking a connected machine to also have republished lately would keep the
+    // apparatus ADR 0023 exists to remove, and would take a working box out of
+    // the pool because an operator's publish loop died.
+    //
+    // Vendors are untouched — a public API is reachable by definition, has no
+    // Connection to hold, and is still judged on staleness.
+    if (offer.supplierKind === "agent" && opts.connectedSupplierIds !== undefined) {
+      if (!opts.connectedSupplierIds.has(offer.supplierId)) {
+        note("supplier-disconnected");
+        continue;
+      }
+    } else {
+      // Defaulted rather than opt-in. An expiry window nobody remembered to
+      // configure is an expiry window that never fires, and then the two
+      // mechanisms that were supposed to overlap are one.
+      const staleAfterMs = opts.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+      if (staleAfterMs > 0 && now.getTime() - offer.publishedAt.getTime() > staleAfterMs) {
+        // A Supplier that stopped reporting has probably gone. Its last known
+        // capabilities are a guess, and dispatching on a guess is how a buyer
+        // discovers an unplugged machine.
+        note("offer-stale");
+        continue;
+      }
     }
 
     const required = requirements.guarantees ?? [];

--- a/packages/mycel/src/server.ts
+++ b/packages/mycel/src/server.ts
@@ -15,7 +15,10 @@ import { createBuyerHandler, type BuyerHandlerOptions } from "./buyer/handler.js
 import { createModelsHandler } from "./buyer/models.js";
 import { ConnectionRegistry } from "./supply/connections.js";
 import { attachConnectionServer } from "./supply/connection-server.js";
+import { createConnectionTransport } from "./supply/connection-transport.js";
+import { createHttpTransport } from "./buyer/transport.js";
 import type { ExchangeStore } from "./store/types.js";
+import type { Supplier } from "./types.js";
 
 /**
  * Mycel's port.
@@ -53,8 +56,26 @@ export interface RunningExchange {
 
 export function createExchangeApp(
   store: ExchangeStore,
-  opts: Pick<ExchangeServerOptions, "verifyCaller" | "staleAfterMs" | "resolveTransport"> = {},
+  opts: Pick<ExchangeServerOptions, "verifyCaller" | "staleAfterMs" | "resolveTransport"> & {
+    connections?: ConnectionRegistry;
+  } = {},
 ) {
+  // Which transport a Supplier gets is decided by its kind, and nothing further
+  // down asks. A vendor is dialled out to because a public API is reachable by
+  // definition; a machine is served over the Connection it dialled in on
+  // (ADR 0023).
+  const connections = opts.connections;
+  const resolveTransport =
+    opts.resolveTransport ??
+    (connections
+      ? (() => {
+          const http = createHttpTransport({ readCredential: (name) => name && process.env[name] });
+          const overConnection = createConnectionTransport({ registry: connections });
+          return (supplier: Supplier) =>
+            supplier.kind === "agent" ? overConnection(supplier) : http(supplier);
+        })()
+      : undefined);
+
   const handlers = [
     createSupplyHandler({ store }),
     createModelsHandler({ store }),
@@ -62,7 +83,12 @@ export function createExchangeApp(
       store,
       verifyCaller: opts.verifyCaller,
       staleAfterMs: opts.staleAfterMs,
-      resolveTransport: opts.resolveTransport,
+      resolveTransport,
+      // Connected is available; disconnected is withdrawn. Passed in rather
+      // than reached for, so Dispatch stays a pure function (ADR 0023).
+      connectedSupplierIds: connections
+        ? () => connections.connectedSupplierIds()
+        : undefined,
     }),
   ];
 
@@ -102,10 +128,15 @@ export function createExchangeApp(
 export async function createExchangeServer(
   opts: ExchangeServerOptions,
 ): Promise<RunningExchange> {
+  // Machine Suppliers dial in on the same port. Empty on boot, which is the
+  // correct state: nothing is connected, because nothing is.
+  const connections = new ConnectionRegistry({ store: opts.store });
+
   const app = createExchangeApp(opts.store, {
     verifyCaller: opts.verifyCaller,
     staleAfterMs: opts.staleAfterMs,
     resolveTransport: opts.resolveTransport,
+    connections,
   });
   await opts.store.setup();
 
@@ -118,9 +149,6 @@ export async function createExchangeServer(
     });
   });
 
-  // Machine Suppliers dial in on the same port. Empty on boot, which is the
-  // correct state: nothing is connected, because nothing is.
-  const connections = new ConnectionRegistry({ store: opts.store });
   const connectionServer = attachConnectionServer({
     server,
     store: opts.store,

--- a/packages/mycel/src/supply/connection-e2e.test.ts
+++ b/packages/mycel/src/supply/connection-e2e.test.ts
@@ -1,0 +1,284 @@
+/**
+ * A buyer request served by a machine that dialled in — end to end.
+ *
+ * Real HTTP, real WebSocket upgrade, real streaming, real ledger. The only
+ * fake is the machine's own runtime, because a GPU is not a test fixture.
+ *
+ * The machine is implemented here rather than imported from
+ * `@umwelten/supplier`: that package deliberately cannot be reached from this
+ * one, so a GPU box never installs a Postgres driver (CONTEXT-MAP.md). Writing
+ * the agent side against the wire is therefore not duplication to be tidied
+ * away — it is the test proving the wire is a contract two independent
+ * implementations can meet, which is exactly what a shared module would stop
+ * proving.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import WebSocket from "ws";
+import { MemoryStore } from "../store/memory-store.js";
+import { supplierFixture } from "../store/conformance.js";
+import { hashCredential } from "../auth/credentials.js";
+import { createExchangeServer, type RunningExchange } from "../server.js";
+import { createIdentityVerifier } from "../auth/identity.js";
+import { makeTestApplication, type TestApplicationKeys } from "../testing/application-keys.js";
+import { startMockUpstream, type MockUpstream, type UpstreamMode } from "../testing/mock-upstream.js";
+import { Balances, endUserOwner } from "../metering/balances.js";
+import { WIRE_VERSION, CONNECT_PATH } from "./wire.js";
+
+const MODEL = "thor-gemma";
+const CREDENTIAL = "sk-mycel-thor-e2e";
+
+/**
+ * A minimal machine: dials in, forwards work to its runtime, streams back.
+ *
+ * Deliberately the smallest thing that satisfies the wire, so a bug in the
+ * Exchange cannot be masked by a clever agent.
+ */
+function machine(exchangeUrl: string, runtimeUrl: string) {
+  const ws = new WebSocket(exchangeUrl.replace("http:", "ws:") + CONNECT_PATH, {
+    headers: { authorization: `Bearer ${CREDENTIAL}` },
+  });
+  const inFlight = new Map<string, AbortController>();
+
+  const send = (frame: unknown) => {
+    if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(frame));
+  };
+
+  const welcomed = new Promise<void>((resolve) => {
+    ws.on("open", () => send({ type: "hello", wireVersion: WIRE_VERSION }));
+    ws.on("message", (raw) => {
+      const frame = JSON.parse(String(raw)) as {
+        type: string;
+        id?: string;
+        body?: Record<string, unknown>;
+      };
+      if (frame.type === "welcome") return resolve();
+      if (frame.type === "cancel" && frame.id) return inFlight.get(frame.id)?.abort();
+      if (frame.type !== "request" || !frame.id || !frame.body) return;
+      void serve(frame.id, frame.body);
+    });
+  });
+
+  async function serve(id: string, body: Record<string, unknown>): Promise<void> {
+    const abort = new AbortController();
+    inFlight.set(id, abort);
+    try {
+      const upstream = await fetch(`${runtimeUrl}/chat/completions`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+        signal: abort.signal,
+      });
+      send({ type: "response-head", id, status: upstream.status });
+      const reader = upstream.body!.getReader();
+      const decoder = new TextDecoder();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done || abort.signal.aborted) break;
+        send({ type: "chunk", id, data: decoder.decode(value, { stream: true }) });
+      }
+      if (!abort.signal.aborted) send({ type: "end", id });
+    } catch (error) {
+      if (!abort.signal.aborted) {
+        send({ type: "request-error", id, message: (error as Error).message });
+      }
+    } finally {
+      inFlight.delete(id);
+    }
+  }
+
+  return {
+    welcomed,
+    hangUp: () =>
+      new Promise<void>((resolve) => {
+        ws.once("close", () => resolve());
+        ws.close();
+      }),
+  };
+}
+
+describe("a machine serves a buyer over its Connection", () => {
+  let store: MemoryStore;
+  let exchange: RunningExchange;
+  let runtime: MockUpstream;
+  let app: TestApplicationKeys;
+  let thor: ReturnType<typeof machine> | undefined;
+
+  async function boot(mode: UpstreamMode = "ok") {
+    runtime = await startMockUpstream(mode);
+    store = new MemoryStore();
+    // An agent has no baseUrl — it has no address, which is the point.
+    await store.createSupplier(
+      supplierFixture({
+        id: "thor",
+        kind: "agent",
+        baseUrl: "",
+        credentialHash: hashCredential(CREDENTIAL),
+      }),
+    );
+    await store.replaceOffers("thor", [
+      { model: MODEL, capabilities: ["chat", "streaming"], servingMode: "managed" },
+    ]);
+
+    app = await makeTestApplication();
+    await store.createClient({ id: "acme", name: "Acme" });
+    await store.createApplication(app.application);
+    exchange = await createExchangeServer({
+      store,
+      port: 0,
+      host: "127.0.0.1",
+      handshakeTimeoutMs: 200,
+      verifyCaller: createIdentityVerifier({ store, makeKeySet: () => app.keySet }),
+    });
+    await new Balances(store).grant(
+      endUserOwner({ application: app.application, subject: "user-1" }),
+      1_000_000_000,
+      "test-grant",
+    );
+  }
+
+  async function dial() {
+    thor = machine(exchange.url, runtime.baseUrl);
+    await thor.welcomed;
+  }
+
+  async function chat(init: RequestInit = {}) {
+    const token = await app.sign("user-1");
+    return fetch(`${exchange.url}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      // Streaming, because that is the case worth testing over a Connection —
+      // tokens crossing a socket as they are produced — and because the
+      // truncation and cancellation modes only exist on the streaming path.
+      body: JSON.stringify({
+        model: MODEL,
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+      ...init,
+    });
+  }
+
+  afterEach(async () => {
+    await thor?.hangUp().catch(() => {});
+    thor = undefined;
+    await exchange?.close();
+    await runtime?.close();
+  });
+
+  it("routes the request to the machine and streams its tokens back", async () => {
+    await boot();
+    await dial();
+
+    const response = await chat();
+    expect(response.status).toBe(200);
+    const text = await response.text();
+
+    // The buyer got real tokens, produced on the machine, relayed over a socket
+    // the machine opened. No tunnel, no inbound port, no address.
+    expect(text).toContain("quick");
+    expect(runtime.requests).toHaveLength(1);
+  });
+
+  it("meters and charges it exactly as a vendor request", async () => {
+    await boot();
+    await dial();
+    const balances = new Balances(store);
+    const owner = endUserOwner({ application: app.application, subject: "user-1" });
+    const before = (await balances.get(owner)).microDollars;
+
+    await (await chat()).text();
+
+    const requests = await store.listRequests();
+    expect(requests).toHaveLength(1);
+    expect(requests[0].outcome).toBe("completed");
+    expect(requests[0].supplierId).toBe("thor");
+    expect(requests[0].completionTokens).toBeGreaterThan(0);
+    // The money path did not change to accommodate a socket. That is the whole
+    // point of the transport seam.
+    expect((await balances.get(owner)).microDollars).toBeLessThan(before);
+  });
+
+  it("refuses the request once the machine hangs up, naming it disconnected", async () => {
+    await boot();
+    await dial();
+    await thor!.hangUp();
+    thor = undefined;
+    // The Connection ending *is* the withdrawal — no window to wait out.
+    await new Promise((r) => setTimeout(r, 30));
+
+    const response = await chat();
+    expect(response.status).toBe(503);
+
+    const body = (await response.json()) as {
+      considered: { supplierId: string; reason: string }[];
+    };
+    // Distinct from offer-stale: the catalogue is current, the machine is off.
+    expect(body.considered[0]).toMatchObject({
+      supplierId: "thor",
+      reason: "supplier-disconnected",
+    });
+  });
+
+  it("serves again the moment the machine reconnects, with no operator action", async () => {
+    await boot();
+    await dial();
+    await thor!.hangUp();
+    await new Promise((r) => setTimeout(r, 30));
+    expect((await chat()).status).toBe(503);
+
+    await dial();
+    expect((await chat()).status).toBe(200);
+  });
+
+  it("records a supply failure when the machine dies mid-stream", async () => {
+    await boot("dies-mid-stream");
+    await dial();
+
+    await (await chat()).text().catch(() => "");
+
+    const [record] = await store.listRequests();
+    // Our choice of Supplier, our problem — the Exchange bears it (ADR 0025).
+    expect(record.outcome).toBe("supply-failed");
+    // And the buyer still owes for the prompt, which was submitted and
+    // processed whatever happened next.
+    expect(record.promptTokens).toBeGreaterThan(0);
+  });
+
+  it("stops the machine generating when the buyer hangs up", async () => {
+    await boot("never-finishes");
+    await dial();
+
+    const abort = new AbortController();
+    const pending = chat({ signal: abort.signal });
+    const response = await pending;
+    const reader = response.body!.getReader();
+    await reader.read();
+    abort.abort();
+
+    await new Promise((r) => setTimeout(r, 80));
+
+    // The cancel travelled the whole way: buyer → Exchange → Connection →
+    // machine → its runtime. Anywhere it stopped short would be GPU time spent
+    // on tokens nobody receives.
+    expect(runtime.sawAbort()).toBe(true);
+    const [record] = await store.listRequests();
+    expect(record.outcome).toBe("buyer-aborted");
+  });
+
+  it("counts what the machine is working on while it works", async () => {
+    await boot("never-finishes");
+    await dial();
+
+    const abort = new AbortController();
+    const response = await chat({ signal: abort.signal });
+    await response.body!.getReader().read();
+
+    // Only the Exchange can know this, because only the Exchange issued it.
+    expect(exchange.connections.inFlight("thor")).toBe(1);
+
+    abort.abort();
+    await new Promise((r) => setTimeout(r, 80));
+    expect(exchange.connections.inFlight("thor")).toBe(0);
+  });
+});

--- a/packages/mycel/src/supply/connection-server.ts
+++ b/packages/mycel/src/supply/connection-server.ts
@@ -165,10 +165,16 @@ function send(ws: WebSocket, frame: unknown): void {
   if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(frame));
 }
 
-/** Adapt a live socket to the two things the registry needs from one. */
+/** Adapt a live socket to what the registry and the relay need from one. */
 function channelFor(ws: WebSocket): Channel {
   return {
     close: () => ws.close(CLOSE.DISPLACED, "displaced"),
+    send: (frame) => {
+      if (ws.readyState === ws.OPEN) ws.send(frame);
+    },
+    // `on`, not `once`: the handshake consumed the first message, and every
+    // frame after it is work.
+    onMessage: (listener) => ws.on("message", (raw) => listener(String(raw))),
     onClose: (listener) => ws.once("close", (code: number) => listener(isCleanClose(code))),
   };
 }

--- a/packages/mycel/src/supply/connection-transport.test.ts
+++ b/packages/mycel/src/supply/connection-transport.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Serving over a held Connection.
+ *
+ * The machine is faked at the Channel — these assert the multiplexing and the
+ * endings, both of which are pure logic and neither of which needs a socket.
+ * What matters is that the relay cannot tell this from a vendor's `fetch`: the
+ * money path was written against a `Response` and must stay that way.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { ConnectionRegistry, type Channel } from "./connections.js";
+import { MemoryStore } from "../store/memory-store.js";
+import { createConnectionTransport } from "./connection-transport.js";
+import { supplierFixture } from "../store/conformance.js";
+
+/** A machine that answers only when the test tells it to. */
+function fakeMachine() {
+  const messageListeners: ((frame: string) => void)[] = [];
+  const closeListeners: ((clean: boolean) => void)[] = [];
+  const sent: Record<string, unknown>[] = [];
+
+  const channel: Channel = {
+    close: () => closeListeners.forEach((l) => l(true)),
+    send: (frame) => sent.push(JSON.parse(frame) as Record<string, unknown>),
+    onMessage: (listener) => messageListeners.push(listener),
+    onClose: (listener) => closeListeners.push(listener),
+  };
+
+  const reply = (frame: Record<string, unknown>) =>
+    messageListeners.forEach((l) => l(JSON.stringify(frame)));
+
+  return {
+    channel,
+    sent,
+    /** What the Exchange pushed down, in order. */
+    requests: () => sent.filter((f) => f.type === "request"),
+    cancels: () => sent.filter((f) => f.type === "cancel"),
+    head: (id: string, status = 200) => reply({ type: "response-head", id, status }),
+    chunk: (id: string, data: string) => reply({ type: "chunk", id, data }),
+    end: (id: string) => reply({ type: "end", id }),
+    fail: (id: string, message: string) => reply({ type: "request-error", id, message }),
+    drop: () => closeListeners.forEach((l) => l(false)),
+  };
+}
+
+async function readAll(response: Response): Promise<string> {
+  return await response.text();
+}
+
+describe("relaying over a Connection", () => {
+  let registry: ConnectionRegistry;
+  let machine: ReturnType<typeof fakeMachine>;
+  const supplier = supplierFixture({ id: "thor", kind: "agent", baseUrl: "" });
+
+  beforeEach(async () => {
+    registry = new ConnectionRegistry({ store: new MemoryStore() });
+    machine = fakeMachine();
+    await registry.connect("thor", machine.channel);
+  });
+
+  function transportFor(ids: string[] = ["req-1", "req-2", "req-3"]) {
+    let next = 0;
+    return createConnectionTransport({
+      registry,
+      newId: () => ids[next++] ?? `req-${next}`,
+      responseHeadTimeoutMs: 50,
+    })(supplier);
+  }
+
+  it("pushes the buyer's body down the Connection unmodified", async () => {
+    const transport = transportFor();
+    const body = { model: "thor-gemma", messages: [{ role: "user", content: "hi" }] };
+    void transport(body, new AbortController().signal).catch(() => {});
+    await Promise.resolve();
+
+    // The Exchange adds nothing. A Supplier that received a rewritten payload
+    // would serve something the buyer did not ask for.
+    expect(machine.requests()[0]).toMatchObject({ type: "request", id: "req-1", body });
+  });
+
+  it("returns a Response as soon as the machine reports a status", async () => {
+    const transport = transportFor();
+    const pending = transport({ model: "m" }, new AbortController().signal);
+    await Promise.resolve();
+
+    machine.head("req-1", 200);
+    const response = await pending;
+    expect(response.status).toBe(200);
+  });
+
+  it("relays a non-2xx from the runtime as itself", async () => {
+    // The runtime answering 400 is the runtime answering. Turning that into a
+    // transport failure would lose the buyer's actual error.
+    const transport = transportFor();
+    const pending = transport({ model: "m" }, new AbortController().signal);
+    await Promise.resolve();
+
+    machine.head("req-1", 400);
+    machine.end("req-1");
+    expect((await pending).status).toBe(400);
+  });
+
+  it("streams tokens as they arrive rather than buffering them", async () => {
+    const transport = transportFor();
+    const pending = transport({ model: "m" }, new AbortController().signal);
+    await Promise.resolve();
+    machine.head("req-1");
+
+    const response = await pending;
+    const reader = response.body!.getReader();
+
+    machine.chunk("req-1", "one");
+    // Readable before the response is finished — the relay counts completion
+    // tokens per chunk and enforces Balance mid-generation, and neither works
+    // against a body that only materialises at the end.
+    const first = await reader.read();
+    expect(new TextDecoder().decode(first.value)).toBe("one");
+
+    machine.chunk("req-1", "two");
+    const second = await reader.read();
+    expect(new TextDecoder().decode(second.value)).toBe("two");
+
+    machine.end("req-1");
+    expect((await reader.read()).done).toBe(true);
+  });
+
+  it("keeps concurrent requests on one Connection from interleaving", async () => {
+    const transport = transportFor();
+    const signal = new AbortController().signal;
+    const first = transport({ model: "m" }, signal);
+    await Promise.resolve();
+    const second = transport({ model: "m" }, signal);
+    await Promise.resolve();
+
+    machine.head("req-1");
+    machine.head("req-2");
+    const [a, b] = [await first, await second];
+
+    // Deliberately out of order, because a real machine will not answer in the
+    // order it was asked.
+    machine.chunk("req-2", "BBB");
+    machine.chunk("req-1", "aaa");
+    machine.chunk("req-2", "BBB");
+    machine.end("req-2");
+    machine.chunk("req-1", "aaa");
+    machine.end("req-1");
+
+    expect(await readAll(b)).toBe("BBBBBB");
+    expect(await readAll(a)).toBe("aaaaaa");
+  });
+
+  it("ends the buyer's stream where the tokens stopped when the machine goes away", async () => {
+    const transport = transportFor();
+    const pending = transport({ model: "m" }, new AbortController().signal);
+    await Promise.resolve();
+    machine.head("req-1");
+    const response = await pending;
+
+    machine.chunk("req-1", "partial");
+    machine.drop();
+
+    // No buffering, no replay, no re-dispatch. The body errors, which the relay
+    // already records as a supply failure — the same shape as a vendor's
+    // connection dying mid-response (ADR 0025).
+    await expect(readAll(response)).rejects.toThrow(/connection closed/);
+  });
+
+  it("fails the request rather than the body when the machine dies before answering", async () => {
+    const transport = transportFor();
+    const pending = transport({ model: "m" }, new AbortController().signal);
+    await Promise.resolve();
+
+    machine.drop();
+    // Nothing was consumed, so this must surface as a transport failure and not
+    // as an empty successful response.
+    await expect(pending).rejects.toThrow(/connection closed/);
+  });
+
+  it("surfaces a machine that could not reach its own runtime", async () => {
+    const transport = transportFor();
+    const pending = transport({ model: "m" }, new AbortController().signal);
+    await Promise.resolve();
+
+    machine.fail("req-1", "ECONNREFUSED localhost:4000");
+    await expect(pending).rejects.toThrow(/ECONNREFUSED/);
+  });
+
+  it("tells the machine to stop when the buyer hangs up", async () => {
+    const transport = transportFor();
+    const abort = new AbortController();
+    const pending = transport({ model: "m" }, abort.signal);
+    await Promise.resolve();
+    machine.head("req-1");
+    await pending;
+
+    abort.abort();
+
+    // Left unsent, the machine keeps burning GPU seconds producing tokens
+    // nobody will receive and nobody will pay for.
+    expect(machine.cancels()).toEqual([{ type: "cancel", id: "req-1" }]);
+  });
+
+  it("counts what is in flight, and stops counting when each one ends", async () => {
+    const transport = transportFor();
+    const signal = new AbortController().signal;
+    // Caught, not discarded: the second one is failed deliberately below, and
+    // an unobserved rejection is noise that hides a real one later.
+    const swallow = () => {};
+    void transport({ model: "m" }, signal).catch(swallow);
+    await Promise.resolve();
+    void transport({ model: "m" }, signal).catch(swallow);
+    await Promise.resolve();
+
+    // The Exchange pushes, so it is the only party that can know this.
+    expect(registry.inFlight("thor")).toBe(2);
+
+    machine.head("req-1");
+    machine.end("req-1");
+    expect(registry.inFlight("thor")).toBe(1);
+
+    machine.fail("req-2", "runtime died");
+    // Counted down on a failure exactly as on a clean finish, or the number
+    // drifts upward for as long as the process lives.
+    expect(registry.inFlight("thor")).toBe(0);
+  });
+
+  it("refuses when the machine is not connected at all", async () => {
+    await registry.disconnect("thor", "closed");
+    const transport = transportFor();
+
+    // Dispatch should not have chosen it, so this is a race rather than a
+    // routing mistake — but nothing was consumed either way.
+    await expect(transport({ model: "m" }, new AbortController().signal)).rejects.toThrow(
+      /not connected/,
+    );
+  });
+});

--- a/packages/mycel/src/supply/connection-transport.ts
+++ b/packages/mycel/src/supply/connection-transport.ts
@@ -1,0 +1,231 @@
+/**
+ * Serving a request over a machine's held Connection.
+ *
+ * This is the other half of the seam in `buyer/transport.ts`. The relay asks
+ * for a `Response` and meters whatever comes back; a vendor's comes from
+ * `fetch`, and a machine's comes from here. **The money path does not know the
+ * difference**, which is the entire reason that seam exists: prompt counted at
+ * admission, completion counted per chunk, Balance enforced during generation,
+ * every exit path recorded — all of it already operates on a `Response` and
+ * none of it changes to accommodate a socket.
+ *
+ * A dropped Connection mid-stream is therefore not a special case. It is a body
+ * that ends early, which the relay already records as `supply-failed` and the
+ * Exchange already bears (ADR 0025). No buffering, no replay, no re-dispatch:
+ * the machine is a laptop and laptops close.
+ *
+ * One Connection carries many requests at once, so every frame is keyed by an
+ * id and each request owns its own stream controller. Interleaving two buyers'
+ * tokens would be the worst bug this file could have, and the id is what
+ * prevents it.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Supplier } from "../types.js";
+import type { SupplierTransport, ResolveTransport } from "../buyer/transport.js";
+import type { Connection, ConnectionRegistry } from "./connections.js";
+import {
+  parseFrame,
+  type AgentFrame,
+  type CancelFrame,
+  type RequestFrame,
+} from "./wire.js";
+
+/** How long to wait for the machine's runtime to answer at all. */
+const RESPONSE_HEAD_TIMEOUT_MS = 60_000;
+
+/** One request in flight on one Connection. */
+interface Pending {
+  /** Resolves when the machine reports a status, so the relay gets a Response. */
+  settle: (response: Response) => void;
+  fail: (error: Error) => void;
+  /** Feeds the body as chunks arrive. Undefined until the head frame lands. */
+  controller?: ReadableStreamDefaultController<Uint8Array>;
+  settled: boolean;
+  /** Release this request's slot in the in-flight count, exactly once. */
+  release: () => void;
+}
+
+/**
+ * Route agent frames to the request that is waiting for them.
+ *
+ * Installed once per Connection rather than once per request: a socket has one
+ * message listener, and a per-request listener would leak one for every request
+ * the machine ever served.
+ */
+class ConnectionMultiplexer {
+  private readonly pending = new Map<string, Pending>();
+
+  constructor(private readonly connection: Connection) {
+    connection.channel.onMessage((raw) => this.onFrame(raw));
+    // A Connection ending mid-stream ends every body riding on it. Each one
+    // becomes a truncated response the relay records as a supply failure — the
+    // buyer's stream stops where the tokens stopped.
+    connection.channel.onClose(() => {
+      for (const id of [...this.pending.keys()]) {
+        this.abandon(id, new Error("connection closed"));
+      }
+    });
+  }
+
+  track(id: string, entry: Pending): void {
+    this.pending.set(id, entry);
+  }
+
+  private onFrame(raw: string): void {
+    const frame = parseFrame<AgentFrame>(raw);
+    if (!frame || !("id" in frame)) return;
+
+    const entry = this.pending.get(frame.id);
+    // A frame for a request that already finished is not an error worth
+    // surfacing: cancellation and the machine's last chunk race by nature.
+    if (!entry) return;
+
+    switch (frame.type) {
+      case "response-head": {
+        if (entry.settled) return;
+        entry.settled = true;
+        const body = new ReadableStream<Uint8Array>({
+          start: (controller) => {
+            entry.controller = controller;
+          },
+        });
+        entry.settle(
+          new Response(body, { status: frame.status, headers: frame.headers ?? {} }),
+        );
+        return;
+      }
+      case "chunk": {
+        // Enqueued the moment it arrives. Buffering here would defeat the point
+        // of streaming and would also break mid-stream credit enforcement,
+        // which only works because the relay sees tokens as they are produced.
+        entry.controller?.enqueue(new TextEncoder().encode(frame.data));
+        return;
+      }
+      case "end": {
+        this.finish(frame.id, () => entry.controller?.close());
+        return;
+      }
+      case "request-error": {
+        this.abandon(frame.id, new Error(frame.message));
+        return;
+      }
+    }
+  }
+
+  /** End a request normally. */
+  private finish(id: string, close: () => void): void {
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.pending.delete(id);
+    entry.release();
+    try {
+      close();
+    } catch {
+      /* already closed by an abort */
+    }
+  }
+
+  /**
+   * End a request badly.
+   *
+   * Before the head frame this rejects, so the relay sees a transport failure.
+   * After it, the body errors — which reaches the relay as a stream that ended
+   * early, and that is deliberately the same shape as a vendor's connection
+   * dying mid-response.
+   */
+  private abandon(id: string, error: Error): void {
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.pending.delete(id);
+    entry.release();
+    if (!entry.settled) {
+      entry.settled = true;
+      entry.fail(error);
+      return;
+    }
+    try {
+      entry.controller?.error(error);
+    } catch {
+      /* already closed */
+    }
+  }
+
+  cancel(id: string): void {
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    send(this.connection, { type: "cancel", id } satisfies CancelFrame);
+    this.abandon(id, new Error("cancelled"));
+  }
+}
+
+function send(connection: Connection, frame: unknown): void {
+  connection.channel.send(JSON.stringify(frame));
+}
+
+/**
+ * One multiplexer per Connection, for as long as that Connection lives.
+ *
+ * Keyed by the Connection object rather than the supplier id: a machine that
+ * reconnects gets a new Connection, and reusing the old multiplexer would point
+ * new requests at a dead socket's pending map.
+ */
+export function createConnectionTransport(opts: {
+  registry: ConnectionRegistry;
+  responseHeadTimeoutMs?: number;
+  newId?: () => string;
+}): ResolveTransport {
+  const multiplexers = new WeakMap<Connection, ConnectionMultiplexer>();
+  const headTimeoutMs = opts.responseHeadTimeoutMs ?? RESPONSE_HEAD_TIMEOUT_MS;
+  const newId = opts.newId ?? (() => randomUUID());
+
+  return (supplier: Supplier): SupplierTransport => {
+    return async (body, signal) => {
+      const connection = opts.registry.get(supplier.id);
+      // Dispatch should not have selected a disconnected machine (#381), so
+      // this is a race — it disconnected between selection and relay — rather
+      // than a routing mistake. Either way nothing was consumed.
+      if (!connection) throw new Error(`supplier ${supplier.id} is not connected`);
+
+      let multiplexer = multiplexers.get(connection);
+      if (!multiplexer) {
+        multiplexer = new ConnectionMultiplexer(connection);
+        multiplexers.set(connection, multiplexer);
+      }
+
+      const id = newId();
+      // Counted before the frame goes out, so the count is never lower than
+      // what the machine is actually working on. Released on every ending —
+      // normal, truncated, cancelled — by whoever ends it.
+      const release = opts.registry.trackInFlight(supplier.id);
+
+      const response = new Promise<Response>((resolve, reject) => {
+        multiplexer.track(id, { settle: resolve, fail: reject, settled: false, release });
+      });
+
+      // The buyer hanging up and credit running out both arrive here, and both
+      // mean the same thing to the machine: stop. Left unsent, it would keep
+      // generating tokens nobody receives and nobody pays for.
+      const onAbort = () => multiplexer.cancel(id);
+      signal.addEventListener("abort", onAbort, { once: true });
+
+      const timeout = setTimeout(() => multiplexer.cancel(id), headTimeoutMs);
+      timeout.unref?.();
+
+      send(connection, { type: "request", id, body } satisfies RequestFrame);
+
+      try {
+        const settled = await response;
+        // Only the head is timed. Generation itself may legitimately take
+        // longer than any timeout worth setting, and the relay is already
+        // watching the stream.
+        clearTimeout(timeout);
+        return settled;
+      } catch (error) {
+        clearTimeout(timeout);
+        signal.removeEventListener("abort", onAbort);
+        throw error;
+      }
+    };
+  };
+}

--- a/packages/mycel/src/supply/connections.test.ts
+++ b/packages/mycel/src/supply/connections.test.ts
@@ -11,15 +11,22 @@ import { ConnectionRegistry, type Channel } from "./connections.js";
 /** A socket stand-in. Nothing here opens a port. */
 function fakeChannel() {
   const listeners: ((clean: boolean) => void)[] = [];
+  const messageListeners: ((frame: string) => void)[] = [];
+  const sent: string[] = [];
   let closed = false;
   const channel: Channel = {
     close: () => {
       closed = true;
     },
+    send: (frame) => sent.push(frame),
+    onMessage: (listener) => messageListeners.push(listener),
     onClose: (listener) => listeners.push(listener),
   };
   return {
     channel,
+    sent,
+    /** A frame arriving from the machine. */
+    deliver: (frame: string) => messageListeners.forEach((l) => l(frame)),
     get closed() {
       return closed;
     },

--- a/packages/mycel/src/supply/connections.ts
+++ b/packages/mycel/src/supply/connections.ts
@@ -28,6 +28,10 @@ import type { ExchangeStore } from "../store/types.js";
  */
 export interface Channel {
   close(): void;
+  /** Push a frame to the machine. Silently ignored once the socket is gone. */
+  send(frame: string): void;
+  /** Every frame the machine sends after the handshake. */
+  onMessage(listener: (frame: string) => void): void;
   /**
    * Fires when the far end goes away without being asked to.
    *

--- a/packages/mycel/src/supply/wire.ts
+++ b/packages/mycel/src/supply/wire.ts
@@ -26,8 +26,8 @@ export const WIRE_VERSION = 1;
 export const CONNECT_PATH = "/suppliers/connect";
 
 /**
- * The first frame, and for now the only one an agent sends. Publishing Offers
- * over the Connection arrives in #379; work frames in #380.
+ * The first frame an agent sends. Publishing Offers over the Connection
+ * arrives in #379.
  */
 export interface HelloFrame {
   type: "hello";
@@ -44,6 +44,69 @@ export interface WelcomeFrame {
 }
 
 /**
+ * Work, pushed down the Connection.
+ *
+ * **The Exchange pushes; the machine never asks.** A machine that polled for
+ * work would need a queue to poll, and a queue is a component with a depth, an
+ * eviction policy and a failure mode of its own (ADR 0023). Pushing keeps the
+ * Exchange's knowledge of what is outstanding exact, which is also the only
+ * reason it can count what is in flight.
+ *
+ * Every frame after the handshake carries an `id`, because one Connection
+ * carries many concurrent requests and their tokens must not interleave.
+ */
+export interface RequestFrame {
+  type: "request";
+  id: string;
+  /** The buyer's OpenAI-shaped payload, forwarded unmodified. */
+  body: Record<string, unknown>;
+}
+
+/**
+ * Stop generating. Sent when the buyer hung up, or credit ran out mid-stream.
+ *
+ * Without this the machine keeps burning GPU seconds on tokens nobody will
+ * receive and nobody will pay for.
+ */
+export interface CancelFrame {
+  type: "cancel";
+  id: string;
+}
+
+/** The machine's runtime answered. Status first, so a 4xx is relayed as one. */
+export interface ResponseHeadFrame {
+  type: "response-head";
+  id: string;
+  status: number;
+  headers?: Record<string, string>;
+}
+
+/** A piece of the body, as produced. Not buffered, not batched. */
+export interface ChunkFrame {
+  type: "chunk";
+  id: string;
+  data: string;
+}
+
+/** The body finished normally. */
+export interface EndFrame {
+  type: "end";
+  id: string;
+}
+
+/**
+ * The machine could not serve it, or stopped part way.
+ *
+ * Distinct from a non-2xx `response-head`: that is the runtime answering, this
+ * is the agent unable to get an answer at all.
+ */
+export interface RequestErrorFrame {
+  type: "request-error";
+  id: string;
+  message: string;
+}
+
+/**
  * The Exchange hanging up with a reason, before closing. A machine that is
  * refused should learn why rather than guess from a close code — an operator
  * debugging a silent agent needs "you are registered as a vendor", not 1008.
@@ -53,8 +116,13 @@ export interface GoodbyeFrame {
   reason: string;
 }
 
-export type AgentFrame = HelloFrame;
-export type ExchangeFrame = WelcomeFrame | GoodbyeFrame;
+export type AgentFrame =
+  | HelloFrame
+  | ResponseHeadFrame
+  | ChunkFrame
+  | EndFrame
+  | RequestErrorFrame;
+export type ExchangeFrame = WelcomeFrame | GoodbyeFrame | RequestFrame | CancelFrame;
 
 /** Close codes. 4000+ is the application-defined range. */
 export const CLOSE = {

--- a/packages/supplier/src/command.ts
+++ b/packages/supplier/src/command.ts
@@ -73,6 +73,9 @@ interface CliOptions {
   heartbeatInterval?: string;
   kind?: string;
   user?: string;
+  // dial
+  runtime?: string;
+  runtimeKey?: string;
 }
 
 /**
@@ -793,9 +796,14 @@ supplierCommand
 
 supplierCommand
   .command("dial")
-  .description("Hold a Connection open to the Exchange (ADR 0023)")
+  .description("Hold a Connection open to the Exchange and serve over it (ADR 0023)")
   .option("--mycel <url>", "Mycel base URL (or MYCEL_URL)")
   .option("--credential <token>", "Supplier credential (or SUPPLIER_CREDENTIAL)")
+  .option(
+    "--runtime <url>",
+    "Local OpenAI-compatible runtime to serve from, e.g. http://localhost:4000/v1",
+  )
+  .option("--runtime-key <token>", "Key the local runtime expects (or RUNTIME_API_KEY)")
   .action(async (opts: CliOptions) => {
     const exchangeUrl = opts.mycel ?? process.env.MYCEL_URL;
     const credential = opts.credential ?? process.env.SUPPLIER_CREDENTIAL;
@@ -815,12 +823,38 @@ supplierCommand
     process.once("SIGINT", stop);
     process.once("SIGTERM", stop);
 
+    const runtimeUrl = opts.runtime;
+    if (!runtimeUrl) {
+      // Holding the Connection without serving is legitimate — it is how you
+      // check reachability — but it is not a Supplier anyone can buy from, and
+      // silence about that reads like success.
+      console.log("no --runtime: holding the Connection, serving nothing");
+    }
+
     console.log(`dialling ${exchangeUrl} …`);
     await dialIn({
       exchangeUrl,
       credential,
       agentVersion: AGENT_VERSION,
       signal: abort.signal,
+      runtimeUrl,
+      runtimeCredential: opts.runtimeKey ?? process.env.RUNTIME_API_KEY,
+      onServeEvent: (event) => {
+        switch (event.type) {
+          case "request-started":
+            console.log(`  → ${event.id.slice(0, 8)} ${event.model ?? ""}`);
+            break;
+          case "request-finished":
+            console.log(`  ← ${event.id.slice(0, 8)} ${event.bytes}b`);
+            break;
+          case "request-cancelled":
+            console.log(`  ✕ ${event.id.slice(0, 8)} cancelled`);
+            break;
+          case "request-failed":
+            console.error(`  ! ${event.id.slice(0, 8)} ${event.message}`);
+            break;
+        }
+      },
       onEvent: (event) => {
         switch (event.type) {
           case "connecting":

--- a/packages/supplier/src/dial.ts
+++ b/packages/supplier/src/dial.ts
@@ -14,6 +14,9 @@
  */
 
 import WebSocket from "ws";
+import { createConnectionServer, type ServeEvent } from "./serve-connection.js";
+
+export type { ServeEvent } from "./serve-connection.js";
 
 /** Must match the Exchange's. Bumped when a frame's meaning changes. */
 export const WIRE_VERSION = 1;
@@ -31,6 +34,15 @@ export interface DialOptions {
   /** Injectable for tests; defaults to a real socket. */
   connect?: (url: string, credential: string) => DialSocket;
   sleep?: (ms: number) => Promise<void>;
+  /**
+   * Where the local runtime listens. Without it this holds the Connection and
+   * serves nothing — which is a legitimate way to run it while the rest of the
+   * relay is being built, but not a Supplier anyone can buy from.
+   */
+  runtimeUrl?: string;
+  runtimeCredential?: string;
+  fetchImpl?: typeof fetch;
+  onServeEvent?: (event: ServeEvent) => void;
 }
 
 export type DialEvent =
@@ -106,6 +118,10 @@ export async function dialIn(opts: DialOptions): Promise<void> {
       signal,
       onEvent,
       connect,
+      runtimeUrl: opts.runtimeUrl,
+      runtimeCredential: opts.runtimeCredential,
+      fetchImpl: opts.fetchImpl,
+      onServeEvent: opts.onServeEvent,
     });
 
     if (signal?.aborted) return;
@@ -129,6 +145,10 @@ function holdOne(
     signal?: AbortSignal;
     onEvent: (event: DialEvent) => void;
     connect: (url: string, credential: string) => DialSocket;
+    runtimeUrl?: string;
+    runtimeCredential?: string;
+    fetchImpl?: typeof fetch;
+    onServeEvent?: (event: ServeEvent) => void;
   },
 ): Promise<"connected" | "failed"> {
   return new Promise((resolve) => {
@@ -156,6 +176,18 @@ function holdOne(
     const hangUp = () => socket.close();
     ctx.signal?.addEventListener("abort", hangUp, { once: true });
 
+    // Scoped to this Connection. A machine that reconnects gets a fresh one,
+    // because nothing in flight on the old socket can be delivered.
+    const server = ctx.runtimeUrl
+      ? createConnectionServer({
+          runtimeUrl: ctx.runtimeUrl,
+          runtimeCredential: ctx.runtimeCredential,
+          fetchImpl: ctx.fetchImpl,
+          send: (frame) => socket.send(frame),
+          onEvent: ctx.onServeEvent,
+        })
+      : undefined;
+
     socket.onOpen(() => {
       socket.send(
         JSON.stringify({ type: "hello", wireVersion: WIRE_VERSION, agentVersion: ctx.agentVersion }),
@@ -173,7 +205,12 @@ function holdOne(
         // The Exchange refusing us for a stated reason — a wire mismatch, say.
         // Worth surfacing rather than showing up as a bare close code.
         ctx.onEvent({ type: "refused", reason: String(frame.reason ?? "refused") });
+        return;
       }
+      // Everything else is work. Without a runtime configured this machine
+      // holds the Connection and serves nothing, which is deliberate rather
+      // than an error to report on every frame.
+      server?.handleFrame(data);
     });
 
     socket.onError((error) => {
@@ -182,6 +219,9 @@ function holdOne(
 
     socket.onClose((code, reason) => {
       ctx.signal?.removeEventListener("abort", hangUp);
+      // Stop generating for an Exchange that is no longer listening. Left
+      // running, these would hold the GPU for responses nobody can receive.
+      server?.stopAll();
       ctx.onEvent({ type: "disconnected", code, reason });
       finish(everConnected ? "connected" : "failed");
     });

--- a/packages/supplier/src/serve-connection.test.ts
+++ b/packages/supplier/src/serve-connection.test.ts
@@ -1,0 +1,195 @@
+/**
+ * The machine end of serving over a Connection.
+ *
+ * `fetch` is faked, so these run without a GPU or a runtime. What matters is
+ * that the machine streams rather than accumulates, and that it actually stops
+ * when told — a cancel it ignores is GPU time spent on tokens nobody receives
+ * and nobody pays for.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createConnectionServer } from "./serve-connection.js";
+
+/** A runtime whose response body the test feeds by hand. */
+function fakeRuntime() {
+  let push: (chunk: string) => void = () => {};
+  let finish: () => void = () => {};
+  let seen: { url: string; init: RequestInit } | undefined;
+  let aborted = false;
+
+  const fetchImpl = (async (url: string, init: RequestInit) => {
+    seen = { url, init };
+    init.signal?.addEventListener("abort", () => {
+      aborted = true;
+    });
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        push = (chunk) => controller.enqueue(new TextEncoder().encode(chunk));
+        finish = () => controller.close();
+      },
+    });
+    return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+  }) as unknown as typeof fetch;
+
+  return {
+    fetchImpl,
+    push: (chunk: string) => push(chunk),
+    finish: () => finish(),
+    get request() {
+      return seen;
+    },
+    get aborted() {
+      return aborted;
+    },
+  };
+}
+
+function harness(fetchImpl: typeof fetch) {
+  const sent: Record<string, unknown>[] = [];
+  const server = createConnectionServer({
+    runtimeUrl: "http://localhost:4000/v1",
+    runtimeCredential: "vllm-key",
+    fetchImpl,
+    send: (frame) => sent.push(JSON.parse(frame) as Record<string, unknown>),
+  });
+  return { server, sent, of: (type: string) => sent.filter((f) => f.type === type) };
+}
+
+const request = (id: string, body: Record<string, unknown> = { model: "thor-gemma" }) =>
+  JSON.stringify({ type: "request", id, body });
+
+describe("serving pushed work", () => {
+  it("forwards the buyer's body to the local runtime unmodified", async () => {
+    const runtime = fakeRuntime();
+    const { server } = harness(runtime.fetchImpl);
+    const body = { model: "thor-gemma", messages: [{ role: "user", content: "hi" }] };
+
+    server.handleFrame(request("r1", body));
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(runtime.request?.url).toBe("http://localhost:4000/v1/chat/completions");
+    expect(JSON.parse(String(runtime.request?.init.body))).toEqual(body);
+  });
+
+  it("presents the runtime's key, which the Exchange never sees", async () => {
+    const runtime = fakeRuntime();
+    const { server } = harness(runtime.fetchImpl);
+
+    server.handleFrame(request("r1"));
+    await new Promise((r) => setTimeout(r, 5));
+
+    const headers = runtime.request?.init.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer vllm-key");
+  });
+
+  it("reports the status before any tokens, so a 4xx relays as itself", async () => {
+    const fetchImpl = (async () =>
+      new Response("nope", { status: 429 })) as unknown as typeof fetch;
+    const { server, of } = harness(fetchImpl);
+
+    server.handleFrame(request("r1"));
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(of("response-head")[0]).toMatchObject({ id: "r1", status: 429 });
+  });
+
+  it("sends each chunk as it is produced rather than accumulating", async () => {
+    const runtime = fakeRuntime();
+    const { server, of } = harness(runtime.fetchImpl);
+
+    server.handleFrame(request("r1"));
+    await new Promise((r) => setTimeout(r, 5));
+
+    runtime.push("one");
+    await new Promise((r) => setTimeout(r, 5));
+    // Already on the wire before the response finished. The Exchange enforces
+    // Balance during generation and cannot do that against a machine that
+    // replies once at the end.
+    expect(of("chunk")).toEqual([{ type: "chunk", id: "r1", data: "one" }]);
+
+    runtime.push("two");
+    runtime.finish();
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(of("chunk").map((f) => f.data)).toEqual(["one", "two"]);
+    expect(of("end")).toEqual([{ type: "end", id: "r1" }]);
+  });
+
+  it("stops generating when the Exchange cancels", async () => {
+    const runtime = fakeRuntime();
+    const { server, of } = harness(runtime.fetchImpl);
+
+    server.handleFrame(request("r1"));
+    await new Promise((r) => setTimeout(r, 5));
+    runtime.push("partial");
+    await new Promise((r) => setTimeout(r, 5));
+
+    server.handleFrame(JSON.stringify({ type: "cancel", id: "r1" }));
+    await new Promise((r) => setTimeout(r, 5));
+
+    // The GPU stops. This is the whole reason the cancel frame exists.
+    expect(runtime.aborted).toBe(true);
+    // And nothing further is claimed about a request that was cut short.
+    expect(of("end")).toEqual([]);
+    expect(of("request-error")).toEqual([]);
+  });
+
+  it("reports a runtime it cannot reach at all", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED localhost:4000");
+    }) as unknown as typeof fetch;
+    const { server, of } = harness(fetchImpl);
+
+    server.handleFrame(request("r1"));
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Distinct from the runtime answering badly: this machine could not get an
+    // answer, which the Exchange records as a supply failure it bears.
+    expect(of("request-error")[0]).toMatchObject({ id: "r1", message: /ECONNREFUSED/ });
+  });
+
+  it("serves several requests at once without one blocking the others", async () => {
+    const runtimes = [fakeRuntime(), fakeRuntime()];
+    let next = 0;
+    const fetchImpl = ((url: string, init: RequestInit) =>
+      runtimes[next++].fetchImpl(url, init)) as unknown as typeof fetch;
+    const { server, of } = harness(fetchImpl);
+
+    server.handleFrame(request("r1"));
+    server.handleFrame(request("r2"));
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(server.inFlightCount()).toBe(2);
+
+    // The second answers first, which is the normal case and must not wait on
+    // the first.
+    runtimes[1].push("second");
+    runtimes[1].finish();
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(of("end")).toEqual([{ type: "end", id: "r2" }]);
+    expect(server.inFlightCount()).toBe(1);
+  });
+
+  it("stops everything when the Connection ends", async () => {
+    const runtime = fakeRuntime();
+    const { server } = harness(runtime.fetchImpl);
+
+    server.handleFrame(request("r1"));
+    await new Promise((r) => setTimeout(r, 5));
+
+    server.stopAll();
+
+    // Nothing in flight can be delivered to an Exchange that is not listening,
+    // so holding the GPU for it is pure waste.
+    expect(runtime.aborted).toBe(true);
+    expect(server.inFlightCount()).toBe(0);
+  });
+
+  it("ignores frames that are not work", async () => {
+    const { server } = harness(fakeRuntime().fetchImpl);
+
+    expect(server.handleFrame("not json")).toBe(false);
+    expect(server.handleFrame(JSON.stringify({ type: "welcome" }))).toBe(false);
+  });
+});

--- a/packages/supplier/src/serve-connection.ts
+++ b/packages/supplier/src/serve-connection.ts
@@ -1,0 +1,156 @@
+/**
+ * Serving work that arrives down the Connection.
+ *
+ * The Exchange pushes a request; this forwards it to the local runtime and
+ * streams the bytes back as they are produced. Nothing is buffered — the
+ * Exchange counts completion tokens per chunk and enforces Balance during
+ * generation (ADR 0017), and a machine that accumulated a whole response before
+ * replying would defeat both.
+ *
+ * **Cancellation is not optional.** A buyer who hangs up, or runs out of
+ * credit, produces a `cancel` frame; ignoring it means burning GPU seconds on
+ * tokens nobody will receive and nobody will pay for. Each in-flight request
+ * therefore owns an AbortController the cancel frame trips.
+ *
+ * The runtime is reached over plain HTTP on this machine — the same
+ * OpenAI-shaped endpoint the supplier agent already probes through, so nothing
+ * here knows whether that is llama.cpp, vLLM or anything else.
+ */
+
+/** Must match the Exchange's `WIRE_VERSION`. */
+export interface ServeConnectionOptions {
+  /** Where the local runtime listens, e.g. `http://localhost:4000/v1`. */
+  runtimeUrl: string;
+  /** Key the runtime expects, if it wants one. */
+  runtimeCredential?: string;
+  /** Push a frame back to the Exchange. */
+  send: (frame: string) => void;
+  fetchImpl?: typeof fetch;
+  onEvent?: (event: ServeEvent) => void;
+}
+
+export type ServeEvent =
+  | { type: "request-started"; id: string; model?: string }
+  | { type: "request-finished"; id: string; bytes: number }
+  | { type: "request-cancelled"; id: string }
+  | { type: "request-failed"; id: string; message: string };
+
+interface InFlight {
+  abort: AbortController;
+}
+
+/**
+ * Handle the work frames on one Connection.
+ *
+ * Returns a frame handler to install on the socket, plus a `stopAll` for when
+ * the Connection ends — every request riding a dead socket is unfinishable, and
+ * leaving them generating would keep the GPU busy for an Exchange that is no
+ * longer listening.
+ */
+export function createConnectionServer(opts: ServeConnectionOptions) {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const onEvent = opts.onEvent ?? (() => {});
+  const inFlight = new Map<string, InFlight>();
+
+  const send = (frame: unknown) => opts.send(JSON.stringify(frame));
+
+  async function serve(id: string, body: Record<string, unknown>): Promise<void> {
+    const abort = new AbortController();
+    inFlight.set(id, { abort });
+    onEvent({ type: "request-started", id, model: typeof body.model === "string" ? body.model : undefined });
+
+    let bytes = 0;
+    try {
+      const url = `${opts.runtimeUrl.replace(/\/$/, "")}/chat/completions`;
+      const response = await doFetch(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(opts.runtimeCredential
+            ? { authorization: `Bearer ${opts.runtimeCredential}` }
+            : {}),
+        },
+        body: JSON.stringify(body),
+        signal: abort.signal,
+      });
+
+      // Status first, and relayed as-is. A runtime answering 400 is the
+      // runtime answering; that is a different thing from this agent being
+      // unable to reach it, and the Exchange has to be able to tell them apart.
+      send({
+        type: "response-head",
+        id,
+        status: response.status,
+        headers: { "content-type": response.headers.get("content-type") ?? "application/json" },
+      });
+
+      if (response.body) {
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (abort.signal.aborted) break;
+          const data = decoder.decode(value, { stream: true });
+          if (data) {
+            bytes += data.length;
+            send({ type: "chunk", id, data });
+          }
+        }
+      }
+
+      if (!abort.signal.aborted) {
+        send({ type: "end", id });
+        onEvent({ type: "request-finished", id, bytes });
+      }
+    } catch (error) {
+      // An abort is a cancellation we caused, not a failure to report. The
+      // Exchange already knows — it asked.
+      if (abort.signal.aborted) {
+        onEvent({ type: "request-cancelled", id });
+        return;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      send({ type: "request-error", id, message });
+      onEvent({ type: "request-failed", id, message });
+    } finally {
+      inFlight.delete(id);
+    }
+  }
+
+  return {
+    /** Returns true if it consumed the frame, so the dial loop can ignore it. */
+    handleFrame(raw: string): boolean {
+      let frame: { type?: string; id?: string; body?: Record<string, unknown> };
+      try {
+        frame = JSON.parse(raw) as typeof frame;
+      } catch {
+        return false;
+      }
+      if (!frame || typeof frame !== "object") return false;
+
+      if (frame.type === "request" && frame.id && frame.body) {
+        // Deliberately not awaited: one slow request must not block the frames
+        // for the others sharing this Connection.
+        void serve(frame.id, frame.body);
+        return true;
+      }
+      if (frame.type === "cancel" && frame.id) {
+        inFlight.get(frame.id)?.abort.abort();
+        return true;
+      }
+      return false;
+    },
+
+    /** How many requests this machine is working on right now. */
+    inFlightCount(): number {
+      return inFlight.size;
+    },
+
+    /** The Connection ended. Nothing in flight can be delivered. */
+    stopAll(): void {
+      for (const entry of inFlight.values()) entry.abort.abort();
+      inFlight.clear();
+    },
+  };
+}


### PR DESCRIPTION
Closes #380. Closes #381.

thor sells its GPU with no tunnel, no inbound port, no address to register. A buyer names a Model, the Exchange pushes the request down the Connection thor is holding, tokens stream back, the Balance is debited.

## #380 — work relays over a Connection

The money path does not change to accommodate a socket, which is what the transport seam in #376 was for. Prompt counted at admission, completion counted per chunk, Balance enforced during generation, every exit path recorded — all of it already operated on a `Response`, and a Connection now produces one.

So a dropped Connection mid-stream is not a special case. It is a body that ends early, which the relay already records as `supply-failed` and the Exchange already bears (ADR 0025). No buffering, no replay, no re-dispatch: the machine is a laptop and laptops close.

**The Exchange pushes; the machine never asks.** A machine that polled would need a queue to poll, and a queue is a component with a depth and an eviction policy of its own. Pushing also keeps the count of what is outstanding exact — which is why the Exchange can count in-flight requests at all.

**Cancellation travels the whole way.** A buyer hangup or credit exhaustion becomes a `cancel` frame, which aborts the machine's fetch to its runtime. Anywhere it stopped short would be GPU seconds spent on tokens nobody receives and nobody pays for.

**The runtime key never leaves the machine.** The Exchange stores no credential for a machine Supplier, so a database compromise yields nothing that can spend someone else's GPU.

## #381 — Dispatch selects connected machines

An Offer from a machine with no Connection is not eligible, and says so distinctly: `supplier-disconnected`, not `offer-stale`. Those have different fixes, and an operator who cannot tell them apart debugs the wrong one.

**For a machine, the Connection replaces staleness rather than adding to it.** Staleness only ever *inferred* liveness; the Connection *is* liveness. Requiring a connected machine to also have republished recently would keep the apparatus ADR 0023 exists to remove, and would drop a working box from the pool because an operator's publish loop died. This anticipates part of #382 for machines only — vendors are untouched, still judged on staleness, because a public API is reachable by definition and has no Connection to hold.

Dispatch stays a pure function: the connection set is passed in, never reached for. An undefined set is deliberately not an empty one — a deployment with no registry behaves exactly as before, rather than silently dropping every machine Offer on upgrade.

Guarantees still filter first. A disconnected machine fails the request rather than falling through to a cheaper Supplier the operator cannot warrant.

## Verification

2840 tests, typecheck clean, 0 lint errors, both bundles built and executed.

End to end over a real HTTP server, real WebSocket upgrade, real streaming and a real ledger — the only fake is the GPU:

- routed to the machine, tokens streamed back, metered and charged identically to a vendor request
- refused with `supplier-disconnected` the moment the machine hangs up
- served again on reconnect, no operator action
- mid-stream death recorded `supply-failed`, prompt still owed
- buyer hangup reaching the machine's own runtime, recorded `buyer-aborted`
- in-flight count rising and falling with the work

The agent side is implemented independently in the Exchange's e2e test rather than imported from `@umwelten/supplier` — that package deliberately cannot be reached from this one, so a GPU box never installs a Postgres driver. Writing it twice against the wire is the test proving the wire is a contract two implementations can meet.

## Operator-visible change

`umwelten supplier dial` gains `--runtime` and `--runtime-key`. **`--runtime` is what makes it a Supplier** — without it the Connection is held and pushed work is dropped, so the agent says so on start rather than letting it look like success.

Machine Offers no longer need `--watch`. `docs/guide/local-supplier-vllm.md` now leads with the dial-in path and demotes the reverse tunnel to "the old way, only if you cannot run the agent".

## Still open

#379 (the agent publishes its own Offers over the Connection — today the operator declares them), #382 (delete the inferred-liveness machinery for good), #377 (a vLLM runtime so `probe` can reach it, which is why thor's Capabilities are still declared rather than measured).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG)_