### PR TITLE
Runnable scripts for selling and buying, and a guide that uses them

### DIFF
--- a/docs/guide/mycel-setup.md
+++ b/docs/guide/mycel-setup.md
@@ -8,7 +8,10 @@ Three people, three jobs. Find yours and do only that section.
 | **A supplier** | Sell your GPU's tokens | [2. Sell a GPU](#2-sell-a-gpu) |
 | **A buyer** | Use models through it | [3. Buy tokens](#3-buy-tokens) |
 
-Each section is copy-paste top to bottom. Placeholders are `UPPERCASE`.
+Each section is copy-paste top to bottom. Anything you must supply yourself is
+an `UPPERCASE_PASTE_MARKER` — and the scripts in `scripts/mycel/` refuse to run
+with a placeholder still in place, so a missed paste fails in one line instead
+of as a mystery.
 
 > **Money is integer micro-dollars.** `$1.00` is `1000000`. Never a float — a
 > Balance is a sum of these, and an amount that cannot be represented exactly is
@@ -62,10 +65,10 @@ Create a Postgres database at [neon.tech](https://neon.tech), then put its
 connection string in. Values arrive on stdin, never in argv:
 
 ```bash
-printf '%s' 'postgres://…' | \
+printf '%s' 'PASTE_THE_NEON_CONNECTION_STRING' | \
   gcloud secrets versions add mycel-database-url --project "$PROJECT" --data-file=-
 
-printf '%s' 'sk-or-…' | \
+printf '%s' 'PASTE_THE_OPENROUTER_KEY' | \
   gcloud secrets versions add mycel-openrouter-api-key --project "$PROJECT" --data-file=-
 ```
 
@@ -179,36 +182,36 @@ pnpm install
 
 ### 2.3 Dial in
 
+One script. It prompts for the credential (so a stale or placeholder export can
+never be presented), checks the runtime and the Exchange are actually
+answering before anything long-lived starts, and refuses values that look like
+placeholders:
+
 ```bash
-export SUPPLIER_CREDENTIAL='sk-mycel-…'
-export VLLM_BASE_URL=http://localhost:8000/v1     # only if not vLLM's default
-export VLLM_API_KEY=YOUR_RUNTIME_KEY              # only if your server wants one
-
-pnpm run cli -- supplier dial \
-  --mycel https://mycel.thefocus.ai \
-  --runtime http://localhost:8000/v1 \
-  --runtime-key "$VLLM_API_KEY"
+./scripts/mycel/sell.sh --runtime http://localhost:4000/v1
 ```
 
-The first run probes the machine, which takes a few minutes:
-
 ```
-probing: nothing cached for this machine
-  …
-publishing 1 offer(s) with the connection
-dialling https://mycel.thefocus.ai …
+Supplier credential (from `mycel supplier register/rotate`, starts sk-mycel-): 
+checking runtime at http://localhost:4000/v1 …
+  serving: unsloth/Qwen3.8-27B-NVFP4, RedHatAI/gemma-4-26B-A4B-it-NVFP4
+checking Exchange at https://mycel.thefocus.ai …
+starting the dial — Ctrl-C hangs up and the Exchange sees it immediately
 connected — this machine is now dispatchable
 ```
 
-You are now selling. Later runs reuse the cached probe and connect immediately.
+You are now serving. By default the script skips the probe battery
+(`--no-probe`) and leaves whatever Offers the Exchange already has — pair it
+with the operator-declared catalogue in §2.4, or pass `--probe` to measure the
+machine first. Add `--runtime-key KEY` if your runtime wants one, and
+`--model SUBSTRING` to limit a probe to matching models.
 
-> **`--runtime` is what makes you a Supplier.** Without it the connection is
-> held, every request is dropped, and nothing is published. Point it at the
-> OpenAI-compatible base — the `/v1`, not the bare port.
+> **`--runtime` is what makes you a Supplier.** It must be the
+> OpenAI-compatible base — the `/v1`, not the bare port — and the script
+> refuses to start until that endpoint actually lists models.
 
 Your runtime key never leaves your machine. The Exchange pushes a request down
-the connection and this agent adds the key locally, so the Exchange stores no
-credential for your box.
+the connection and this agent adds the key locally.
 
 Keep it running. To survive reboots:
 
@@ -221,10 +224,8 @@ After=network-online.target
 [Service]
 User=YOUR_USER
 WorkingDirectory=/home/YOUR_USER/mycel
-Environment=SUPPLIER_CREDENTIAL=sk-mycel-…
-Environment=VLLM_API_KEY=YOUR_RUNTIME_KEY
-ExecStart=/usr/bin/env pnpm run cli -- supplier dial \
-  --mycel https://mycel.thefocus.ai --runtime http://localhost:8000/v1
+Environment=SUPPLIER_CREDENTIAL=PASTE_THE_REAL_CREDENTIAL
+ExecStart=/home/YOUR_USER/mycel/scripts/mycel/sell.sh --runtime http://localhost:4000/v1
 Restart=always
 RestartSec=10
 
@@ -232,9 +233,10 @@ RestartSec=10
 WantedBy=multi-user.target
 ```
 
-### 2.4 What just got published
+### 2.4 The catalogue: probed or declared
 
-The probe **runs each model and watches what happens** — it does not read a
+With `--probe`, the script measures the machine before connecting. The probe
+**runs each model and watches what happens** — it does not read a
 list of names. Recognised runtimes: **ollama, LM Studio, LlamaBarn, llama-swap,
 vLLM**. Each model is tested for chat, streaming, tool calling, structured
 output and reasoning by actually being asked to do them, then measured for
@@ -249,7 +251,7 @@ hello, so the Exchange never has you connected without knowing what you serve.
 It re-probes only when the machine's fingerprint changes, so reconnecting costs
 no measurement.
 
-To see what it found without dialling:
+To see what it would find without dialling or publishing:
 
 ```bash
 pnpm run cli -- supplier probe
@@ -259,8 +261,9 @@ pnpm run cli -- supplier probe
 > llama.cpp-class runtimes. A vLLM box comfortably serving 32–64 is sampled
 > entirely below its knee, so its measured throughput understates it.
 
-**If your runtime is none of the five**, nothing can probe it and the operator
-publishes on your behalf instead. Find the exact model id it answers to, because
+**Without `--probe`** — the default, and the right call while a router or
+runtime is misbehaving under the battery — the operator declares the catalogue
+instead. Find the exact model id it answers to, because
 the buyer's request reaches you unmodified:
 
 ```bash
@@ -347,11 +350,21 @@ curl -s https://mycel.thefocus.ai/v1/models | jq .
 
 ### 3.3 Make a request
 
-OpenAI-shaped, so any OpenAI client works by pointing `base_url` at
-`https://mycel.thefocus.ai/v1`.
+With a umwelten checkout, one script shows the catalogue with prices, buys from
+it, and explains any failure:
 
 ```bash
-export APP_CREDENTIAL='sk-mycel-…'
+./scripts/mycel/buy.sh                  # first model for sale
+./scripts/mycel/buy.sh MODEL_ID         # a specific one
+```
+
+It prompts for the Application credential and refuses placeholder values.
+
+Without the checkout, it is an OpenAI-shaped endpoint — any OpenAI client works
+by pointing `base_url` at `https://mycel.thefocus.ai/v1`:
+
+```bash
+export APP_CREDENTIAL='PASTE_THE_REAL_CREDENTIAL'
 
 curl -s https://mycel.thefocus.ai/v1/chat/completions \
   -H "Authorization: Bearer $APP_CREDENTIAL" \

--- a/scripts/mycel/buy.sh
+++ b/scripts/mycel/buy.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Buy tokens through Mycel — the end-to-end proof from the buyer's side.
+#
+# Shows the catalogue with prices, sends one streaming completion, and tells
+# you what to look at if it fails. Refuses placeholder credentials, because a
+# pasted "sk-mycel-…" has already cost a real debugging session.
+#
+# Usage, from anywhere with curl and python3:
+#   ./scripts/mycel/buy.sh                 # picks the first model for sale
+#   ./scripts/mycel/buy.sh MODEL_ID        # buys from a specific model
+#
+# Environment:
+#   APP_CREDENTIAL   Application credential (or an interactive prompt).
+#   MYCEL_URL        Default: https://mycel.thefocus.ai
+#   END_USER         X-Mycel-End-User attribution. Default: your username.
+set -euo pipefail
+
+die() { echo "error: $*" >&2; exit 1; }
+
+refuse_placeholder() {
+  local name="$1" value="$2"
+  case "$value" in
+    *…* | *PASTE* | *YOUR_* | *example.com* | *"<"*">"*)
+      die "$name looks like a placeholder: \"$value\" — paste the real value" ;;
+  esac
+}
+
+MYCEL_URL="${MYCEL_URL:-https://mycel.thefocus.ai}"
+END_USER="${END_USER:-$(id -un)}"
+MODEL="${1:-}"
+refuse_placeholder "MYCEL_URL" "$MYCEL_URL"
+
+if [ -z "${APP_CREDENTIAL:-}" ]; then
+  printf 'Application credential (from `mycel application create/rotate`): ' >&2
+  read -rs APP_CREDENTIAL
+  echo >&2
+fi
+[ -n "$APP_CREDENTIAL" ] || die "no credential given"
+refuse_placeholder "APP_CREDENTIAL" "$APP_CREDENTIAL"
+
+echo "Exchange: $MYCEL_URL"
+curl -sf -m 10 "$MYCEL_URL/health" | grep -q '"ok"' ||
+  die "the Exchange is not healthy at $MYCEL_URL/health"
+
+echo "for sale:"
+catalogue=$(curl -sf -m 10 "$MYCEL_URL/v1/models") || die "could not list models"
+echo "$catalogue" | python3 -c '
+import json, sys
+data = json.load(sys.stdin).get("data", [])
+if not data:
+    print("  (nothing — no Offers are live; is the machine connected and synced?)")
+for m in data:
+    p = m.get("pricing") or {}
+    print("  %s  ($%s/M in, $%s/M out)" % (m["id"], p.get("prompt", "?"), p.get("completion", "?")))
+'
+
+if [ -z "$MODEL" ]; then
+  MODEL=$(echo "$catalogue" | python3 -c 'import json,sys; d=json.load(sys.stdin)["data"]; print(d[0]["id"] if d else "")')
+  [ -n "$MODEL" ] || die "nothing is for sale, so nothing to buy"
+  echo "no model named — buying from the first: $MODEL"
+fi
+
+echo
+echo "asking $MODEL to say hi (streaming) …"
+echo "────────────────────────────────────"
+http_code=$(curl -s -m 120 -o /tmp/mycel-buy-response.$$ -w '%{http_code}' \
+  "$MYCEL_URL/v1/chat/completions" \
+  -H "Authorization: Bearer $APP_CREDENTIAL" \
+  -H "X-Mycel-End-User: $END_USER" \
+  -H "content-type: application/json" \
+  -d "{\"model\":\"$MODEL\",\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"Say hi in one short sentence.\"}]}")
+cat /tmp/mycel-buy-response.$$; rm -f /tmp/mycel-buy-response.$$
+echo
+echo "────────────────────────────────────"
+
+case "$http_code" in
+  200) echo "HTTP 200 — served, metered, and charged. \`mycel balance <client>\` shows the debit." ;;
+  401) die "HTTP 401 — the credential (or the X-Mycel-End-User header) was refused" ;;
+  402) die "HTTP 402 insufficient_balance — fund it: \`mycel grant <client> 50000000\` (\$50)" ;;
+  503) die "HTTP 503 no_eligible_offer — the body above lists every Offer considered and
+  why each was rejected. supplier-disconnected: start the machine's dial.
+  offer-stale: a vendor's sync stopped. missing-*: nothing carries what you required." ;;
+  *)   die "HTTP $http_code — body above" ;;
+esac

--- a/scripts/mycel/sell.sh
+++ b/scripts/mycel/sell.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Sell this machine's tokens through Mycel.
+#
+# Every failure this script guards against has happened on a real box:
+# a placeholder credential pasted verbatim (401 at the upgrade), the wrong
+# runtime port (probing one server while serving another), and an Exchange
+# hostname that didn't resolve. So it checks everything cheap BEFORE starting
+# the long-lived dial, prompts for what it needs instead of relying on
+# copy-pasted exports, and refuses values that are obviously placeholders.
+#
+# Usage, on the GPU machine, from the repo root:
+#   ./scripts/mycel/sell.sh --runtime http://localhost:4000/v1
+#
+# Options:
+#   --runtime <url>      REQUIRED. The OpenAI-compatible base to serve from
+#                        (the /v1, not the bare port).
+#   --runtime-key <key>  Key that runtime expects, if any (or RUNTIME_API_KEY).
+#   --mycel <url>        Exchange base URL (or MYCEL_URL).
+#                        Default: https://mycel.thefocus.ai
+#   --probe              Run the full probe battery before connecting.
+#                        Default is --no-probe: connect and serve immediately,
+#                        leaving whatever Offers the Exchange already has.
+#   --model <substring>  With --probe: only probe Models matching this.
+#
+# The Supplier credential comes from $SUPPLIER_CREDENTIAL or an interactive
+# prompt — pasting it at a prompt cannot leave a stale placeholder in a shell.
+set -euo pipefail
+
+die() { echo "error: $*" >&2; exit 1; }
+
+# The placeholder patterns that have actually been pasted into production
+# shells. A value matching one of these is never a real secret or URL.
+refuse_placeholder() {
+  local name="$1" value="$2"
+  case "$value" in
+    *…* | *PASTE* | *YOUR_* | *example.com* | *"<"*">"*)
+      die "$name looks like a placeholder: \"$value\" — paste the real value" ;;
+  esac
+}
+
+MYCEL_URL="${MYCEL_URL:-https://mycel.thefocus.ai}"
+RUNTIME_URL=""
+RUNTIME_KEY="${RUNTIME_API_KEY:-}"
+PROBE_FLAG="--no-probe"
+MODEL_FILTER=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --runtime)      RUNTIME_URL="$2"; shift 2 ;;
+    --runtime-key)  RUNTIME_KEY="$2"; shift 2 ;;
+    --mycel)        MYCEL_URL="$2"; shift 2 ;;
+    --probe)        PROBE_FLAG=""; shift ;;
+    --model)        MODEL_FILTER="$2"; shift 2 ;;
+    -h|--help)      sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "unknown option: $1 (try --help)" ;;
+  esac
+done
+
+[ -n "$RUNTIME_URL" ] || die "--runtime is required — it is what makes this machine a Supplier.
+  e.g. ./scripts/mycel/sell.sh --runtime http://localhost:4000/v1"
+refuse_placeholder "--runtime" "$RUNTIME_URL"
+refuse_placeholder "--mycel" "$MYCEL_URL"
+case "$RUNTIME_URL" in
+  */v1) ;;
+  *) die "--runtime should end in /v1 (the OpenAI-compatible base), got: $RUNTIME_URL" ;;
+esac
+
+# ── The credential: env var, or a prompt that cannot be copy-pasted wrong ──
+if [ -z "${SUPPLIER_CREDENTIAL:-}" ]; then
+  printf 'Supplier credential (from `mycel supplier register/rotate`, starts sk-mycel-): ' >&2
+  read -rs SUPPLIER_CREDENTIAL
+  echo >&2
+fi
+[ -n "$SUPPLIER_CREDENTIAL" ] || die "no credential given"
+refuse_placeholder "SUPPLIER_CREDENTIAL" "$SUPPLIER_CREDENTIAL"
+case "$SUPPLIER_CREDENTIAL" in
+  sk-mycel-*) ;;
+  *) die "SUPPLIER_CREDENTIAL should start with sk-mycel- — is this the right value?" ;;
+esac
+export SUPPLIER_CREDENTIAL
+
+# ── Preflight: every network hop, cheap, before anything long-lived ──
+auth_header=()
+[ -n "$RUNTIME_KEY" ] && auth_header=(-H "Authorization: Bearer $RUNTIME_KEY")
+
+echo "checking runtime at $RUNTIME_URL …"
+models_json=$(curl -sf -m 10 "${auth_header[@]}" "$RUNTIME_URL/models") ||
+  die "runtime not answering at $RUNTIME_URL/models
+  Is the server up? Is this the right port? (curl it yourself to check.)
+  If it returned 401, pass its key with --runtime-key."
+echo "$models_json" | grep -q '"data"' ||
+  die "runtime answered but not with an OpenAI model list — wrong port?"
+echo "  serving: $(echo "$models_json" | python3 -c 'import json,sys; print(", ".join(m["id"] for m in json.load(sys.stdin)["data"]))' 2>/dev/null || echo '(unparseable)')"
+
+echo "checking Exchange at $MYCEL_URL …"
+curl -sf -m 10 "$MYCEL_URL/health" | grep -q '"ok"' ||
+  die "the Exchange at $MYCEL_URL is not healthy — check the URL, or the operator"
+
+# ── Point discovery and serving at the same endpoint (ADR 0015) ──
+export VLLM_BASE_URL="$RUNTIME_URL"
+[ -n "$RUNTIME_KEY" ] && export VLLM_API_KEY="$RUNTIME_KEY"
+
+cd "$(dirname "$0")/../.."
+[ -f package.json ] || die "run this from a umwelten checkout"
+
+echo "starting the dial — Ctrl-C hangs up and the Exchange sees it immediately"
+exec pnpm run cli -- supplier dial \
+  --mycel "$MYCEL_URL" \
+  --runtime "$RUNTIME_URL" \
+  ${RUNTIME_KEY:+--runtime-key "$RUNTIME_KEY"} \
+  ${MODEL_FILTER:+--model "$MODEL_FILTER"} \
+  $PROBE_FLAG


### PR DESCRIPTION
Three copy-paste failures in one operating session — a placeholder hostname that didn't resolve, a placeholder credential pasted verbatim (401 at the upgrade), and a skipped export that pointed the probe at the wrong server — and each was the guide's fault, not the operator's. A copy-paste guide with placeholders inside runnable blocks is a collection of landmines.

**`scripts/mycel/sell.sh`** — the GPU machine's one command:

- prompts for the credential instead of relying on an export, so a stale or placeholder value can't be presented
- refuses values that look like placeholders (`…`, `PASTE`, `YOUR_`, `example.com`)
- verifies the runtime actually lists models and the Exchange is healthy **before** anything long-lived starts, with each failure explained in a sentence
- points discovery and serving at the same endpoint (ADR 0015), so the skipped-export mistake can't happen
- dials `--no-probe` by default; `--probe` and `--model` opt in

**`scripts/mycel/buy.sh`** — anywhere: shows the catalogue with prices, buys from a named or the first model, and translates 401/402/503 into what to actually do.

**Verified end to end**, not just syntax-checked: a real Exchange (MemoryStore) plus a fake OpenAI runtime; `sell.sh` preflighted, dialled and served; `buy.sh` purchased and the tokens streamed back through the Connection with HTTP 200. All three guard rails exercised (missing `--runtime`, placeholder credential, wrong port).

The guide's §2.3 and §3.3 now lead with the scripts, and every remaining paste-site is an `UPPERCASE_MARKER` the scripts would refuse.

2870 tests, docs build clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgrWzAxdm9YN7J8UTAq3DG)_