### PR TITLE
dial gains --no-probe and --model

### DIFF
--- a/packages/supplier/src/command.ts
+++ b/packages/supplier/src/command.ts
@@ -75,6 +75,8 @@ interface CliOptions {
   // dial
   runtime?: string;
   runtimeKey?: string;
+  /** Commander sets this false for --no-probe. */
+  probe?: boolean;
 }
 
 /**
@@ -801,6 +803,11 @@ supplierCommand
     "Local OpenAI-compatible runtime to serve from, e.g. http://localhost:4000/v1",
   )
   .option("--runtime-key <token>", "Key the local runtime expects (or RUNTIME_API_KEY)")
+  .option(
+    "--no-probe",
+    "Connect and serve without probing. The Exchange keeps whatever Offers it has",
+  )
+  .option("--model <substring>", "Probe and publish only Models matching this")
   .action(async (opts: CliOptions) => {
     const exchangeUrl = opts.mycel ?? process.env.MYCEL_URL;
     const credential = opts.credential ?? process.env.SUPPLIER_CREDENTIAL;
@@ -847,7 +854,13 @@ supplierCommand
     // silently dialling in with an empty catalogue is how a box ends up
     // connected and unbuyable.
     let offers: ReturnType<typeof toOfferDrafts> | undefined;
-    if (config && runtimeUrl) {
+    if (opts.probe === false) {
+      // The escape hatch the wire always had: a hello with no offer set means
+      // "do not touch my catalogue". It exists for exactly this — getting a
+      // machine connected and serving while its catalogue is operator-declared,
+      // or while the probe battery is being debugged rather than trusted.
+      console.log("--no-probe: skipping the probe battery");
+    } else if (config && runtimeUrl) {
       const cached = loadState();
       const inputs = probeInputsFor(config);
       const reason = reprobeReason({


### PR DESCRIPTION
Making `dial` auto-probe removed the escape hatch the wire always had: a hello with no offer set means "do not touch my catalogue", and there was no way to say it from the CLI. The first real machine needed it within the hour — thor's router hangs on structured-output requests, so every advertised model rode out a three-minute watchdog before the box could even connect, with no way to say "just connect and serve; the catalogue is handled separately".

**`--no-probe`** connects and serves with the Exchange's stored Offers left exactly as they are — an operator-declared catalogue plus a serving machine is a working Supplier while the probe battery is being debugged rather than trusted.

**`--model <substring>`** narrows the probe. The plumbing existed (`resolveConfig` → `probeTargets`); `dial` just never declared the flag. The same router advertises a `direct` control-alias that should never be probed or sold, and this is how to leave it out.

2870 tests, typecheck clean, 0 lint errors, `--help` smoke-tested.

Field notes from the same session, for follow-up issues rather than this PR: probe failures print raw undici stacks instead of one line; a cold-loading router can eat the 3-minute watchdog as a false negative; and the probe fingerprint doesn't record which endpoint was measured, so repointing `VLLM_BASE_URL` never triggers a re-probe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG)_